### PR TITLE
fix default CPU usage description.

### DIFF
--- a/website/docs/using-qovery/configuration/application.md
+++ b/website/docs/using-qovery/configuration/application.md
@@ -109,7 +109,7 @@ To configure the number of CPUs that your app needs, adjust the setting in the `
 
 <Alert type="info">
 
-Default is 256m. The maximum you can set is 1CPU in **Community** version and unlimited in [paid plans][urls.qovery_pricing].
+Default is 0.25CPU. The maximum you can set is 1CPU in **Community** version and unlimited in [paid plans][urls.qovery_pricing].
 
 </Alert>
 


### PR DESCRIPTION
current description seems to refer RAM. 
I'm not sure the default, but in my case, it shows 0.25 CPU.