### PR TITLE
docs: add disk_iops and disk_throughput to KarpenterGpuNodePoolOverride API reference

### DIFF
--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -22627,8 +22627,16 @@ components:
           type: integer
         disk_iops:
           type: integer
+          minimum: 3000
+          maximum: 16000
+          example: 7800
+          description: Unit is operation/seconds. The disk IOPS to be used for the Karpenter node pool configuration
         disk_throughput:
           type: integer
+          minimum: 125
+          maximum: 1000
+          example: 255
+          description: Unit is in MB/s. The disk throughput to be used for the Karpenter node pool configuration
           x-stoplight:
             id: nwpjqw3bf7px0
         default_service_architecture:
@@ -23229,6 +23237,18 @@ components:
           minimum: 0
           default: 100
           example: 150
+        disk_iops:
+          type: integer
+          minimum: 3000
+          maximum: 16000
+          example: 7800
+          description: Unit is operation/seconds. The disk IOPS to be used for the GPU node pool configuration
+        disk_throughput:
+          type: integer
+          minimum: 125
+          maximum: 1000
+          example: 255
+          description: Unit is in MB/s. The disk throughput to be used for the GPU node pool configuration
         spot_enabled:
           type: boolean
           x-stoplight:


### PR DESCRIPTION
Updated the OpenAPI spec copy in docs to include disk_iops and disk_throughput fields in the GPU node pool override schema. Also added min/max constraints to existing fields in ClusterFeatureKarpenterParameters.