### PR TITLE
docs(deployment): document skipped services feature

### DIFF
--- a/docs/configuration/deployment/actions.mdx
+++ b/docs/configuration/deployment/actions.mdx
@@ -114,11 +114,24 @@ Queued deployment requests can be merged under specific conditions: if the same 
 
 **Example 2**: Same as Example 1, but this time another user triggers the deployment of C. In this case, the deployments of B and C will NOT be merged. B will deploy first, then C will deploy, following the order defined in the Deployment Pipeline.
 
+## Skipped Services
+
+Services marked as **skipped** in the [Deployment Pipeline](/configuration/deployment/pipeline#skipped-services) are excluded from environment-level deployment actions:
+
+- **Deploy, Stop, Restart** at environment level: Skipped services are **not included** in the operation
+- **Delete** at environment level: Skipped services are **still deleted** along with the rest of the environment
+- **Service-level actions**: You can still trigger actions directly on a skipped service individually
+- **Multi-service selection**: Skipped services cannot be selected for bulk operations
+
+<Note>
+Skipped services appear with reduced opacity in the service list and cannot be checked for bulk actions. To include a skipped service in deployments again, move it back to a regular deployment stage in **Settings > Deployment Pipeline**.
+</Note>
+
 ## Executing Actions
 
 Actions can be triggered at different levels:
 
-- **Environment level**: Click the play button on the environment to execute the action on all services according to the Deployment Pipeline order
+- **Environment level**: Click the play button on the environment to execute the action on all services according to the Deployment Pipeline order. [Skipped services](#skipped-services) are excluded from this action.
 - **Service level**: Click the play button on a specific service to execute the action only on that service
 - **Multi-service selection**: Select multiple services and use the floating action button to execute the action on selected services
 

--- a/docs/configuration/deployment/logs.mdx
+++ b/docs/configuration/deployment/logs.mdx
@@ -33,6 +33,7 @@ The pipeline view provides a centralized overview of your deployment process, sh
 - Pre-check logs for validation processes
 - Direct access to specific deployment logs per service
 - Automatic filtering of services not involved in the deployment
+- **Hide skipped** toggle to show or hide [skipped services](/configuration/deployment/pipeline#skipped-services) in the pipeline view
 
 ## Deployment Logs
 

--- a/docs/configuration/deployment/pipeline.mdx
+++ b/docs/configuration/deployment/pipeline.mdx
@@ -85,6 +85,27 @@ If you have multiple applications that share the same base image or dependencies
 
 Don't use environment-specific Docker ARG values in your Dockerfiles. This causes Qovery to rebuild images for each environment even when the code hasn't changed. Instead, use environment variables that are injected at runtime.
 
+## Skipped Services
+
+You can exclude specific services from environment-level deployment actions by marking them as **skipped** in the deployment pipeline settings.
+
+### How to Skip a Service
+
+In your environment's **Settings > Deployment Pipeline**, drag a service into the **Skipped** column. Skipped services appear visually separated from the regular deployment stages.
+
+### Behavior
+
+- **Environment deployment actions** (deploy, stop, restart): Skipped services are **excluded** from the operation. They will not be built, deployed, stopped, or restarted when you trigger an environment-level action.
+- **Environment delete**: Skipped services are **still deleted** along with the rest of the environment. The skipped status does not prevent deletion.
+- **Service-level actions**: You can still deploy, stop, or restart a skipped service individually by triggering the action directly on that service.
+- **Clone and Preview Environments**: When you clone an environment or create a preview environment, the skipped status is **inherited** by the cloned services. Services that were skipped in the source environment will also be skipped in the new environment.
+
+### Use Cases
+
+- **Temporarily disable a service** without removing it from the environment
+- **Speed up deployments** by excluding services that don't need frequent updates
+- **Reduce costs** by preventing unnecessary builds and deployments for stable services
+
 ## Managing Deployment Stages
 
 You can customize your deployment pipeline by creating, modifying, or removing deployment stages from your environment configuration section.

--- a/docs/configuration/deployment/statuses.mdx
+++ b/docs/configuration/deployment/statuses.mdx
@@ -65,6 +65,7 @@ The deployment follows these statuses:
 - **BUILDING ERROR**: The build failed
 - **DEPLOYMENT ERROR**: The deployment to Kubernetes failed
 - **DEPLOYMENT OK**: The deployment was successful
+- **SKIPPED**: The service was excluded from the deployment because it is marked as [skipped](/configuration/deployment/pipeline#skipped-services) in the deployment pipeline
 
 ### Important Note
 

--- a/docs/configuration/environment.mdx
+++ b/docs/configuration/environment.mdx
@@ -123,13 +123,14 @@ Preview Environments solve the challenge of maintaining testing environments tha
 
 #### Blueprint Environment
 
-A Blueprint Environment serves as the template for all your Preview Environments. It's a fully-configured, working environment that Qovery clones whenever a new pull request is created.
+A Blueprint Environment serves as the template for all your Preview Environments. It's a fully-configured, working environment that Qovery clones whenever a new pull request is created. The deployment pipeline configuration, including [skipped services](/configuration/deployment/pipeline#skipped-services), is inherited by each Preview Environment created from the Blueprint.
 
 **Blueprint Best Practices**:
 - Use a separate cluster from production for Preview Environments
 - Ensure all applications and services are properly configured
 - Test the Blueprint thoroughly before enabling Preview Environments
 - Keep it in sync with your production configuration
+- Review which services are [skipped](/configuration/deployment/pipeline#skipped-services) in the Blueprint, as Preview Environments will inherit this configuration
 
 <Frame>
   <img src="/images/preview-environment/preview_env_branching.jpg" alt="Git branching strategy for Preview Environments" />
@@ -403,6 +404,10 @@ Duplicate an existing environment to quickly create a copy across projects or cl
 Cloning excludes:
 - Custom domains
 - Certain built-in environment variables
+
+Cloning preserves:
+- [Deployment pipeline](/configuration/deployment/pipeline) stage configuration
+- [Skipped services](/configuration/deployment/pipeline#skipped-services) status — services that were skipped in the source environment will also be skipped in the cloned environment
 </Info>
 
 ## Deployment & Deletion


### PR DESCRIPTION
Add documentation for the new skipped services feature across deployment pipeline, actions, statuses, logs, and environment pages. Covers behavior for deploy/stop/restart/delete actions, clone and preview environment inheritance, and pipeline view filtering.