### PR TITLE
feat(devops-copilot): update copilot access guide

### DIFF
--- a/docs/copilot/mcp-server.mdx
+++ b/docs/copilot/mcp-server.mdx
@@ -8,7 +8,7 @@ description: "Setup Qovery AI Copilot with Claude Desktop using the Model Contex
 The Qovery MCP (Model Context Protocol) Server enables you to use Qovery AI Copilot directly in Claude Desktop and other MCP-compatible clients. This gives you natural language control over your entire Qovery infrastructure.
 
 <Note>
-**Early Access Required**: The Qovery MCP Server is available online and on demand. Contact [Qovery Support](mailto:support@qovery.com) to request early access.
+**Activation Required**: Before using the MCP Server, organization administrators must first activate Qovery AI Copilot from the console settings. See the [Getting Started guide](/copilot/getting-started#activation) for activation instructions.
 </Note>
 
 <Info>

--- a/docs/copilot/overview.mdx
+++ b/docs/copilot/overview.mdx
@@ -169,7 +169,7 @@ Read the technical deep-dive: [How We Built an Agentic DevOps Copilot](https://w
 ## Access Methods
 
 <Note>
-**Early Access**: Qovery AI Copilot is available online and on demand. Contact [Qovery Support](mailto:support@qovery.com) to request early access.
+**Activation**: Organization administrators can activate Qovery AI Copilot directly from the console settings. See the [Getting Started guide](/copilot/getting-started#activation) for step-by-step instructions.
 </Note>
 
 You can interact with Qovery AI Copilot through two interfaces:
@@ -183,7 +183,6 @@ You can interact with Qovery AI Copilot through two interfaces:
     - Full automation capabilities
     - Maintains conversation context
     - No additional setup required
-    - **Requires early access** - contact support@qovery.com
   </Tab>
 
   <Tab title="MCP Server (Beta)">
@@ -193,7 +192,6 @@ You can interact with Qovery AI Copilot through two interfaces:
     - Full automation capabilities
     - Maintains conversation context
     - Works from any MCP-compatible AI assistant
-    - **Requires early access** - contact support@qovery.com
     - [Setup Guide →](/copilot/mcp-server)
   </Tab>
 </Tabs>

--- a/docs/copilot/slack-bot.mdx
+++ b/docs/copilot/slack-bot.mdx
@@ -8,7 +8,7 @@ description: "Use AI Copilot directly in Slack to manage your infrastructure"
 The Qovery Slack Bot brings AI Copilot capabilities directly into your Slack workspace, allowing you and your team to manage infrastructure through natural language commands in Slack channels.
 
 <Note>
-**Early Access Required**: The Qovery Slack Bot is available online and on demand. Contact [Qovery Support](mailto:support@qovery.com) to request early access.
+**Activation Required**: Before using the Slack Bot, organization administrators must first activate Qovery AI Copilot from the console settings. See the [Getting Started guide](/copilot/getting-started#activation) for activation instructions.
 </Note>
 
 <Warning>


### PR DESCRIPTION
Copilot access guide update: removal of "on-demand" access to autonomous activation