### PR TITLE
Fix S3 endpoint for CloudFormation template URL (PermanentRedirect error)

### DIFF
--- a/website/docs/getting-started/install-qovery/aws/cluster-managed-by-qovery/create-credentials.md
+++ b/website/docs/getting-started/install-qovery/aws/cluster-managed-by-qovery/create-credentials.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2025-07-07"
+last_modified_on: "2025-08-01"
 title: "Create Credentials"
 description: "Generate AWS credentials for Qovery"
 ---
@@ -55,7 +55,7 @@ For security reasons, we strongly recommend using Assume Role via STS. Static cr
 
 <li>
 
-Execute the following [Cloudformation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https%3A%2F%2Fs3.amazonaws.com%2Fcloudformation-qovery-role-creation%2Ftemplate.json&stackName=qovery-role-creation
+Execute the following [Cloudformation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https%3A%2F%2Fcloudformation-qovery-role-creation.s3.amazonaws.com%2Ftemplate.json&stackName=qovery-role-creation
 ), make sure you select the checkbox `I acknowledge that AWS CloudFormation might create IAM resources with custom names`
 
 

--- a/website/docs/getting-started/install-qovery/aws/cluster-managed-by-qovery/create-credentials.md.erb
+++ b/website/docs/getting-started/install-qovery/aws/cluster-managed-by-qovery/create-credentials.md.erb
@@ -42,7 +42,7 @@ For security reasons, we strongly recommend using Assume Role via STS. Static cr
 
 <li>
 
-Execute the following [Cloudformation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https%3A%2F%2Fs3.amazonaws.com%2Fcloudformation-qovery-role-creation%2Ftemplate.json&stackName=qovery-role-creation
+Execute the following [Cloudformation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https%3A%2F%2Fcloudformation-qovery-role-creation.s3.amazonaws.com%2Ftemplate.json&stackName=qovery-role-creation
 ), make sure you select the checkbox `I acknowledge that AWS CloudFormation might create IAM resources with custom names`
 
 

--- a/website/docs/using-qovery/troubleshoot.md
+++ b/website/docs/using-qovery/troubleshoot.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2023-12-26"
+last_modified_on: "2025-08-01"
 title: Troubleshoot
 description: "Everything you need to troubleshoot your application with Qovery"
 sidebar_label: hidden


### PR DESCRIPTION
### What happened

Customers clicking the link to the CloudFormation template received a **PermanentRedirect** error from S3:

<img width="1282" height="215" alt="{64755F49-3B4C-4518-B465-9E4DA79C2963}" src="https://github.com/user-attachments/assets/c53cff41-1350-4656-8c9f-b1883612d137" />

### Root cause

The URL pointed to the generic `https://s3.amazonaws.com/<bucket>/…` format.
Because the bucket is region-locked, S3 requires the **region-specific endpoint**, otherwise it issues a 301 → `PermanentRedirect`.

### Fix

Replaced the old URL with the correct region-aware endpoint:

```
https://cloudformation-qovery-role-creation.s3.amazonaws.com/<template-file>
```

No other logic changes.

