### PR TITLE
docs: add aws.vpc.enable_nat_gateway_secondary_eip setting

### DIFF
--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -15709,9 +15709,6 @@ components:
         aws.vpc.flow_logs_retention_days:
           type: integer
           description: Set the number of retention days for flow logs. Disable with value "0"
-        aws.vpc.enable_nat_gateway_secondary_eip:
-          type: boolean
-          description: Enable a secondary Elastic IP per NAT Gateway, increasing the number of outbound public IPs. Useful for services with IP-based rate limits.
         loki.log_retention_in_week:
           type: integer
           description: For how long in week loki is going to keep logs of your applications

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -15709,6 +15709,9 @@ components:
         aws.vpc.flow_logs_retention_days:
           type: integer
           description: Set the number of retention days for flow logs. Disable with value "0"
+        aws.vpc.enable_nat_gateway_secondary_eip:
+          type: boolean
+          description: Enable a secondary Elastic IP per NAT Gateway, increasing the number of outbound public IPs. Useful for services with IP-based rate limits.
         loki.log_retention_in_week:
           type: integer
           description: For how long in week loki is going to keep logs of your applications

--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -194,7 +194,7 @@ resource "qovery_cluster" "my_cluster" {
 **Default Value:** `false`
 
 <Warning>
-Enabling this setting creates 3 additional Elastic IPs in your AWS account. Each EIP incurs standard AWS charges. This setting only takes effect when the cluster uses NAT Gateways.
+Enabling this setting creates 3 additional Elastic IPs in your AWS account. Each EIP incurs standard AWS charges. This setting only takes effect when the cluster uses NAT Gateways. Before enabling, verify that your AWS account has sufficient EIP quota (default is 5 per region). You can check and request an increase in the AWS Service Quotas console.
 </Warning>
 
 <a id="loki-log-retention-in-week"></a>

--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -181,6 +181,22 @@ resource "qovery_cluster" "my_cluster" {
 
 **Default Value:** `365`
 
+<a id="aws-vpc-enable-nat-gateway-secondary-eip"></a>
+
+### aws.vpc.enable_nat_gateway_secondary_eip
+
+**Cloud Provider:** <img src="/images/logos/cloud-providers/aws-icon.svg" alt="AWS" width="20"  style={{display: "inline", verticalAlign: "middle", marginRight: "4px"}} />
+
+**Type:** `boolean`
+
+**Description:** Enable a secondary Elastic IP (EIP) per NAT Gateway. When enabled, each of the 3 NAT Gateways in your VPC receives an additional EIP, doubling the number of outbound public IP addresses from 3 to 6. This is useful when your workloads interact with external services that have IP-based rate limits — more IPs means higher aggregate limits.
+
+**Default Value:** `false`
+
+<Warning>
+Enabling this setting creates 3 additional Elastic IPs in your AWS account. Each EIP incurs standard AWS charges. This setting only takes effect when the cluster uses NAT Gateways.
+</Warning>
+
 <a id="loki-log-retention-in-week"></a>
 
 ### loki.log_retention_in_week


### PR DESCRIPTION
## Summary
- Document `aws.vpc.enable_nat_gateway_secondary_eip` in cluster advanced settings page
- Update API reference OpenAPI copy

## Test plan
- [ ] Verify documentation renders correctly