### PR TITLE
Improve wording deny ip + EC2 limitations

### DIFF
--- a/website/docs/using-qovery/configuration/cluster-advanced-settings.md
+++ b/website/docs/using-qovery/configuration/cluster-advanced-settings.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2023-03-09"
+last_modified_on: "2023-03-20"
 title: "Cluster Advanced Settings"
 description: "Learn how to set advanced settings on your infrastructure with Qovery"
 ---
@@ -86,7 +86,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                                                                                                                                        | Default Value |
 |---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all PostgreSQL databases.<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all PostgreSQL databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "any IP").<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment| `false`       |
 
 #### database.postgresql.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 
@@ -98,7 +98,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                                                                                                                                    | Default Value |
 |---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all MySQL databases. <br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all MySQL databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "any IP"). <br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
 
 #### database.mysql.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 
@@ -110,7 +110,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                                                                                                                                     | Default Value |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all MongoDB databases.<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all MongoDB databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "any IP"). <br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
 
 #### database.mongodb.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 
@@ -122,7 +122,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                            | Default Value |
 |---------|--------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all Redis databases.<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all Redis databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "anyone").<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
 
 #### database.redis.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 

--- a/website/docs/using-qovery/configuration/cluster-advanced-settings.md.erb
+++ b/website/docs/using-qovery/configuration/cluster-advanced-settings.md.erb
@@ -77,7 +77,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                                                                                                                                        | Default Value |
 |---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all PostgreSQL databases.<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all PostgreSQL databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "any IP").<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment| `false`       |
 
 #### database.postgresql.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 
@@ -89,7 +89,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                                                                                                                                    | Default Value |
 |---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all MySQL databases. <br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all MySQL databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "any IP"). <br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
 
 #### database.mysql.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 
@@ -101,7 +101,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                                                                                                                                     | Default Value |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all MongoDB databases.<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all MongoDB databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "any IP"). <br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
 
 #### database.mongodb.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 
@@ -113,7 +113,7 @@ Below is the list of advanced settings currently available for clusters.
 
 | Type    | Description                                                                                            | Default Value |
 |---------|--------------------------------------------------------------------------------------------------------|---------------|
-| boolean | Deny public access to all Redis databases.<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
+| boolean | Deny public access to all Redis databases. When true, configure the CIDR range you want to allow within the associated `allowed_cidrs` parameter (default is "anyone").<br />⚠️ Public access to managed databases will instantly be removed<br />⚠️ Public access to container databases will be removed only after a database redeployment | `false`       |
 
 #### database.redis.allowed_cidrs ![](/img/advanced_settings/aws.svg) ![](/img/advanced_settings/database-managed.svg) 
 

--- a/website/docs/using-qovery/configuration/clusters.md
+++ b/website/docs/using-qovery/configuration/clusters.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2023-02-13"
+last_modified_on: "2023-03-20"
 title: "Clusters"
 description: "Learn how to configure your Kubernetes clusters on Qovery"
 ---
@@ -56,7 +56,6 @@ Single EC2 (K3s) is still in BETA phase and has the following limitations
 * You can’t access the historical logs and thus you can access your application logs only if it's running (Since we don’t have loki installed)
 * No public accessibility for DB container (we do not manage the public DNS entry for db). We will work on it in the upcoming weeks, in the meantime we will write a guide on how to connect to the DB via the ssh key / kubeconf
 * You can configure only 1 instance per application. Thus you can’t change the number of instances nor activate the sticky session feature
-* We do not manage YET the cluster version upgrades
 * Stop instance feature not ready YET
 * You can’t change the cluster settings without a service downtime since we kill the instance and we spawn a new one
 * We do not manage YET the external storage

--- a/website/docs/using-qovery/configuration/clusters.md.erb
+++ b/website/docs/using-qovery/configuration/clusters.md.erb
@@ -56,7 +56,6 @@ Single EC2 (K3s) is still in BETA phase and has the following limitations
 * You can’t access the historical logs and thus you can access your application logs only if it's running (Since we don’t have loki installed)
 * No public accessibility for DB container (we do not manage the public DNS entry for db). We will work on it in the upcoming weeks, in the meantime we will write a guide on how to connect to the DB via the ssh key / kubeconf
 * You can configure only 1 instance per application. Thus you can’t change the number of instances nor activate the sticky session feature
-* We do not manage YET the cluster version upgrades
 * Stop instance feature not ready YET
 * You can’t change the cluster settings without a service downtime since we kill the instance and we spawn a new one
 * We do not manage YET the external storage


### PR DESCRIPTION
- improved wording on the deny ip advanced settings to ensure the user set as well the CIDR
- removed some EC2 limitation given the recent fixes