### PR TITLE
docs: add AWS IAM permissions reference page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,10 +96,15 @@
                 "group": "Security & Compliance",
                 "pages": [
                   "getting-started/security-and-compliance/overview",
-                  "getting-started/security-and-compliance/aws-iam-permissions",
-                  "getting-started/security-and-compliance/gcp-iam-permissions",
-                  "getting-started/security-and-compliance/azure-iam-permissions",
-                  "getting-started/security-and-compliance/scaleway-iam-permissions",
+                  {
+                    "group": "IAM Permissions Reference",
+                    "pages": [
+                      "getting-started/security-and-compliance/aws-iam-permissions",
+                      "getting-started/security-and-compliance/gcp-iam-permissions",
+                      "getting-started/security-and-compliance/azure-iam-permissions",
+                      "getting-started/security-and-compliance/scaleway-iam-permissions"
+                    ]
+                  },
                   "getting-started/security-and-compliance/audit-logs",
                   "getting-started/security-and-compliance/soc2",
                   "getting-started/security-and-compliance/gdpr",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,6 +98,7 @@
                   "getting-started/security-and-compliance/overview",
                   "getting-started/security-and-compliance/aws-iam-permissions",
                   "getting-started/security-and-compliance/gcp-iam-permissions",
+                  "getting-started/security-and-compliance/azure-iam-permissions",
                   "getting-started/security-and-compliance/audit-logs",
                   "getting-started/security-and-compliance/soc2",
                   "getting-started/security-and-compliance/gdpr",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,6 +99,7 @@
                   "getting-started/security-and-compliance/aws-iam-permissions",
                   "getting-started/security-and-compliance/gcp-iam-permissions",
                   "getting-started/security-and-compliance/azure-iam-permissions",
+                  "getting-started/security-and-compliance/scaleway-iam-permissions",
                   "getting-started/security-and-compliance/audit-logs",
                   "getting-started/security-and-compliance/soc2",
                   "getting-started/security-and-compliance/gdpr",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,6 +96,7 @@
                 "group": "Security & Compliance",
                 "pages": [
                   "getting-started/security-and-compliance/overview",
+                  "getting-started/security-and-compliance/aws-iam-permissions",
                   "getting-started/security-and-compliance/audit-logs",
                   "getting-started/security-and-compliance/soc2",
                   "getting-started/security-and-compliance/gdpr",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,6 +97,7 @@
                 "pages": [
                   "getting-started/security-and-compliance/overview",
                   "getting-started/security-and-compliance/aws-iam-permissions",
+                  "getting-started/security-and-compliance/gcp-iam-permissions",
                   "getting-started/security-and-compliance/audit-logs",
                   "getting-started/security-and-compliance/soc2",
                   "getting-started/security-and-compliance/gdpr",

--- a/docs/getting-started/installation/aws.mdx
+++ b/docs/getting-started/installation/aws.mdx
@@ -240,7 +240,7 @@ Follow these steps to create your first Qovery cluster on AWS:
             - **S3**: Store Terraform state and logs
             - **CloudWatch**: Collect logs and metrics
 
-            You can review the full CloudFormation template before creating the stack.
+            For a detailed breakdown of every permission and why it's needed, see the [AWS IAM Permissions Reference](/getting-started/security-and-compliance/aws-iam-permissions).
           </Accordion>
 
           <Accordion title="Can I use a custom IAM policy?">

--- a/docs/getting-started/installation/azure.mdx
+++ b/docs/getting-started/installation/azure.mdx
@@ -137,7 +137,7 @@ Qovery needs credentials to manage resources in your Azure subscription. We use 
     1. Paste the command from Qovery into Azure Cloud Shell
     2. Press **Enter**
     3. Review the subscription details displayed
-    4. The script will create a service principal and assign necessary permissions
+    4. The script will create a service principal and assign necessary permissions. For a detailed breakdown of every permission and why it's needed, see the [Azure IAM Permissions Reference](/getting-started/security-and-compliance/azure-iam-permissions)
 
     **Example output:**
     ```bash

--- a/docs/getting-started/installation/gcp.mdx
+++ b/docs/getting-started/installation/gcp.mdx
@@ -109,7 +109,7 @@ Qovery needs credentials to manage resources in your GCP project. We use a secur
     ```
 
     <Info>
-    This script creates a service account with minimal required permissions.
+    This script creates a service account with minimal required permissions. For a detailed breakdown of every permission and why it's needed, see the [GCP IAM Permissions Reference](/getting-started/security-and-compliance/gcp-iam-permissions).
     </Info>
   </Step>
 </Steps>

--- a/docs/getting-started/installation/scaleway.mdx
+++ b/docs/getting-started/installation/scaleway.mdx
@@ -125,7 +125,7 @@ Qovery needs API credentials to manage resources in your Scaleway account. We us
     6. Click **Create policy**
 
     <Info>
-    These permissions allow Qovery to fully manage your Kubernetes infrastructure, including creating instances, configuring networking, and managing storage.
+    These permissions allow Qovery to fully manage your Kubernetes infrastructure, including creating instances, configuring networking, and managing storage. For a detailed breakdown of every permission and why it's needed, see the [Scaleway IAM Permissions Reference](/getting-started/security-and-compliance/scaleway-iam-permissions).
     </Info>
   </Step>
 

--- a/docs/getting-started/security-and-compliance/aws-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/aws-iam-permissions.mdx
@@ -9,6 +9,17 @@ This page explains every AWS IAM permission that Qovery requires to create and m
   Qovery follows the **principle of least privilege** where possible. S3 and SQS permissions are scoped to `qovery*` resources only. Some services require broad permissions because Qovery fully manages the lifecycle of those resources on your behalf.
 </Info>
 
+## Setup Overview
+
+Qovery provides two methods to set up AWS credentials:
+
+1. **STS Assume Role (recommended)** — A CloudFormation stack creates an IAM role with temporary, auto-rotating credentials
+2. **Static Credentials** — An IAM user with an access key pair (requires manual rotation)
+
+Both methods use the same IAM policy. You can review the full setup process in the [AWS installation guide](/getting-started/installation/aws).
+
+---
+
 ## Policy Structure
 
 The Qovery IAM policy has **two statements**:
@@ -260,6 +271,27 @@ These permissions are **restricted** to resources whose names start with `qovery
 |---|---|
 | Creates SQS queues for Karpenter interruption events | Receives EventBridge events for spot interruptions, health events, and instance state changes |
 | Karpenter reads and deletes messages (`ReceiveMessage`, `DeleteMessage`, `GetQueueUrl`) | Karpenter processes interruption events to gracefully drain workloads before node termination |
+
+---
+
+## What Qovery Creates in Your Account
+
+Here's a summary of all resources Qovery provisions per cluster:
+
+| Resource | Count | Purpose |
+|---|---|---|
+| EKS cluster | 1 | Managed Kubernetes control plane |
+| VPC | 1 | Network isolation for the cluster |
+| Subnets | 6 | 3 public + 3 private across availability zones |
+| NAT Gateways | up to 3 | Static outbound IP addresses |
+| Elastic IPs | up to 3 | Fixed IPs for NAT Gateways |
+| Security Groups | 3+ | Network access control for cluster, workers, databases |
+| EC2 instances | varies | Worker nodes managed by Karpenter |
+| S3 buckets | 3+ | Terraform state, VPC flow logs, Loki logs |
+| SQS queues | 1 | Karpenter interruption events |
+| IAM roles | 8+ | EKS, workers, Karpenter, ALB controller, Loki, ESO, etc. |
+| Load Balancer | 1+ | Ingress traffic routing |
+| CloudWatch log groups | 5 | EKS control plane logs |
 
 ---
 

--- a/docs/getting-started/security-and-compliance/aws-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/aws-iam-permissions.mdx
@@ -1,0 +1,284 @@
+---
+title: "AWS IAM Permissions Reference"
+description: "Detailed breakdown of every AWS IAM permission required by Qovery and why it's needed"
+---
+
+This page explains every AWS IAM permission that Qovery requires to create and manage your EKS clusters, and what each permission is used for in our infrastructure engine.
+
+<Info>
+  Qovery follows the **principle of least privilege** where possible. S3 and SQS permissions are scoped to `qovery*` resources only. Some services require broad permissions because Qovery fully manages the lifecycle of those resources on your behalf.
+</Info>
+
+## Policy Structure
+
+The Qovery IAM policy has **two statements**:
+
+1. **Statement 1** — Permissions on all resources (`"Resource": "*"`) for services where AWS does not support resource-level restrictions, or where Qovery needs to create new resources.
+2. **Statement 2** — Permissions scoped to `qovery*` resources only (S3 buckets and SQS queues).
+
+You can download the full policy JSON [here](/files/qovery-iam-aws.json).
+
+---
+
+## Statement 1 — Permissions on All Resources
+
+### IAM — `iam:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates IAM roles for the EKS control plane | AWS requires a service role for EKS to manage Kubernetes components |
+| Creates IAM roles and instance profiles for worker nodes | EC2 instances need roles to pull container images (ECR) and join the EKS cluster |
+| Creates IAM roles for Karpenter (node provisioner) | Karpenter needs permissions to launch/terminate EC2 instances and manage fleet requests |
+| Creates IAM roles for the AWS Load Balancer Controller | The ALB controller needs permissions to create and configure load balancers on your behalf |
+| Creates IAM roles for the Cluster Autoscaler | Autoscaler needs permissions to read and modify Auto Scaling groups |
+| Creates IAM roles for the CloudWatch exporter | Exporter needs read access to CloudWatch metrics for monitoring |
+| Creates IAM roles for Loki (log aggregation) | Loki stores logs in S3 and needs a dedicated role with scoped bucket access |
+| Creates IAM roles for External Secrets Operator | ESO needs permissions to read from AWS Secrets Manager and Parameter Store |
+| Manages OIDC providers for IRSA | IAM Roles for Service Accounts (IRSA) enables fine-grained pod-level permissions without sharing node credentials |
+
+<Info>
+  All IAM roles created by Qovery follow the IRSA pattern (IAM Roles for Service Accounts), meaning each Kubernetes workload gets its own scoped role rather than sharing a single broad role.
+</Info>
+
+---
+
+### EC2 — `ec2:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates a dedicated VPC | Isolates your Qovery infrastructure from other workloads in your AWS account |
+| Creates public and private subnets across 3 availability zones | Multi-AZ subnets provide high availability for your applications |
+| Creates security groups for EKS and worker nodes | Controls inbound/outbound traffic to the cluster and its nodes |
+| Creates Internet Gateways and NAT Gateways | Internet Gateway enables outbound connectivity; NAT Gateways provide static outbound IPs |
+| Allocates Elastic IPs for NAT Gateways | Required for static IP addresses when the Static IP feature is enabled |
+| Creates route tables and associations | Directs traffic between subnets, internet, and NAT gateways |
+| Launches EC2 instances via Karpenter (`CreateFleet`, `RunInstances`) | Karpenter provisions compute capacity for your application workloads |
+| Creates launch templates | Defines the AMI (Bottlerocket), instance configuration, and user data for worker nodes |
+| Describes instance types, availability zones, images, and spot prices | Karpenter uses this information to select the most cost-effective instances |
+| Manages network interfaces | Required for pod networking via the AWS VPC CNI plugin |
+
+---
+
+### EKS — `eks:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates EKS clusters | Provisions the Kubernetes control plane managed by AWS |
+| Configures control plane logging (API, audit, authenticator, controller manager, scheduler) | Sends EKS logs to CloudWatch for diagnostics and security auditing |
+| Enables Kubernetes secrets encryption via KMS | Encrypts sensitive data (secrets) stored in etcd at rest |
+| Creates and manages EKS managed node groups | Provisions the initial node group before Karpenter takes over scaling |
+| Installs EKS add-ons (CoreDNS, VPC-CNI, EBS-CSI) | Core Kubernetes networking and storage plugins required for cluster operation |
+
+---
+
+### Elastic Load Balancing — `elasticloadbalancing:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates Network Load Balancers (NLB) | Routes incoming HTTPS traffic to the Nginx Ingress controller inside the cluster |
+| Manages target groups and listeners | Configures how traffic is distributed to your application pods |
+| Manages listener certificates and SSL policies | Handles TLS termination for your custom domains |
+| Tags load balancers for cluster association | Ensures load balancers are tracked and cleaned up with the cluster lifecycle |
+| Cleans up orphaned load balancers | Removes NLBs that are no longer referenced by any Kubernetes service |
+
+---
+
+### RDS — `rds:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates RDS instances (PostgreSQL, MySQL) | Provisions managed databases requested through the Qovery console |
+| Configures Multi-AZ with automatic failover | Ensures database high availability across availability zones |
+| Enables encryption at rest and in transit | Protects your data with AES-256 encryption and TLS connections |
+| Creates DB subnet groups | Places databases in dedicated private subnets for network isolation |
+| Enables Performance Insights monitoring | Provides database performance metrics in the Qovery dashboard |
+| Manages snapshots and backup retention | Enables point-in-time recovery and scheduled backups |
+| Creates enhanced monitoring roles | Provides OS-level metrics for database instances |
+
+---
+
+### ElastiCache — `elasticache:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates ElastiCache replication groups (Redis) | Provisions managed Redis instances requested through the Qovery console |
+| Configures Multi-AZ with automatic failover | Ensures cache high availability |
+| Creates cache subnet groups | Places cache nodes in dedicated private subnets |
+| Enables transit encryption with auth tokens | Secures data in motion between your application and Redis |
+| Manages snapshots and maintenance windows | Enables backups and controlled maintenance |
+
+---
+
+### ECR — `ecr:*`
+
+| What Qovery does | Why |
+|---|---|
+| Grants worker nodes read access to ECR | Kubernetes nodes need to pull container images from your ECR repositories |
+| Manages ECR repositories for Qovery-built images | When building from source, Qovery pushes built images to ECR |
+
+<Info>
+  Worker nodes receive the `AmazonEC2ContainerRegistryReadOnly` managed policy via their IAM role.
+</Info>
+
+---
+
+### CloudWatch — `cloudwatch:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates CloudWatch log groups for EKS | Stores EKS control plane logs (API server, audit, authenticator, controller manager, scheduler) |
+| Configures log retention policies | Controls how long EKS logs are kept (configurable) |
+| Reads metrics via CloudWatch Exporter (`GetMetricData`, `GetMetricStatistics`, `ListMetrics`) | Collects AWS resource metrics for Qovery's monitoring dashboard |
+
+---
+
+### CloudWatch Logs — `logs:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates and manages log groups | Required by EKS for control plane logging |
+| Sets retention policies | Prevents unbounded log storage costs |
+| Streams log events | Enables viewing EKS control plane logs for debugging |
+
+---
+
+### Auto Scaling — `autoscaling:*`, `application-autoscaling:*`
+
+| What Qovery does | Why |
+|---|---|
+| Reads Auto Scaling group state (`Describe*`) | Cluster Autoscaler monitors current node capacity |
+| Modifies desired capacity (`SetDesiredCapacity`, `TerminateInstanceInAutoScalingGroup`) | Cluster Autoscaler scales nodes up/down based on pod scheduling pressure |
+
+<Info>
+  Qovery primarily uses **Karpenter** for node provisioning, which manages EC2 instances directly. Auto Scaling permissions are retained for the initial managed node group and as a fallback.
+</Info>
+
+---
+
+### KMS — `kms:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates or uses KMS keys for EKS secrets encryption | Encrypts Kubernetes secrets in etcd at rest using envelope encryption |
+| Encrypts S3 buckets (logs, Terraform state) | Ensures all stored data is encrypted with AWS-managed or customer-managed keys |
+
+---
+
+### EventBridge — `events:*` (scoped actions)
+
+The policy grants only specific EventBridge actions:
+
+| Action | Why |
+|---|---|
+| `PutRule`, `PutTargets` | Creates event rules to capture EC2 spot interruption warnings, rebalance recommendations, and instance state changes |
+| `DescribeRule`, `ListRuleNamesByTarget`, `ListTargetsByRule` | Reads existing rules for idempotent Terraform management |
+| `DeleteRule`, `RemoveTargets` | Cleans up event rules when the cluster is deleted |
+| `TagResource`, `UntagResource`, `ListTagsForResource` | Tags event rules for cluster lifecycle tracking |
+
+<Info>
+  These events are forwarded to an SQS queue that Karpenter monitors to gracefully drain nodes before spot interruptions or maintenance events.
+</Info>
+
+---
+
+### Organizations — Read-Only Access
+
+| Action | Why |
+|---|---|
+| `DescribeAccount`, `DescribeOrganization`, `DescribeOrganizationalUnit`, `DescribePolicy` | Reads AWS account metadata to validate the account context and detect organizational constraints |
+| `ListChildren`, `ListParents`, `ListPoliciesForTarget`, `ListRoots`, `ListPolicies`, `ListTargetsForPolicy` | Enumerates organizational structure to detect Service Control Policies (SCPs) that might restrict Qovery operations |
+
+<Info>
+  These are **read-only** permissions. Qovery never modifies your AWS Organization structure.
+</Info>
+
+---
+
+### DynamoDB — `dynamodb:*`
+
+| What Qovery does | Why |
+|---|---|
+| Creates DynamoDB tables for Terraform state locking | Prevents concurrent Terraform operations from corrupting your infrastructure state |
+
+---
+
+### ECS — `ecs:*`
+
+| What Qovery does | Why |
+|---|---|
+| Reserved for future use and hybrid ECS/EKS workloads | Ensures Qovery can manage ECS-based workloads if enabled on your cluster |
+
+---
+
+### Elasticsearch Service — `es:*` (scoped actions)
+
+| Action | Why |
+|---|---|
+| `CreateElasticsearchDomain`, `DeleteElasticsearchDomain`, `DescribeElasticsearchDomain` | Provisions and manages Elasticsearch domains when requested as a managed service |
+| `AddTags`, `RemoveTags`, `ListTags` | Tags Elasticsearch domains for cluster lifecycle tracking and cost allocation |
+
+---
+
+### CloudTrail — `cloudtrail:LookupEvents`
+
+| What Qovery does | Why |
+|---|---|
+| Looks up recent API events | Used for debugging infrastructure provisioning failures by checking recent AWS API activity |
+
+---
+
+### Resource Groups Tagging — `tag:GetResources`
+
+| What Qovery does | Why |
+|---|---|
+| Discovers resources by tag across all services | Used by the CloudWatch Exporter to find all resources belonging to your cluster for metrics collection |
+
+---
+
+## Statement 2 — Scoped to `qovery*` Resources
+
+These permissions are **restricted** to resources whose names start with `qovery`. Qovery cannot access any S3 buckets or SQS queues that you created outside of Qovery.
+
+### S3 — `s3:*` (on `arn:aws:s3:::qovery*`)
+
+| What Qovery does | Why |
+|---|---|
+| Creates S3 buckets for Terraform state | Stores infrastructure state files needed to manage your cluster |
+| Creates S3 buckets for VPC flow logs | Stores network traffic logs for security auditing (encrypted, with lifecycle policies) |
+| Creates S3 buckets for Loki log storage | Stores application and infrastructure logs with configurable retention |
+| Manages bucket encryption and access policies | Ensures all buckets have server-side encryption and public access blocking enabled |
+
+<Info>
+  The `s3:ListAllMyBuckets` permission in Statement 1 is required to verify bucket existence before creation. It is read-only and does not grant access to bucket contents.
+</Info>
+
+---
+
+### SQS — `sqs:*` (on `arn:aws:sqs:*:*:qovery*`)
+
+| What Qovery does | Why |
+|---|---|
+| Creates SQS queues for Karpenter interruption events | Receives EventBridge events for spot interruptions, health events, and instance state changes |
+| Karpenter reads and deletes messages (`ReceiveMessage`, `DeleteMessage`, `GetQueueUrl`) | Karpenter processes interruption events to gracefully drain workloads before node termination |
+
+---
+
+## Security Best Practices
+
+<AccordionGroup>
+  <Accordion title="Can I restrict these permissions further?">
+    Some permissions can be scoped more narrowly for advanced use cases. Contact [Qovery support](/getting-started/useful-resources/help-and-support) for a minimal policy template tailored to your specific configuration (e.g., if you don't use managed databases, RDS and ElastiCache permissions can be removed).
+  </Accordion>
+
+  <Accordion title="Why use STS Assume Role instead of static credentials?">
+    STS Assume Role provides **temporary credentials** that automatically rotate. Qovery never stores long-lived access keys, and you can revoke access instantly by deleting the CloudFormation stack. See the [AWS installation guide](/getting-started/installation/aws) for setup instructions.
+  </Accordion>
+
+  <Accordion title="Does Qovery access my existing AWS resources?">
+    No. S3 and SQS permissions are scoped to `qovery*` resources only. Other services (EC2, EKS, RDS, etc.) create **new** resources dedicated to your Qovery cluster. Qovery does not read or modify resources created outside of Qovery.
+  </Accordion>
+
+  <Accordion title="How can I audit what Qovery does with these permissions?">
+    Enable AWS CloudTrail in your account to get a full audit log of every API call made by the Qovery IAM role. You can also review Qovery's [audit logs](/getting-started/security-and-compliance/audit-logs) for a high-level view of operations.
+  </Accordion>
+</AccordionGroup>

--- a/docs/getting-started/security-and-compliance/azure-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/azure-iam-permissions.mdx
@@ -1,0 +1,283 @@
+---
+title: "Azure IAM Permissions Reference"
+description: "Detailed breakdown of every Azure permission required by Qovery and why it's needed"
+---
+
+This page explains every Azure permission that Qovery requires to create and manage your AKS clusters, and what each permission is used for in our infrastructure engine.
+
+<Info>
+  Qovery uses a **custom role** with granular permissions rather than the built-in `Contributor` role, following the principle of least privilege. The role is scoped to a single subscription.
+</Info>
+
+## Setup Overview
+
+Qovery provides a setup script that:
+
+1. **Registers required Azure resource providers** (Container Service, Container Registry, Storage, Network, etc.)
+2. **Creates a custom IAM role** with the exact permissions listed below, scoped to your subscription
+3. **Creates a multi-tenant service principal** in your Azure AD tenant
+4. **Assigns the custom role** to the service principal
+
+You can review the full setup process in the [Azure installation guide](/getting-started/installation/azure).
+
+---
+
+## Required Resource Providers
+
+The setup script registers these Azure resource providers before provisioning:
+
+| Provider | Why |
+|---|---|
+| `Microsoft.ContainerService` | AKS cluster creation and management |
+| `Microsoft.ContainerRegistry` | Docker image registry for built container images |
+| `Microsoft.Storage` | Storage accounts and blob storage for Terraform state, logs, and metrics |
+| `Microsoft.Network` | Virtual networks, subnets, NAT gateways, public IPs, load balancers, DNS |
+| `Microsoft.ContainerInstance` | Container instance support |
+| `Microsoft.Compute` | Virtual machine scale sets, disks, and snapshots for AKS nodes |
+| `Microsoft.Authorization` | Role assignments and role definitions for managed identities |
+| `Microsoft.Insights` | Monitoring, diagnostics, and metrics |
+| `Microsoft.KeyVault` | Secret and key management |
+| `Microsoft.AppConfiguration` | Application configuration management |
+| `Microsoft.EventGrid` | Event-driven integrations |
+| `Microsoft.ServiceBus` | Message queue support |
+| `Microsoft.ManagedIdentity` | User-assigned managed identities for Workload Identity |
+| `Microsoft.Features` | Feature flag registration for preview features |
+
+---
+
+## Control Plane Permissions (Actions)
+
+### AKS — `Microsoft.ContainerService`
+
+| Permission | Why |
+|---|---|
+| `managedClusters/*` | Full lifecycle management of AKS clusters: create, update, delete, scale, upgrade. Qovery provisions AKS clusters with OIDC issuer, Workload Identity, Cilium network policy, system-assigned managed identity, and multi-zone node pools |
+| `locations/operationresults/read` | Monitors long-running AKS operations (cluster create, upgrade, delete) |
+| `locations/operations/read` | Reads operation status during provisioning |
+| `operations/read` | Lists available AKS operations |
+| `locations/usages/read` | Checks AKS quota and capacity before provisioning |
+| `locations/orchestrators/read` | Lists available Kubernetes versions for cluster creation and upgrades |
+
+<Info>
+  Qovery creates AKS clusters with:
+  - **Cilium** network policy and data plane
+  - **Azure CNI Overlay** networking
+  - **Workload Identity** via OIDC issuer
+  - **Multi-zone node pools** (zones 1, 2, 3) with auto-scaling
+  - **Maintenance windows** (Tuesdays 21:00–23:00 UTC)
+</Info>
+
+---
+
+### Container Registry — `Microsoft.ContainerRegistry`
+
+| Permission | Why |
+|---|---|
+| `registries/*` | Creates and manages Azure Container Registry instances to store container images built from your source code. Includes image push/pull, repository management, retention policies, and AKS pull access configuration |
+| `locations/operationresults/read` | Monitors ACR provisioning operations |
+| `operations/read` | Lists available ACR operations |
+| `checkNameAvailability/read` | Validates registry name uniqueness before creation (Azure requires globally unique names) |
+
+---
+
+### Storage — `Microsoft.Storage`
+
+Qovery creates a **Standard ZRS** (Zone-Redundant Storage) account per cluster with three blob containers:
+- **`qovery-kubeconfigs-{id}`** — Stores kubeconfig files
+- **`qovery-logs-{id}`** — Stores application and infrastructure logs (Loki)
+- **`qovery-thanos-{id}`** — Stores metrics (Thanos long-term storage)
+
+| Permission | Why |
+|---|---|
+| `storageAccounts/*` | Full lifecycle management of storage accounts: create, configure, delete |
+| `locations/usages/read` | Checks storage quota before creating accounts |
+| `operations/read` | Lists available storage operations |
+| `storageAccounts/listAccountSas/action` | Generates SAS tokens for scoped access to storage resources |
+| `storageAccounts/listServiceSas/action` | Generates service-level SAS tokens for blob container access |
+| `storageAccounts/listKeys/action` | Retrieves storage account access keys for Terraform state backend and blob operations |
+| `storageAccounts/blobServices/*` | Manages blob containers and configuration (versioning, lifecycle policies) |
+| `storageAccounts/fileServices/*` | Manages file shares if needed for persistent volumes |
+
+---
+
+### Networking — `Microsoft.Network`
+
+Qovery creates a complete network stack per cluster:
+- **VNet** with configurable CIDR (default `10.0.0.0/16`)
+- **3 subnets** (one per availability zone, each `/20`)
+- **3 NAT Gateways** with static public IPs (one per zone)
+- **Network policy** via Cilium
+
+| Permission | Why |
+|---|---|
+| `virtualNetworks/*` | Creates the cluster VNet with custom CIDR blocks, or uses an existing VNet |
+| `networkSecurityGroups/*` | Creates NSGs to control inbound/outbound traffic to cluster nodes and pods |
+| `routeTables/*` | Creates route tables for custom traffic routing within the VNet |
+| `publicIPAddresses/*` | Allocates static public IPs for NAT gateways (Standard SKU, one per AZ) |
+| `loadBalancers/*` | Manages the Kubernetes Standard load balancer for service exposure |
+| `networkInterfaces/*` | Manages network interfaces for AKS node VMs |
+| `natGateways/*` | Creates zone-redundant NAT gateways for deterministic outbound IP addresses |
+| `locations/operations/read` | Monitors long-running network operations |
+| `locations/usages/read` | Checks networking quota (public IPs, VNets, etc.) |
+| `operations/read` | Lists available network operations |
+| `dnsZones/*` | Manages public DNS zones for application domain resolution |
+| `privateDnsZones/*` | Manages private DNS zones for internal service discovery |
+| `publicIPPrefixes/*` | Manages public IP prefixes for contiguous IP allocation |
+| `applicationSecurityGroups/*` | Groups VMs by security policy for granular NSG rules |
+| `privateEndpoints/*` | Creates private endpoints for secure access to Azure services (storage, registry) without public internet |
+| `privateLinkServices/*` | Exposes services via Azure Private Link |
+
+---
+
+### Compute — `Microsoft.Compute`
+
+| Permission | Why |
+|---|---|
+| `virtualMachineScaleSets/*` | Manages AKS node pool VMSS: scaling, updates, instance management. Karpenter uses VMSS for dynamic node provisioning |
+| `virtualMachines/*` | Manages individual VM instances within node pools |
+| `disks/*` | Creates and manages managed disks for persistent volumes (supports Standard, Premium, Premium V2, and Ultra SSD) |
+| `snapshots/*` | Creates disk snapshots for backup and restore of persistent volumes |
+| `availabilitySets/*` | Manages availability sets for VM placement across fault domains |
+| `locations/operations/read` | Monitors long-running compute operations |
+| `locations/usages/read` | Checks compute quota (vCPUs, VMs) before provisioning |
+| `locations/vmSizes/read` | Lists available VM sizes in the target region — Qovery supports 600+ Azure instance types (B, D, E, F series and more) |
+| `operations/read` | Lists available compute operations |
+
+---
+
+### Resource Manager — `Microsoft.Resources`
+
+| Permission | Why |
+|---|---|
+| `subscriptions/resourceGroups/*` | Creates a dedicated resource group per cluster to isolate all Qovery resources. Tags include cluster_id, organization_id, region, creation_date |
+| `subscriptions/resources/read` | Lists resources within the subscription for discovery and validation |
+| `deployments/*` | Manages Azure Resource Manager deployments (ARM templates) used by some provisioning operations |
+| `subscriptions/operationresults/read` | Monitors long-running subscription-level operations |
+| `subscriptions/providers/read` | Reads registered resource providers to verify prerequisites |
+
+---
+
+### Authorization — `Microsoft.Authorization`
+
+| Permission | Why |
+|---|---|
+| `roleAssignments/*` | Creates role assignments to bind managed identities to Azure roles. Qovery assigns: **Virtual Machine Contributor** and **Network Contributor** to Karpenter, **Storage Blob Data Contributor** to storage and Thanos identities, **Contributor** to the AKS system identity |
+| `roleDefinitions/read` | Reads built-in role definitions to reference them in assignments |
+| `*/read` | Reads authorization metadata across all resource types for validation |
+
+<Info>
+  Qovery creates these managed identities with **Workload Identity** (OIDC federation):
+  - **Karpenter MSI** — VM/Network Contributor for node provisioning
+  - **Storage MSI** — Blob Data Contributor for logs and state
+  - **Thanos MSI** — Blob Data Contributor for metrics storage
+
+  Each identity is scoped to the cluster's resource group.
+</Info>
+
+---
+
+### Managed Identity — `Microsoft.ManagedIdentity`
+
+| Permission | Why |
+|---|---|
+| `userAssignedIdentities/*` | Creates user-assigned managed identities for Karpenter, storage, and Thanos. Each identity gets a federated credential linked to a Kubernetes service account via OIDC |
+| `*/read` | Reads managed identity metadata for validation and reference |
+
+---
+
+### Key Vault — `Microsoft.KeyVault`
+
+| Permission | Why |
+|---|---|
+| `vaults/*` | Creates and manages Key Vault instances for storing secrets, certificates, and encryption keys used by cluster components |
+| `operations/read` | Lists available Key Vault operations |
+
+---
+
+### Monitoring — `Microsoft.Insights`
+
+| Permission | Why |
+|---|---|
+| `components/*` | Creates Application Insights components for application monitoring |
+| `webtests/*` | Manages availability tests for endpoint monitoring |
+| `alertRules/*` | Creates alert rules for infrastructure and application health |
+| `diagnosticSettings/*` | Configures diagnostic settings to route platform logs and metrics |
+| `logDefinitions/read` | Reads available log categories for diagnostic configuration |
+| `metricDefinitions/read` | Reads available metric definitions for monitoring dashboards |
+
+---
+
+### Features — `Microsoft.Features`
+
+| Permission | Why |
+|---|---|
+| `features/read` | Reads available Azure feature flags |
+| `providers/features/read` | Checks if preview features are registered for the subscription |
+| `providers/features/register/action` | Registers preview features required by AKS (e.g., Karpenter support, Cilium data plane) |
+
+---
+
+### Container Instances — `Microsoft.ContainerInstance`
+
+| Permission | Why |
+|---|---|
+| `containerGroups/*` | Creates container groups for utility tasks (similar to Cloud Run Jobs on GCP) |
+| `locations/operations/read` | Monitors container instance operations |
+| `operations/read` | Lists available container instance operations |
+| `locations/usages/read` | Checks container instance quota |
+
+---
+
+## Data Plane Permissions (DataActions)
+
+These permissions control access to the **data** within Azure resources (as opposed to management operations).
+
+### Blob Storage — `Microsoft.Storage`
+
+| Permission | Why |
+|---|---|
+| `storageAccounts/blobServices/containers/blobs/*` | Read, write, and delete blob objects in Qovery storage containers (kubeconfigs, log chunks, metrics blocks). Required for Loki log ingestion, Thanos metrics storage, and kubeconfig management |
+
+### Container Registry — `Microsoft.ContainerRegistry`
+
+| Permission | Why |
+|---|---|
+| `registries/repositories/content/read` | Pulls container images from ACR during pod deployments |
+| `registries/repositories/content/write` | Pushes built container images to ACR during CI/CD builds |
+| `registries/repositories/content/delete` | Removes old container images during cleanup and retention enforcement |
+| `registries/repositories/metadata/read` | Reads image tags, manifests, and repository metadata for version management |
+| `registries/repositories/metadata/write` | Updates image tags and metadata during build and promotion workflows |
+
+---
+
+## Security Best Practices
+
+<AccordionGroup>
+  <Accordion title="Why does Qovery use a multi-tenant service principal?">
+    Qovery uses a **multi-tenant application** registered in Qovery's Azure AD tenant. When you run the setup script, it creates a service principal in **your** tenant that references this application. This means:
+    - Qovery never has direct access to your tenant credentials
+    - You control the service principal and its role assignment
+    - You can revoke access instantly by deleting the role assignment or service principal
+  </Accordion>
+
+  <Accordion title="Can I restrict these permissions further?">
+    The custom role contains the minimum permissions required for full cluster lifecycle management. If you don't use certain features (e.g., Key Vault, Container Instances), contact [Qovery support](/getting-started/useful-resources/help-and-support) for a tailored role definition.
+  </Accordion>
+
+  <Accordion title="What is the scope of the custom role?">
+    The custom role is scoped to a **single subscription** (`/subscriptions/{id}`). Qovery cannot access resources in other subscriptions. Within the subscription, Qovery creates a dedicated resource group per cluster and operates primarily within that group.
+  </Accordion>
+
+  <Accordion title="How can I audit what Qovery does with these permissions?">
+    Enable [Azure Activity Log](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log) and [Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/) to get a full record of every API call made by the Qovery service principal. You can also review Qovery's [audit logs](/getting-started/security-and-compliance/audit-logs) for a high-level view.
+  </Accordion>
+
+  <Accordion title="What managed identities does Qovery create?">
+    Qovery creates dedicated **user-assigned managed identities** with Workload Identity (OIDC federation):
+    - **Karpenter MSI** — Virtual Machine Contributor + Network Contributor for dynamic node provisioning
+    - **Storage MSI** — Storage Blob Data Contributor for kubeconfig and log storage
+    - **Thanos MSI** — Storage Blob Data Contributor for long-term metrics storage
+
+    Each identity is federated with a specific Kubernetes service account, so credentials are never stored in pods.
+  </Accordion>
+</AccordionGroup>

--- a/docs/getting-started/security-and-compliance/azure-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/azure-iam-permissions.mdx
@@ -250,6 +250,26 @@ These permissions control access to the **data** within Azure resources (as oppo
 
 ---
 
+## What Qovery Creates in Your Account
+
+Here's a summary of all resources Qovery provisions per cluster:
+
+| Resource | Count | Purpose |
+|---|---|---|
+| Resource Group | 1 | Isolates all cluster resources |
+| AKS cluster | 1 | Managed Kubernetes control plane |
+| Virtual Network | 1 | Network isolation for the cluster |
+| Subnets | 3 | One per availability zone |
+| NAT Gateways | 3 | One per zone for static outbound IPs |
+| Public IPs | 3 | Static IPs for NAT Gateways |
+| Storage Account | 1 | Blob storage for kubeconfigs, logs, metrics |
+| Blob containers | 3 | Kubeconfigs, logs (Loki), metrics (Thanos) |
+| Container Registry | 1 | Docker image storage |
+| Managed Identities | 3+ | Karpenter, storage, Thanos |
+| Load Balancer | 1+ | Ingress traffic routing |
+
+---
+
 ## Security Best Practices
 
 <AccordionGroup>

--- a/docs/getting-started/security-and-compliance/gcp-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/gcp-iam-permissions.mdx
@@ -304,6 +304,24 @@ Qovery uses Cloud Run Jobs for **asynchronous cleanup tasks** (e.g., deleting GC
 
 ---
 
+## What Qovery Creates in Your Account
+
+Here's a summary of all resources Qovery provisions per cluster:
+
+| Resource | Count | Purpose |
+|---|---|---|
+| GKE Autopilot cluster | 1 | Managed Kubernetes control plane |
+| VPC network | 1 | Network isolation for the cluster |
+| Subnetwork | 1 | Pod and service IP ranges |
+| Cloud Router | 1 | BGP router for NAT configuration |
+| Cloud NAT | 1 | Outbound internet access for nodes |
+| GCS buckets | 3 | Kubeconfigs, logs (Loki), metrics (Thanos) |
+| Artifact Registry repositories | 1+ | Docker image storage |
+| Service accounts | 5+ | Cluster nodes, Loki, ESO, KEDA, Thanos |
+| Firewall rules | 5+ | Intra-cluster, webhook, and logging rules |
+
+---
+
 ## Security Best Practices
 
 <AccordionGroup>

--- a/docs/getting-started/security-and-compliance/gcp-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/gcp-iam-permissions.mdx
@@ -1,0 +1,332 @@
+---
+title: "GCP IAM Permissions Reference"
+description: "Detailed breakdown of every GCP IAM permission required by Qovery and why it's needed"
+---
+
+This page explains every GCP IAM permission that Qovery requires to create and manage your GKE clusters, and what each permission is used for in our infrastructure engine.
+
+<Info>
+  Qovery uses a **custom IAM role** with granular permissions rather than predefined GCP roles, following the principle of least privilege. The setup script also enables only the specific GCP APIs that Qovery needs.
+</Info>
+
+## Setup Overview
+
+Qovery provides a setup script that:
+
+1. **Enables required GCP APIs** (Container, Compute, Artifact Registry, Storage, Resource Manager, Cloud Run)
+2. **Creates a custom IAM role** with the exact permissions listed below
+3. **Creates a service account** and binds it to the custom role
+4. **Generates a JSON key** for the service account to upload in Qovery
+
+You can review the full setup script in the [GCP installation guide](/getting-started/installation/gcp).
+
+---
+
+## Required GCP APIs
+
+| API | Why |
+|---|---|
+| `container.googleapis.com` | GKE cluster creation and management |
+| `compute.googleapis.com` | VPC networks, subnetworks, routers, NAT gateways, firewall rules |
+| `artifactregistry.googleapis.com` | Docker image repository management |
+| `storage.googleapis.com` | GCS buckets for Terraform state, logs, and metrics |
+| `cloudresourcemanager.googleapis.com` | Project-level IAM policy management |
+| `run.googleapis.com` | Cloud Run Jobs for asynchronous cleanup tasks |
+
+---
+
+## IAM Permissions — Service Accounts
+
+### `iam.serviceAccounts.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `disable`, `enable`, `undelete` | Qovery creates dedicated GCP service accounts for each cluster component (GKE nodes, Loki logging, External Secrets Operator, KEDA autoscaler, Thanos metrics) |
+| `get`, `list` | Reads existing service accounts to avoid duplicates during updates |
+| `update` | Updates service account display names or descriptions when cluster configuration changes |
+| `getIamPolicy`, `setIamPolicy` | Configures Workload Identity bindings — maps Kubernetes service accounts to GCP service accounts so pods authenticate without JSON keys |
+| `actAs` | Required for assigning service accounts to GKE nodes and Cloud Run Jobs |
+
+<Info>
+  **Workload Identity** is the recommended way to authenticate workloads on GKE. Qovery creates dedicated service accounts for each component:
+  - **Cluster SA** — Default node SA with logging, monitoring, and image pull permissions
+  - **Loki SA** — GCS access for log storage
+  - **ESO SA** — Secret Manager access for external secrets
+  - **KEDA SA** — Workload Identity for autoscaling
+  - **Thanos SA** — GCS access for metrics storage
+</Info>
+
+---
+
+## IAM Permissions — Resource Manager
+
+### `resourcemanager.projects.*`
+
+| Permission | Why |
+|---|---|
+| `get` | Reads project metadata to validate the project context before provisioning |
+| `getIamPolicy` | Reads existing project-level IAM bindings to check current state before making changes |
+| `setIamPolicy` | Binds service accounts to IAM roles at the project level (e.g., granting the cluster SA `roles/logging.logWriter`) |
+
+---
+
+## Kubernetes Engine — `container.*`
+
+Qovery creates **GKE Autopilot** clusters, which requires full control over Kubernetes resources. The permissions are grouped by function below.
+
+### Cluster Management
+
+| Permission group | Why |
+|---|---|
+| `container.clusters.create`, `delete`, `update`, `get`, `list` | Creates and manages GKE Autopilot clusters with VPC-native networking, private nodes, release channels, and maintenance windows |
+| `container.clusters.connect`, `getCredentials` | Retrieves cluster credentials (kubeconfig) to deploy Helm charts and Kubernetes resources |
+| `container.clusters.createTagBinding`, `deleteTagBinding`, `listEffectiveTags`, `listTagBindings` | Tags clusters for lifecycle tracking and cost allocation |
+| `container.operations.get`, `list` | Monitors long-running cluster operations (create, upgrade, delete) |
+
+### Core Kubernetes Resources
+
+These permissions are required to deploy and manage Qovery system components (Nginx Ingress, cert-manager, Loki, Prometheus, KEDA, etc.) via Helm charts.
+
+| Permission group | Why |
+|---|---|
+| `container.pods.*` | Deploys application pods, reads logs, executes into pods for debugging, manages pod lifecycle |
+| `container.deployments.*` | Creates Deployments for Qovery agent, ingress controller, monitoring stack |
+| `container.services.*` | Creates Kubernetes Services (LoadBalancer, ClusterIP) to expose applications |
+| `container.configMaps.*` | Stores configuration for Helm releases and application settings |
+| `container.secrets.*` | Manages TLS certificates, registry credentials, and application secrets |
+| `container.namespaces.*` | Creates isolated namespaces for each Qovery environment |
+| `container.serviceAccounts.*` | Creates Kubernetes service accounts for Workload Identity bindings |
+| `container.persistentVolumeClaims.*`, `container.persistentVolumes.*` | Manages persistent storage for stateful workloads (databases, caches) |
+
+### Workload Scaling & Scheduling
+
+| Permission group | Why |
+|---|---|
+| `container.horizontalPodAutoscalers.*` | Configures HPA for auto-scaling application workloads based on CPU/memory |
+| `container.statefulSets.*` | Deploys stateful components (Prometheus, Loki) that need stable identities |
+| `container.daemonSets.*` | Deploys node-level agents (Promtail log forwarder) on every node |
+| `container.cronJobs.*` | Schedules recurring tasks (certificate renewal, cleanup jobs) |
+| `container.jobs.*` | Runs one-off tasks (database migrations, lifecycle hooks) |
+| `container.replicaSets.*` | Manages pod replicas created by Deployments |
+| `container.podDisruptionBudgets.*` | Ensures minimum pod availability during node maintenance |
+| `container.priorityClasses.*` | Defines scheduling priority for system components vs user workloads |
+| `container.limitRanges.*`, `container.resourceQuotas.*` | Enforces resource limits per namespace to prevent noisy-neighbor issues |
+
+### Networking & Ingress
+
+| Permission group | Why |
+|---|---|
+| `container.ingresses.*` | Creates Ingress resources to route external traffic to applications |
+| `container.networkPolicies.*` | Enforces network isolation between namespaces/environments |
+| `container.endpointSlices.*`, `container.endpoints.*` | Service discovery — maps Services to pod IPs |
+| `container.backendConfigs.*`, `container.frontendConfigs.*` | Configures GCP-specific load balancer settings (health checks, SSL policies) |
+| `container.managedCertificates.*` | Manages Google-managed TLS certificates for HTTPS endpoints |
+
+### RBAC & Security
+
+| Permission group | Why |
+|---|---|
+| `container.clusterRoles.*`, `container.clusterRoleBindings.*` | Defines cluster-wide permissions for Qovery system components |
+| `container.roles.*`, `container.roleBindings.*` | Defines namespace-scoped permissions for application workloads |
+| `container.podSecurityPolicies.*` | Configures pod security constraints (deprecated but required for older clusters) |
+| `container.mutatingWebhookConfigurations.*`, `container.validatingWebhookConfigurations.*` | Installs admission webhooks for cert-manager and policy enforcement |
+| `container.certificateSigningRequests.*` | Manages internal TLS certificate signing within the cluster |
+| `container.selfSubjectAccessReviews.create`, `container.selfSubjectRulesReviews.create`, `container.subjectAccessReviews.create`, `container.localSubjectAccessReviews.create`, `container.tokenReviews.create` | RBAC authorization checks — verifies what actions are permitted |
+
+### Storage & CSI
+
+| Permission group | Why |
+|---|---|
+| `container.storageClasses.*` | Defines storage classes (SSD, standard) for persistent volumes |
+| `container.csiDrivers.*`, `container.csiNodes.*`, `container.csiNodeInfos.*` | Container Storage Interface plugins for dynamic volume provisioning |
+| `container.volumeAttachments.*` | Attaches/detaches persistent disks to nodes |
+| `container.volumeSnapshots.*`, `container.volumeSnapshotClasses.*`, `container.volumeSnapshotContents.*` | Creates volume snapshots for backup and restore |
+| `container.storageStates.*`, `container.storageVersionMigrations.*` | Internal storage state management and API version migrations |
+
+### Cluster Internals
+
+| Permission group | Why |
+|---|---|
+| `container.nodes.*` | Reads node status, labels, and taints for scheduling decisions |
+| `container.events.*` | Reads Kubernetes events for debugging and monitoring |
+| `container.leases.*` | Leader election for HA components (controller-manager, scheduler) |
+| `container.controllerRevisions.*` | Tracks revision history for Deployments and StatefulSets |
+| `container.replicationControllers.*` | Legacy workload management (backward compatibility) |
+| `container.componentStatuses.*` | Health checks on cluster components |
+| `container.customResourceDefinitions.*` | Installs CRDs for cert-manager, Prometheus Operator, KEDA, and other operators |
+| `container.apiServices.*` | Registers custom API services (metrics server, custom metrics) |
+| `container.runtimeClasses.*` | Configures container runtimes (gVisor, containerd) |
+| `container.bindings.create` | Binds pods to nodes during scheduling |
+| `container.podTemplates.*` | Pod template management for workload controllers |
+| `container.thirdPartyObjects.*` | Legacy third-party resource support |
+| `container.updateInfos.*` | Cluster update state tracking |
+| `container.auditSinks.*` | Configures audit log forwarding |
+| `container.hostServiceAgent.use` | Required for GKE host service agent integration |
+
+---
+
+## Artifact Registry — `artifactregistry.*`
+
+| Permission group | Why |
+|---|---|
+| `repositories.create`, `delete`, `update`, `get`, `list` | Creates Docker repositories (prefixed `qovery-`) to store container images built from your source code |
+| `repositories.getIamPolicy`, `setIamPolicy` | Grants the cluster service account pull access to Qovery repositories |
+| `repositories.uploadArtifacts`, `downloadArtifacts`, `readViaVirtualRepository`, `deleteArtifacts` | Pushes built images during CI/CD, pulls images during deployment, cleans up old images |
+| `repositories.createTagBinding`, `deleteTagBinding`, `listEffectiveTags`, `listTagBindings` | Tags repositories for lifecycle tracking |
+| `dockerimages.get`, `list` | Lists and inspects images for version management and cleanup |
+| `tags.create`, `delete`, `get`, `list`, `update` | Manages image tags (e.g., `latest`, commit SHA, version numbers) |
+| `versions.delete`, `get`, `list` | Manages image versions and removes unused versions to save storage costs |
+| `locations.get`, `list` | Discovers available Artifact Registry regions |
+
+---
+
+## Compute Engine — Networking
+
+### VPC Networks — `compute.networks.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `get`, `list` | Creates a dedicated VPC for the GKE cluster or uses an existing one |
+| `access`, `use`, `useExternalIp` | Allows GKE nodes and pods to use the VPC for networking |
+| `getEffectiveFirewalls`, `getRegionEffectiveFirewalls` | Reads firewall state for debugging and validation |
+| `setFirewallPolicy`, `updatePolicy`, `updatePeering` | Configures network policies and VPC peering for cross-VPC connectivity |
+| `mirror` | Network traffic mirroring for security analysis (if enabled) |
+| `createTagBinding`, `deleteTagBinding`, `listEffectiveTags`, `listTagBindings` | Tags networks for lifecycle tracking |
+
+### Subnetworks — `compute.subnetworks.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `update`, `get`, `list` | Creates subnetworks for GKE pods and services with secondary IP ranges |
+| `use`, `useExternalIp` | Allows GKE to schedule pods in the subnetwork |
+| `expandIpCidrRange` | Expands subnet CIDR if more pod IPs are needed |
+| `getIamPolicy`, `setIamPolicy` | Grants GKE access to the subnetwork |
+| `setPrivateIpGoogleAccess` | Enables private Google access so nodes can reach GCP APIs without public IPs |
+| `mirror` | Subnet-level traffic mirroring |
+| `createTagBinding`, `deleteTagBinding`, `listEffectiveTags`, `listTagBindings` | Tags subnetworks for lifecycle tracking |
+
+### Routers & NAT — `compute.routers.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `update`, `get`, `list` | Creates Cloud Routers for NAT gateway configuration |
+| `use` | Associates the router with the VPC network |
+| `getRoutePolicy`, `deleteRoutePolicy`, `listRoutePolicies`, `updateRoutePolicy`, `listBgpRoutes` | Manages BGP routing policies for advanced networking |
+
+### Routes — `compute.routes.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `get`, `list` | Creates custom routes for VPC traffic (e.g., routing to NAT gateway) |
+| `createTagBinding`, `deleteTagBinding`, `listEffectiveTags`, `listTagBindings` | Tags routes for lifecycle tracking |
+
+### Instance Groups — `compute.instanceGroupManagers.*`, `compute.instanceGroups.*`
+
+| Permission | Why |
+|---|---|
+| `get`, `list`, `update`, `use` | Reads and manages GKE node pool instance groups (managed by Autopilot) |
+| `listEffectiveTags`, `listTagBindings` | Tags instance groups for lifecycle tracking |
+
+### Regions — `compute.regions.*`
+
+| Permission | Why |
+|---|---|
+| `get`, `list` | Discovers available regions for cluster placement |
+
+---
+
+## Cloud Storage — `storage.*`
+
+Qovery creates three GCS buckets per cluster, all prefixed with `qovery-`:
+- **`qovery-kubeconfigs-{id}`** — Stores kubeconfig files (versioned)
+- **`qovery-logs-{id}`** — Stores application and infrastructure logs (Loki)
+- **`qovery-prometheus-{id}`** — Stores metrics (Thanos long-term storage)
+
+### Bucket Operations — `storage.buckets.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `update`, `get`, `list` | Full lifecycle management of Qovery GCS buckets |
+| `getIamPolicy`, `setIamPolicy` | Grants Loki and Thanos service accounts access to their respective buckets |
+| `enableObjectRetention`, `restore` | Configures retention policies for compliance |
+| `getObjectInsights` | Storage analytics for cost optimization |
+| `createTagBinding`, `deleteTagBinding`, `listEffectiveTags`, `listTagBindings` | Tags buckets for lifecycle tracking |
+
+### Object Operations — `storage.objects.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `update`, `get`, `list` | Reads and writes kubeconfigs, log chunks, and metrics blocks |
+| `getIamPolicy`, `setIamPolicy` | Fine-grained object-level access control |
+| `overrideUnlockedRetention`, `setRetention`, `restore` | Manages object retention for compliance requirements |
+
+### Other Storage — `storage.bucketOperations.*`, `storage.managedFolders.*`, `storage.multipartUploads.*`
+
+| Permission group | Why |
+|---|---|
+| `bucketOperations.cancel`, `get`, `list` | Monitors and manages long-running bucket operations |
+| `managedFolders.*` | Organizes objects within buckets with folder-level IAM |
+| `multipartUploads.*` | Large file uploads (log archives, metrics snapshots) using multipart upload |
+
+---
+
+## Cloud Run — `run.*`
+
+Qovery uses Cloud Run Jobs for **asynchronous cleanup tasks** (e.g., deleting GCS buckets with many objects in the background).
+
+### Services — `run.services.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `update`, `get`, `list` | Manages Cloud Run services if enabled for workload deployment |
+| `getIamPolicy` | Reads IAM policies on Cloud Run services |
+| `listEffectiveTags`, `listTagBindings` | Tags services for lifecycle tracking |
+
+### Jobs — `run.jobs.*`
+
+| Permission | Why |
+|---|---|
+| `create`, `delete`, `update`, `get`, `list` | Creates cleanup jobs that run `gcloud storage rm` to delete buckets asynchronously |
+| `run`, `runWithOverrides` | Executes jobs with specific parameters (bucket name, cleanup commands) |
+| `getIamPolicy` | Reads IAM policies on Cloud Run jobs |
+| `listEffectiveTags`, `listTagBindings` | Tags jobs for lifecycle tracking |
+
+### Other Cloud Run — `run.configurations.*`, `run.executions.*`, `run.revisions.*`, `run.routes.*`, `run.operations.*`, `run.locations.*`
+
+| Permission group | Why |
+|---|---|
+| `configurations.get`, `list` | Reads service configuration state |
+| `executions.cancel`, `delete`, `get`, `list` | Monitors and manages job execution lifecycle |
+| `revisions.delete`, `get`, `list` | Manages Cloud Run revision history |
+| `routes.get`, `list`, `invoke` | Routes traffic to Cloud Run services |
+| `operations.delete`, `get`, `list` | Monitors long-running Cloud Run operations |
+| `locations.list` | Discovers available Cloud Run regions |
+
+---
+
+## Security Best Practices
+
+<AccordionGroup>
+  <Accordion title="Can I restrict these permissions further?">
+    The permissions listed are the minimum required for Qovery to fully manage your GKE infrastructure. If you don't use certain features (e.g., Cloud Run workloads), contact [Qovery support](/getting-started/useful-resources/help-and-support) for a tailored minimal role.
+  </Accordion>
+
+  <Accordion title="Why does Qovery need so many Kubernetes Engine permissions?">
+    GCP's Kubernetes Engine permissions are extremely granular — each Kubernetes resource type (Pod, Service, Deployment, etc.) and action (create, get, list, update, delete) requires a separate permission. Qovery fully manages the cluster lifecycle, including deploying system components (ingress, monitoring, logging, autoscaling) via Helm charts, which requires CRUD access to nearly all Kubernetes resource types.
+  </Accordion>
+
+  <Accordion title="What service accounts does Qovery create?">
+    Qovery creates dedicated service accounts with **Workload Identity** bindings:
+    - **Cluster node SA** — logging, monitoring, image pull
+    - **Loki SA** — GCS access for log storage
+    - **ESO SA** — Secret Manager access
+    - **KEDA SA** — autoscaling metrics
+    - **Thanos SA** — GCS access for metrics storage
+
+    Each SA has the minimum permissions for its specific function.
+  </Accordion>
+
+  <Accordion title="How can I audit what Qovery does with these permissions?">
+    Enable [GCP Audit Logs](https://cloud.google.com/logging/docs/audit) on your project to get a full record of every API call made by the Qovery service account. You can also review Qovery's [audit logs](/getting-started/security-and-compliance/audit-logs) for a high-level view.
+  </Accordion>
+</AccordionGroup>

--- a/docs/getting-started/security-and-compliance/scaleway-iam-permissions.mdx
+++ b/docs/getting-started/security-and-compliance/scaleway-iam-permissions.mdx
@@ -1,0 +1,218 @@
+---
+title: "Scaleway IAM Permissions Reference"
+description: "Detailed breakdown of every Scaleway IAM permission required by Qovery and why it's needed"
+---
+
+This page explains every Scaleway IAM permission that Qovery requires to create and manage your Kapsule clusters, and what each permission is used for in our infrastructure engine.
+
+<Info>
+  Qovery uses a dedicated **IAM Application** with a scoped policy rather than your personal API keys. This isolates Qovery's access and makes it easy to revoke.
+</Info>
+
+## Setup Overview
+
+The Scaleway credential setup involves:
+
+1. **Creating an IAM Application** — A dedicated identity for Qovery (`qovery-manager`)
+2. **Generating an API Key** — Scoped to your project for authentication
+3. **Creating a Policy** — Five permission sets granting access to the required services
+4. **Attaching the Policy** — Binding permissions to the application
+
+You can review the full setup process in the [Scaleway installation guide](/getting-started/installation/scaleway).
+
+---
+
+## Required Permission Sets
+
+Qovery requires **five IAM permission sets**, each granting full access to a specific Scaleway product. Below is a detailed explanation of what Qovery does with each.
+
+---
+
+### Containers — Full Access
+
+This permission set covers **Kapsule** (managed Kubernetes) and **Container Registry**.
+
+#### Kapsule (Kubernetes)
+
+| What Qovery does | Why |
+|---|---|
+| Creates Kapsule clusters | Provisions the managed Kubernetes control plane in your chosen region (Paris, Amsterdam, or Warsaw) |
+| Configures Cilium CNI | Sets up the network plugin for pod networking and network policies |
+| Creates and manages node pools | Provisions worker node groups with auto-scaling (configurable min/max), per-zone placement (zones 1, 2, 3), and custom root volume sizes |
+| Configures cluster auto-upgrade | Enables automatic Kubernetes minor version upgrades on a controlled schedule |
+| Lists clusters and pools | Reads cluster and node pool state to monitor health, detect drift, and plan upgrades |
+| Deletes clusters | Tears down the full cluster infrastructure when requested |
+
+<Info>
+  Qovery manages node pools with auto-scaling enabled. Each pool is configured with minimum and maximum node counts, and Kubernetes automatically scales within these bounds based on pod scheduling pressure.
+</Info>
+
+#### Container Registry
+
+| What Qovery does | Why |
+|---|---|
+| Creates registry namespaces | Creates private Docker repositories (max 50 characters, prefixed for Qovery) to store container images built from your source code |
+| Lists namespaces | Discovers existing registries to avoid duplicates |
+| Lists images and tags | Enumerates stored images for version management, cleanup, and deployment |
+| Deletes tags | Removes old image tags during retention policy enforcement to save storage |
+| Deletes namespaces | Cleans up registries when a cluster or environment is deleted |
+| Authenticates for image pull | Generates Docker `config.json` credentials so Kapsule nodes can pull images from the registry |
+
+---
+
+### Network Services — Full Access
+
+This permission set covers **VPC**, **Private Networks**, **Public Gateways**, and **Load Balancers**.
+
+#### VPC & Private Networks
+
+| What Qovery does | Why |
+|---|---|
+| Creates Private Networks | Provisions an isolated network for the Kapsule cluster, separating it from other workloads in your account |
+| Tags Private Networks | Adds metadata tags (cluster ID, organization) for lifecycle tracking |
+| Checks Private Network existence | Queries the VPC API (`/vpc/v2/regions/{region}/private-networks`) to verify network state before provisioning |
+| Updates Private Networks | Modifies network configuration when cluster settings change |
+| Deletes Private Networks | Cleans up networking resources when a cluster is deleted |
+
+#### Public Gateways (NAT)
+
+| What Qovery does | Why |
+|---|---|
+| Allocates static Public Gateway IPs | Reserves a dedicated public IP for deterministic outbound traffic (useful for IP whitelisting) |
+| Creates Public Gateways | Provisions a NAT gateway so cluster nodes on the private network can reach the internet. Supports multiple gateway sizes (VPC-GW-S, VPC-GW-M, VPC-GW-L) |
+| Associates Gateways to Networks | Binds the gateway to the cluster's private network with MASQUERADE/IPAM configuration for outbound connectivity |
+| Deletes Gateways and IPs | Cleans up gateway resources when a cluster is deleted |
+
+#### Load Balancers
+
+| What Qovery does | Why |
+|---|---|
+| Creates Load Balancers | Kubernetes creates Scaleway Load Balancers via the cloud controller manager when Services of type `LoadBalancer` are deployed (Nginx Ingress) |
+| Configures LB annotations | Sets Scaleway-specific annotations for proxy protocol, health checks, and backend configuration |
+| Deletes Load Balancers | Cleans up LBs when services are removed or the cluster is deleted |
+
+---
+
+### Compute — Full Access
+
+This permission set covers **Instances** (virtual machines) used as Kapsule worker nodes.
+
+| What Qovery does | Why |
+|---|---|
+| Provisions compute instances via node pools | Kapsule creates and manages instances as worker nodes. Qovery supports a wide range of instance types across general purpose, compute-optimized, and memory-optimized families |
+| Scales instances up and down | Auto-scaling adjusts the number of instances based on pod resource requirements |
+| Manages instance lifecycle | Handles node draining, replacement, and termination during upgrades and scale-down |
+
+<Info>
+  Qovery supports Scaleway regions **Paris** (`fr-par`), **Amsterdam** (`nl-ams`), and **Warsaw** (`pl-waw`), each with multiple availability zones.
+</Info>
+
+---
+
+### Storage — Full Access
+
+This permission set covers **Object Storage** (S3-compatible) and **Block Storage**.
+
+#### Object Storage
+
+Qovery creates three buckets per cluster, using Scaleway's S3-compatible API (`s3.{zone}.scw.cloud`):
+- **`qovery-kubeconfigs-{id}`** — Stores kubeconfig files for cluster access
+- **`qovery-logs-{id}`** — Stores application and infrastructure logs (Loki)
+- **`qovery-prometheus-{id}`** — Stores metrics (Thanos long-term storage)
+
+| What Qovery does | Why |
+|---|---|
+| Creates buckets | Provisions storage for kubeconfigs, logs, and metrics |
+| Enables bucket versioning | Protects kubeconfig files from accidental overwrites |
+| Configures bucket logging | Enables access logging for audit and debugging |
+| Tags buckets with metadata | Stores creation date, TTL, and cluster association for lifecycle management |
+| Reads bucket lifecycle and tags | Checks TTL and retention settings during updates |
+| Uploads and downloads objects | Writes kubeconfigs, log chunks (Loki), and metrics blocks (Thanos); reads them back for cluster access and monitoring |
+| Deletes objects and buckets | Cleans up storage when a cluster is deleted. Handles Scaleway's 24-hour bucket deletion delay by reusing existing buckets when possible |
+
+<Info>
+  Scaleway Object Storage has a **24-hour deletion delay** on buckets. Qovery handles this gracefully by reusing existing buckets with matching names rather than failing on re-creation.
+</Info>
+
+#### Block Storage
+
+| What Qovery does | Why |
+|---|---|
+| Provisions SSD block volumes via CSI | Kapsule uses the `csi.scaleway.com` driver to dynamically provision `b_ssd` (SSD) persistent volumes for stateful workloads |
+| Expands volumes | Supports online volume expansion for growing storage needs |
+| Deletes volumes on PVC deletion | Uses the `Delete` reclaim policy to clean up unused volumes |
+
+---
+
+### VPC — Full Access
+
+This permission set provides additional VPC-level controls beyond what Network Services covers.
+
+| What Qovery does | Why |
+|---|---|
+| Manages VPC-level resources | Controls the overall VPC configuration that contains private networks, gateways, and routing |
+| Configures VPC peering (if applicable) | Enables connectivity between your Qovery VPC and other VPCs in your account |
+
+<Info>
+  The **VPC** and **Network Services** permission sets are both required because Scaleway splits networking permissions across two product scopes. VPC covers the top-level virtual private cloud, while Network Services covers the resources within it (private networks, gateways, load balancers).
+</Info>
+
+---
+
+## Managed Databases (Optional)
+
+If you use Scaleway managed databases through Qovery, the **Containers** permission set also covers **RDB** (Relational Database) operations:
+
+### PostgreSQL & MySQL
+
+| What Qovery does | Why |
+|---|---|
+| Creates RDB instances | Provisions managed PostgreSQL or MySQL databases with configurable instance types and storage |
+| Creates databases within instances | Sets up the actual database schema after the instance is ready |
+| Configures access control (ACL) | Adds ACL rules to allow connections from the Kapsule cluster (public or private access) |
+| Enables high availability | Configures HA clustering for production databases when requested |
+| Manages backups | Enables or disables automated backups based on your configuration |
+| Deletes instances | Tears down database infrastructure when requested |
+
+---
+
+## What Qovery Creates in Your Account
+
+Here's a summary of all resources Qovery provisions per cluster:
+
+| Resource | Count | Purpose |
+|---|---|---|
+| Kapsule cluster | 1 | Managed Kubernetes control plane |
+| Node pools | 1+ | Worker nodes with auto-scaling |
+| Private Network | 1 | Network isolation for the cluster |
+| Public Gateway | 1 | NAT for outbound internet access |
+| Public IP | 1 | Static IP for the gateway |
+| Object Storage buckets | 3 | Kubeconfigs, logs, metrics |
+| Container Registry namespace | 1+ | Docker image storage |
+| Load Balancer | 1+ | Ingress traffic routing |
+| Block volumes | varies | Persistent storage for stateful workloads |
+
+---
+
+## Security Best Practices
+
+<AccordionGroup>
+  <Accordion title="Why use an IAM Application instead of personal API keys?">
+    IAM Applications provide **isolated identities** for automated systems. Using a dedicated application means:
+    - Qovery's access is separate from your personal credentials
+    - You can revoke access by deleting the application or its API key without affecting your own access
+    - API key usage is tracked separately in Scaleway's audit logs
+  </Accordion>
+
+  <Accordion title="Can I restrict these permissions further?">
+    Scaleway IAM uses product-level permission sets (e.g., "Containers — Full access") rather than individual API-level permissions. This means you cannot restrict to read-only within a product. However, you can remove entire products if you don't use certain features. For example, if you don't use managed databases, the Containers permission still covers Kapsule and Registry but you can skip database-related configuration. Contact [Qovery support](/getting-started/useful-resources/help-and-support) for guidance.
+  </Accordion>
+
+  <Accordion title="Is the API key scoped to a single project?">
+    Yes. When generating the API key, you select an **Object Storage preferred Project**. The API key and its associated policy operate within the scope of your Scaleway project and organization, not across all projects.
+  </Accordion>
+
+  <Accordion title="How can I audit what Qovery does with these permissions?">
+    Scaleway provides audit logging through the **Cockpit** observability platform. You can track API calls made by the Qovery application's API key. You can also review Qovery's [audit logs](/getting-started/security-and-compliance/audit-logs) for a high-level view of operations.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
Add a detailed documentation page explaining every AWS IAM permission required by Qovery, justified by what the engine actually does with each permission. Placed under Security & Compliance and linked from the AWS installation guide.