### PR TITLE
chore: removing script to avoid user mistakes

### DIFF
--- a/website/docs/getting-started/install-qovery/azure/cluster-managed-by-qovery/create-credentials.md
+++ b/website/docs/getting-started/install-qovery/azure/cluster-managed-by-qovery/create-credentials.md
@@ -35,13 +35,13 @@ In the **"Create New Credential"** modal, fill in the required Azure details:
 
 Once you've entered both values, click **Next** to generate the command you need to run in your embedded Azure shell.
 
-The command will look like this:
-
-```bash
-bash <(curl -s https://hub.qovery.com/files/create_credentials_azure.sh) --qovery-app-id <generated-in-qovery-console>  --subscription-id <your-azure-subscription-id>
-```
-
 Copy this command to your clipboard.
+
+<Alert type="info">
+
+You can inspect the content of the command before running it at https://hub.qovery.com/files/create_credentials_azure.sh
+
+</Alert>
 
 </li>
 

--- a/website/docs/getting-started/install-qovery/azure/cluster-managed-by-qovery/create-credentials.md.erb
+++ b/website/docs/getting-started/install-qovery/azure/cluster-managed-by-qovery/create-credentials.md.erb
@@ -26,13 +26,13 @@ In the **"Create New Credential"** modal, fill in the required Azure details:
 
 Once you've entered both values, click **Next** to generate the command you need to run in your embedded Azure shell.
 
-The command will look like this:
-
-```bash
-bash <(curl -s https://hub.qovery.com/files/create_credentials_azure.sh) --qovery-app-id <generated-in-qovery-console>  --subscription-id <your-azure-subscription-id>
-```
-
 Copy this command to your clipboard.
+
+<Alert type="info">
+
+You can inspect the content of the command before running it at https://hub.qovery.com/files/create_credentials_azure.sh
+
+</Alert>
 
 </li>
 


### PR DESCRIPTION
removing the command to create the script since it might lead to mistakes (copy and paste from the doc)