### PR TITLE
fix: apply same filter mechanism as Helm for AWS icon in dark mode

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -522,11 +522,11 @@ html[data-theme="dark"] img[src*="/helm-icon-light.svg"],
   filter: brightness(0) invert(1);
 }
 
-/* AWS icon - swap to dark version to preserve orange arrow */
+/* AWS icon - make white in dark mode */
 html[class*="dark"] img[src*="/aws-icon.svg"],
 html[data-theme="dark"] img[src*="/aws-icon.svg"],
 .dark img[src*="/aws-icon.svg"] {
-  content: url("/images/logos/cloud-providers/aws-icon-dark.svg");
+  filter: brightness(0) invert(1);
 }
 
 /* GitHub icon - make white in dark mode */


### PR DESCRIPTION
Use the same filter approach (brightness(0) invert(1)) as Helm icon for AWS icon in dark mode to ensure consistent behavior. This makes the entire icon white, including the arrow.