### PR TITLE
removed option to edit the page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -187,7 +187,6 @@ module.exports = {
     [
       "@docusaurus/plugin-content-docs",
       {
-        editUrl: "https://github.com/Qovery/documentation/edit/master/website/",
         sidebarPath: require.resolve("./sidebars.js"),
       },
     ],


### PR DESCRIPTION
the edit button was redirecting to the editing of the .md file which is not what we want. The user should follow the guide to generate the md files as explained in the readme