### PR TITLE
Fix typos in documentation for Cluster Troubleshooting

### DIFF
--- a/website/docs/using-qovery/troubleshoot/cluster-troubleshoot.md
+++ b/website/docs/using-qovery/troubleshoot/cluster-troubleshoot.md
@@ -110,7 +110,7 @@ echo "Load Balancers:"
 aws elb describe-load-balancers --query "LoadBalancers[?VpcId=='$VPC_ID']" 
 ```
 
-## My cloud account has been blockVed, what should I do?
+## My cloud account has been blocked, what should I do?
 
 If you encounter this kind of error during an infrastructure deployment (including managed DBs):
 

--- a/website/docs/using-qovery/troubleshoot/cluster-troubleshoot.md.erb
+++ b/website/docs/using-qovery/troubleshoot/cluster-troubleshoot.md.erb
@@ -99,7 +99,7 @@ echo "Load Balancers:"
 aws elb describe-load-balancers --query "LoadBalancers[?VpcId=='$VPC_ID']" 
 ```
 
-## My cloud account has been blockVed, what should I do?
+## My cloud account has been blocked, what should I do?
 
 If you encounter this kind of error during an infrastructure deployment (including managed DBs):
 


### PR DESCRIPTION
Fixing some typos while seeking information in the documentation.