### PR TITLE
feat: add GCP support for KEDA event-driven autoscaling

### DIFF
--- a/docs/configuration/application.mdx
+++ b/docs/configuration/application.mdx
@@ -203,7 +203,7 @@ For high availability:
     </Warning>
 
     <Warning>
-    **AWS clusters only** - KEDA autoscaling is currently available exclusively for applications deployed on AWS.
+    **AWS and GCP clusters only** - KEDA autoscaling is currently available for applications deployed on AWS and GCP.
     </Warning>
 
     **Prerequisite: Enable KEDA at Cluster Level**

--- a/docs/getting-started/guides/qovery-101/optimize.mdx
+++ b/docs/getting-started/guides/qovery-101/optimize.mdx
@@ -97,7 +97,7 @@ KEDA scales your applications based on external event sources like:
 </Warning>
 
 <Warning>
-**AWS clusters only** - KEDA event-driven autoscaling is currently available exclusively for applications deployed on AWS clusters.
+**AWS and GCP clusters only** - KEDA event-driven autoscaling is currently available for applications deployed on AWS and GCP clusters.
 </Warning>
 
 <Card title="KEDA Configuration Guide" icon="book" href="/configuration/application#keda-event-driven">


### PR DESCRIPTION
Update documentation to reflect that KEDA autoscaling is now available on both AWS and GCP clusters.