### PR TITLE
docs: add egress filtering guide with Squid proxy

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -170,6 +170,7 @@
                           "getting-started/guides/advanced-tutorials/cloudflare-custom-domain",
                           "getting-started/guides/advanced-tutorials/rate-limiting",
                           "getting-started/guides/advanced-tutorials/ip-header-authorization",
+                          "getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy",
                           "getting-started/guides/advanced-tutorials/customizing-preview-url-with-qovery-cli"
                         ]
                       },

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -13,7 +13,7 @@ Qovery's built-in controls focus on ingress. Per-application egress domain filte
 
 The approach has three parts:
 
-1. **Squid forward proxy** — runs inside the cluster and enforces a domain allowlist
+1. **Squid forward proxy** — runs inside the cluster as a container service and enforces a domain allowlist
 2. **App environment variables** — tell your application to route all outbound traffic through the proxy
 3. **Kubernetes NetworkPolicy** *(optional)* — prevents the application from bypassing the proxy by talking directly to the internet
 
@@ -30,16 +30,33 @@ IP-based filtering (Security Groups / NACLs) is **not reliable** for domain-base
 ## Prerequisites
 
 - A Qovery environment with at least one application running
-- Basic familiarity with Kubernetes and Helm
 - A list of domains your application needs to reach
 
-## Step 1: Deploy a Squid proxy in your environment
+## Step 1: Deploy Squid as a container service
 
-Deploy Squid as a dedicated service inside the same Qovery environment as your application. You can use a Helm chart or a custom container.
+Create a new **Container** service in your Qovery environment using the `ubuntu/squid` image.
 
-### Squid configuration
+### Configure the service
 
-Create a `squid.conf` with your domain allowlist:
+| Setting | Value |
+|---|---|
+| Image | `ubuntu/squid` |
+| Port | `3128` (do not expose publicly) |
+
+### Pass the Squid configuration as a file variable
+
+Rather than baking a config into a custom image, pass your `squid.conf` as a **file variable** mounted directly into the container.
+
+In Qovery, create a new variable with:
+
+| Field | Value |
+|---|---|
+| Name | `SQUID_CONF` (or any name) |
+| Type | File |
+| Mount path | `/etc/squid/squid.conf` |
+| Value | *(the squid.conf content below)* |
+
+File content:
 
 ```nginx
 http_port 3128
@@ -57,45 +74,25 @@ access_log stdio:/dev/stdout
 cache_log stdio:/dev/stderr
 ```
 
+Replace `.example.com` and `.another-service.com` with the domains your application actually needs to reach.
+
 <Tip>
 Start with a permissive allowlist and use the proxy logs to discover all the domains your application actually contacts before tightening it. External services often use multiple hostnames for APIs, CDNs, redirects, and object storage.
 </Tip>
 
-### Deploy via Helm
+### Configure health probes
 
-Use any Squid Helm chart and mount the config above. Example `values.yaml`:
+Add the following exec probe so Qovery (and Kubernetes) can verify Squid is healthy:
 
-```yaml
-replicaCount: 1
+| Probe | Command |
+|---|---|
+| Liveness | `squid -k check` |
+| Readiness | `squid -k check` |
 
-service:
-  type: ClusterIP
-  port: 3128
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
-
-config: |
-  http_port 3128
-
-  acl allowed_domains dstdomain \
-    .example.com \
-    .another-service.com
-
-  http_access allow allowed_domains
-  http_access deny all
-
-  access_log stdio:/dev/stdout
-  cache_log stdio:/dev/stderr
-```
+`squid -k check` sends a signal to the running Squid process and exits with a non-zero code if the process is not responding — making it a reliable health signal.
 
 <Warning>
-Use `ClusterIP` — this proxy is for internal use only and should never be exposed publicly.
+Do not expose this service publicly. It is an internal proxy and should only be reachable from within the cluster.
 </Warning>
 
 ## Step 2: Configure the application to use the proxy
@@ -104,11 +101,11 @@ Add the following environment variables to your application in Qovery:
 
 | Variable | Value | Purpose |
 |---|---|---|
-| `HTTPS_PROXY` | `http://squid-proxy:3128` | Route HTTPS traffic through proxy |
-| `HTTP_PROXY` | `http://squid-proxy:3128` | Route HTTP traffic through proxy |
+| `HTTPS_PROXY` | `http://<squid-service-name>:3128` | Route HTTPS traffic through proxy |
+| `HTTP_PROXY` | `http://<squid-service-name>:3128` | Route HTTP traffic through proxy |
 | `NO_PROXY` | `127.0.0.1,localhost,.svc,.cluster.local` | Bypass proxy for internal traffic |
 
-Replace `squid-proxy` with the actual Kubernetes service name of your Squid deployment.
+Replace `<squid-service-name>` with the internal DNS name of the Squid service (the Qovery service name in lowercase, e.g. `squid-proxy`).
 
 <Info>
 Some runtimes and libraries also read lowercase variants: `http_proxy`, `https_proxy`, `no_proxy`. Set both if your language runtime requires it.
@@ -179,7 +176,7 @@ Once an egress NetworkPolicy is applied, **only traffic explicitly listed is all
     Check that:
     - `HTTPS_PROXY` and `HTTP_PROXY` are set and point to the correct hostname and port
     - `NO_PROXY` includes `.svc` and `.cluster.local`
-    - The Squid pod is running and healthy
+    - The Squid pod is running and healthy (`squid -k check` probe passes)
     - The Squid service name matches the hostname in the env vars
     - If NetworkPolicy is applied, DNS (port 53) is explicitly allowed
   </Accordion>
@@ -198,17 +195,21 @@ Once an egress NetworkPolicy is applied, **only traffic explicitly listed is all
   <Accordion title="Some requests succeed but others fail intermittently">
     This often happens when an external service uses multiple backend hostnames or load balances across CDN nodes. Check proxy logs for blocked requests and add the missing hostnames to the allowlist.
   </Accordion>
+
+  <Accordion title="Squid health probe is failing">
+    Make sure the container has fully started before the probe runs — `ubuntu/squid` may take a few seconds to initialize. Add a `initialDelaySeconds` to the probe if needed. You can also exec into the container and run `squid -k check` manually to check the process state.
+  </Accordion>
 </AccordionGroup>
 
 ## Related documentation
 
 <CardGroup cols={2}>
   <Card title="Environment Variables" icon="key" href="/configuration/environment-variable">
-    Configure environment variables and secrets on your services
+    Configure environment variables and file variables on your services
   </Card>
 
-  <Card title="Deploy a Helm Chart" icon="helm" href="/configuration/helm-chart">
-    Deploy Squid or other tools as a Helm service in Qovery
+  <Card title="Container Service" icon="docker" href="/configuration/application">
+    Deploy a container image as a Qovery service
   </Card>
 
   <Card title="Security Overview" icon="shield" href="/getting-started/security-and-compliance/overview">

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -3,7 +3,7 @@ title: "Filter Outbound Traffic with an Egress Proxy"
 description: "Restrict outbound HTTP(S) traffic for a single application using a Squid forward proxy and Kubernetes NetworkPolicy"
 ---
 
-This guide shows how to restrict outbound HTTP(S) traffic for a single application running on a Qovery-managed cluster. The pattern is particularly useful for **agentic or automation workloads** where you want to reduce data exfiltration risk by only allowing calls to a predefined set of domains.
+This guide shows how to restrict outbound HTTP(S) traffic for a single application running on a Qovery-managed cluster. The goal is to enforce a domain allowlist so the application can only reach a predefined set of external services.
 
 <Info>
 Qovery's built-in controls focus on ingress. Per-application egress domain filtering is handled at the Kubernetes level using a dedicated forward proxy.
@@ -24,7 +24,7 @@ The approach has three parts:
 ```
 
 <Warning>
-IP-based filtering (Security Groups / NACLs) is **not reliable** for this use case. Services like GitHub, npm, Anthropic, and Linear sit behind CDNs and use multiple IPs that change over time. Domain-based filtering via a forward proxy is the right approach.
+IP-based filtering (Security Groups / NACLs) is **not reliable** for domain-based allowlisting. Many external services sit behind CDNs and use multiple IPs that change over time. A forward proxy that filters on the destination hostname is the right approach.
 </Warning>
 
 ## Prerequisites
@@ -32,10 +32,6 @@ IP-based filtering (Security Groups / NACLs) is **not reliable** for this use ca
 - A Qovery environment with at least one application running
 - Basic familiarity with Kubernetes and Helm
 - A list of domains your application needs to reach
-
-<Info>
-**About EKS Application Network Policies and Envoy:** EKS FQDN-based policies are tied to EKS Auto Mode and are not available on standard Qovery-managed clusters. The Envoy Gateway being introduced in Qovery covers ingress only — it is a different component from an egress gateway. The proxy pattern described here is the recommended approach today.
-</Info>
 
 ## Step 1: Deploy a Squid proxy in your environment
 
@@ -50,12 +46,8 @@ http_port 3128
 
 # Define your approved destinations
 acl allowed_domains dstdomain \
-  .anthropic.com \
-  .github.com \
-  .githubusercontent.com \
-  .npmjs.org \
-  .npmjs.com \
-  .linear.app
+  .example.com \
+  .another-service.com
 
 http_access allow allowed_domains
 http_access deny all
@@ -66,7 +58,7 @@ cache_log stdio:/dev/stderr
 ```
 
 <Tip>
-Start with a permissive allowlist and use the proxy logs to discover all the domains your application actually contacts before tightening it. SaaS services often use multiple hostnames for APIs, CDNs, redirects, and object storage.
+Start with a permissive allowlist and use the proxy logs to discover all the domains your application actually contacts before tightening it. External services often use multiple hostnames for APIs, CDNs, redirects, and object storage.
 </Tip>
 
 ### Deploy via Helm
@@ -92,12 +84,8 @@ config: |
   http_port 3128
 
   acl allowed_domains dstdomain \
-    .anthropic.com \
-    .github.com \
-    .githubusercontent.com \
-    .npmjs.org \
-    .npmjs.com \
-    .linear.app
+    .example.com \
+    .another-service.com
 
   http_access allow allowed_domains
   http_access deny all
@@ -136,30 +124,27 @@ Once both services are deployed, exec into your application container and test:
 
 ```bash
 # Should succeed — domain is in the allowlist
-curl -I https://api.anthropic.com
-
-# Should succeed
-curl -I https://api.github.com
+curl -I https://allowed-service.example.com
 
 # Should fail — domain is not in the allowlist
-curl -I https://example.org
+curl -I https://not-allowed.example.com
 ```
 
 Check the Squid container logs in Qovery to see all outbound requests and their status.
 
 ## Step 4 (optional): Enforce with a NetworkPolicy
 
-A NetworkPolicy prevents your application from bypassing the proxy and talking directly to the internet. This step requires that your cluster networking plugin supports egress enforcement (e.g. AWS VPC CNI with network policy support enabled, or Calico/Cilium).
+A NetworkPolicy prevents your application from bypassing the proxy and talking directly to the internet. This step requires that your cluster networking plugin supports egress enforcement (e.g. AWS VPC CNI with network policy support enabled).
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: my-agent-egress-via-proxy
+  name: my-app-egress-via-proxy
 spec:
   podSelector:
     matchLabels:
-      app: my-agent        # label on your application pods
+      app: my-app           # label on your application pods
   policyTypes:
     - Egress
   egress:
@@ -187,47 +172,6 @@ spec:
 Once an egress NetworkPolicy is applied, **only traffic explicitly listed is allowed** — everything else is dropped by default. Make sure DNS is allowed or name resolution will fail entirely.
 </Warning>
 
-<Info>
-This NetworkPolicy is optional but strongly recommended for workloads where data exfiltration risk is a concern, such as autonomous AI agents.
-</Info>
-
-## Domain allowlist reference
-
-For common SaaS services used in AI agent workloads, here is a starter allowlist. Adjust based on what your proxy logs show during testing.
-
-<AccordionGroup>
-  <Accordion title="Anthropic">
-    ```
-    .anthropic.com
-    ```
-  </Accordion>
-
-  <Accordion title="GitHub">
-    ```
-    .github.com
-    .githubusercontent.com
-    .githubassets.com
-    ```
-  </Accordion>
-
-  <Accordion title="npm">
-    ```
-    .npmjs.org
-    .npmjs.com
-    ```
-  </Accordion>
-
-  <Accordion title="Linear">
-    ```
-    .linear.app
-    ```
-  </Accordion>
-</AccordionGroup>
-
-<Warning>
-Treat this list as a starting point only. SaaS services frequently use additional hostnames for CDNs, object storage, authentication, and redirects. Always validate with proxy logs before locking down the allowlist.
-</Warning>
-
 ## Troubleshooting
 
 <AccordionGroup>
@@ -252,7 +196,7 @@ Treat this list as a starting point only. SaaS services frequently use additiona
   </Accordion>
 
   <Accordion title="Some requests succeed but others fail intermittently">
-    This often happens when a SaaS service uses multiple backend hostnames or load balances across CDN nodes. Check proxy logs for blocked requests and add the missing hostnames to the allowlist.
+    This often happens when an external service uses multiple backend hostnames or load balances across CDN nodes. Check proxy logs for blocked requests and add the missing hostnames to the allowlist.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -1,0 +1,277 @@
+---
+title: "Filter Outbound Traffic with an Egress Proxy"
+description: "Restrict outbound HTTP(S) traffic for a single application using a Squid forward proxy and Kubernetes NetworkPolicy"
+---
+
+This guide shows how to restrict outbound HTTP(S) traffic for a single application running on a Qovery-managed cluster. The pattern is particularly useful for **agentic or automation workloads** where you want to reduce data exfiltration risk by only allowing calls to a predefined set of domains.
+
+<Info>
+Qovery's built-in controls focus on ingress. Per-application egress domain filtering is handled at the Kubernetes level using a dedicated forward proxy.
+</Info>
+
+## How it works
+
+The approach has three parts:
+
+1. **Squid forward proxy** — runs inside the cluster and enforces a domain allowlist
+2. **App environment variables** — tell your application to route all outbound traffic through the proxy
+3. **Kubernetes NetworkPolicy** *(optional)* — prevents the application from bypassing the proxy by talking directly to the internet
+
+```
+[ Your App ] → [ Squid Proxy ] → [ Allowed domains only ]
+                    ↑
+             allowlist enforced here
+```
+
+<Warning>
+IP-based filtering (Security Groups / NACLs) is **not reliable** for this use case. Services like GitHub, npm, Anthropic, and Linear sit behind CDNs and use multiple IPs that change over time. Domain-based filtering via a forward proxy is the right approach.
+</Warning>
+
+## Prerequisites
+
+- A Qovery environment with at least one application running
+- Basic familiarity with Kubernetes and Helm
+- A list of domains your application needs to reach
+
+<Info>
+**About EKS Application Network Policies and Envoy:** EKS FQDN-based policies are tied to EKS Auto Mode and are not available on standard Qovery-managed clusters. The Envoy Gateway being introduced in Qovery covers ingress only — it is a different component from an egress gateway. The proxy pattern described here is the recommended approach today.
+</Info>
+
+## Step 1: Deploy a Squid proxy in your environment
+
+Deploy Squid as a dedicated service inside the same Qovery environment as your application. You can use a Helm chart or a custom container.
+
+### Squid configuration
+
+Create a `squid.conf` with your domain allowlist:
+
+```nginx
+http_port 3128
+
+# Define your approved destinations
+acl allowed_domains dstdomain \
+  .anthropic.com \
+  .github.com \
+  .githubusercontent.com \
+  .npmjs.org \
+  .npmjs.com \
+  .linear.app
+
+http_access allow allowed_domains
+http_access deny all
+
+# Send logs to stdout/stderr for visibility in Qovery logs
+access_log stdio:/dev/stdout
+cache_log stdio:/dev/stderr
+```
+
+<Tip>
+Start with a permissive allowlist and use the proxy logs to discover all the domains your application actually contacts before tightening it. SaaS services often use multiple hostnames for APIs, CDNs, redirects, and object storage.
+</Tip>
+
+### Deploy via Helm
+
+Use any Squid Helm chart and mount the config above. Example `values.yaml`:
+
+```yaml
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 3128
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+config: |
+  http_port 3128
+
+  acl allowed_domains dstdomain \
+    .anthropic.com \
+    .github.com \
+    .githubusercontent.com \
+    .npmjs.org \
+    .npmjs.com \
+    .linear.app
+
+  http_access allow allowed_domains
+  http_access deny all
+
+  access_log stdio:/dev/stdout
+  cache_log stdio:/dev/stderr
+```
+
+<Warning>
+Use `ClusterIP` — this proxy is for internal use only and should never be exposed publicly.
+</Warning>
+
+## Step 2: Configure the application to use the proxy
+
+Add the following environment variables to your application in Qovery:
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `HTTPS_PROXY` | `http://squid-proxy:3128` | Route HTTPS traffic through proxy |
+| `HTTP_PROXY` | `http://squid-proxy:3128` | Route HTTP traffic through proxy |
+| `NO_PROXY` | `127.0.0.1,localhost,.svc,.cluster.local` | Bypass proxy for internal traffic |
+
+Replace `squid-proxy` with the actual Kubernetes service name of your Squid deployment.
+
+<Info>
+Some runtimes and libraries also read lowercase variants: `http_proxy`, `https_proxy`, `no_proxy`. Set both if your language runtime requires it.
+</Info>
+
+<Warning>
+Always include `.svc` and `.cluster.local` in `NO_PROXY`. Without this, internal Kubernetes service calls will be routed through the proxy and may fail.
+</Warning>
+
+## Step 3: Validate the setup
+
+Once both services are deployed, exec into your application container and test:
+
+```bash
+# Should succeed — domain is in the allowlist
+curl -I https://api.anthropic.com
+
+# Should succeed
+curl -I https://api.github.com
+
+# Should fail — domain is not in the allowlist
+curl -I https://example.org
+```
+
+Check the Squid container logs in Qovery to see all outbound requests and their status.
+
+## Step 4 (optional): Enforce with a NetworkPolicy
+
+A NetworkPolicy prevents your application from bypassing the proxy and talking directly to the internet. This step requires that your cluster networking plugin supports egress enforcement (e.g. AWS VPC CNI with network policy support enabled, or Calico/Cilium).
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: my-agent-egress-via-proxy
+spec:
+  podSelector:
+    matchLabels:
+      app: my-agent        # label on your application pods
+  policyTypes:
+    - Egress
+  egress:
+    # Allow traffic to the Squid proxy
+    - to:
+        - podSelector:
+            matchLabels:
+              app: squid-proxy   # label on your Squid pods
+      ports:
+        - protocol: TCP
+          port: 3128
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+```
+
+<Warning>
+Once an egress NetworkPolicy is applied, **only traffic explicitly listed is allowed** — everything else is dropped by default. Make sure DNS is allowed or name resolution will fail entirely.
+</Warning>
+
+<Info>
+This NetworkPolicy is optional but strongly recommended for workloads where data exfiltration risk is a concern, such as autonomous AI agents.
+</Info>
+
+## Domain allowlist reference
+
+For common SaaS services used in AI agent workloads, here is a starter allowlist. Adjust based on what your proxy logs show during testing.
+
+<AccordionGroup>
+  <Accordion title="Anthropic">
+    ```
+    .anthropic.com
+    ```
+  </Accordion>
+
+  <Accordion title="GitHub">
+    ```
+    .github.com
+    .githubusercontent.com
+    .githubassets.com
+    ```
+  </Accordion>
+
+  <Accordion title="npm">
+    ```
+    .npmjs.org
+    .npmjs.com
+    ```
+  </Accordion>
+
+  <Accordion title="Linear">
+    ```
+    .linear.app
+    ```
+  </Accordion>
+</AccordionGroup>
+
+<Warning>
+Treat this list as a starting point only. SaaS services frequently use additional hostnames for CDNs, object storage, authentication, and redirects. Always validate with proxy logs before locking down the allowlist.
+</Warning>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Application cannot reach anything">
+    Check that:
+    - `HTTPS_PROXY` and `HTTP_PROXY` are set and point to the correct hostname and port
+    - `NO_PROXY` includes `.svc` and `.cluster.local`
+    - The Squid pod is running and healthy
+    - The Squid service name matches the hostname in the env vars
+    - If NetworkPolicy is applied, DNS (port 53) is explicitly allowed
+  </Accordion>
+
+  <Accordion title="An allowed domain is still blocked">
+    Check:
+    - Whether the service uses a different hostname than expected (e.g. a CDN endpoint)
+    - Whether there are HTTP redirects to a non-allowlisted domain
+    - The proxy access log — it shows the exact destination the client is requesting
+  </Accordion>
+
+  <Accordion title="Internal service calls are failing">
+    Check that `.svc` and `.cluster.local` are in `NO_PROXY`. Without this, Kubernetes internal service discovery goes through the proxy and typically fails.
+  </Accordion>
+
+  <Accordion title="Some requests succeed but others fail intermittently">
+    This often happens when a SaaS service uses multiple backend hostnames or load balances across CDN nodes. Check proxy logs for blocked requests and add the missing hostnames to the allowlist.
+  </Accordion>
+</AccordionGroup>
+
+## Related documentation
+
+<CardGroup cols={2}>
+  <Card title="Environment Variables" icon="key" href="/configuration/environment-variable">
+    Configure environment variables and secrets on your services
+  </Card>
+
+  <Card title="Deploy a Helm Chart" icon="helm" href="/configuration/helm-chart">
+    Deploy Squid or other tools as a Helm service in Qovery
+  </Card>
+
+  <Card title="Security Overview" icon="shield" href="/getting-started/security-and-compliance/overview">
+    Security and compliance capabilities in Qovery
+  </Card>
+
+  <Card title="Advanced Settings" icon="sliders" href="/configuration/service-advanced-settings">
+    Fine-tune service behavior with advanced settings
+  </Card>
+</CardGroup>

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -134,7 +134,7 @@ Check the Squid container logs in Qovery to see all outbound requests and their 
 
 ## Step 4 (optional): Enforce with a NetworkPolicy
 
-A NetworkPolicy prevents your application from bypassing the proxy and talking directly to the internet. This step requires that your cluster networking plugin supports egress enforcement (e.g. AWS VPC CNI with network policy support enabled).
+A NetworkPolicy prevents your application from bypassing the proxy and talking directly to the internet. Qovery-managed clusters run AWS VPC CNI with network policy support enabled, so this works out of the box.
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -68,10 +68,6 @@ acl allowed_domains dstdomain \
 
 http_access allow allowed_domains
 http_access deny all
-
-# Send logs to stdout/stderr for visibility in Qovery logs
-access_log stdio:/dev/stdout
-cache_log stdio:/dev/stderr
 ```
 
 Replace `.example.com` and `.another-service.com` with the domains your application actually needs to reach.

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -101,11 +101,18 @@ Add the following environment variables to your application in Qovery:
 
 | Variable | Value | Purpose |
 |---|---|---|
-| `HTTPS_PROXY` | `http://<squid-service-name>:3128` | Route HTTPS traffic through proxy |
-| `HTTP_PROXY` | `http://<squid-service-name>:3128` | Route HTTP traffic through proxy |
+| `HTTPS_PROXY` | `http://$QOVERY_CONTAINER_<ID>_HOST_INTERNAL:3128` | Route HTTPS traffic through proxy |
+| `HTTP_PROXY` | `http://$QOVERY_CONTAINER_<ID>_HOST_INTERNAL:3128` | Route HTTP traffic through proxy |
 | `NO_PROXY` | `127.0.0.1,localhost,.svc,.cluster.local` | Bypass proxy for internal traffic |
 
-Replace `<squid-service-name>` with the internal DNS name of the Squid service (the Qovery service name in lowercase, e.g. `squid-proxy`).
+Qovery automatically exposes a built-in variable for each service's internal hostname. For your Squid container service it will look like `QOVERY_CONTAINER_<ID>_HOST_INTERNAL`. You can find the exact variable name in the **Environment Variables** tab of your Squid service, under the built-in variables section.
+
+Use it by reference so the value stays correct across redeployments:
+
+```
+HTTP_PROXY=http://{{ QOVERY_CONTAINER_<ID>_HOST_INTERNAL }}:3128
+HTTPS_PROXY=http://{{ QOVERY_CONTAINER_<ID>_HOST_INTERNAL }}:3128
+```
 
 <Info>
 Some runtimes and libraries also read lowercase variants: `http_proxy`, `https_proxy`, `no_proxy`. Set both if your language runtime requires it.

--- a/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/egress-filtering-squid-proxy.mdx
@@ -5,6 +5,8 @@ description: "Restrict outbound HTTP(S) traffic for a single application using a
 
 This guide shows how to restrict outbound HTTP(S) traffic for a single application running on a Qovery-managed cluster. The goal is to enforce a domain allowlist so the application can only reach a predefined set of external services.
 
+For example: an AI agent that should only be allowed to call the Anthropic API and GitHub, a backend service restricted to your payment provider's endpoints, or a data pipeline that must only reach specific S3 buckets and your database host.
+
 <Info>
 Qovery's built-in controls focus on ingress. Per-application egress domain filtering is handled at the Kubernetes level using a dedicated forward proxy.
 </Info>


### PR DESCRIPTION
## Summary

- Adds a new advanced tutorial for filtering outbound HTTP(S) traffic per application using a Squid forward proxy
- Covers proxy setup, app env var configuration, optional NetworkPolicy enforcement, and domain allowlist reference
- Added to the "Networking & Access Control" section in the nav

## Context

Based on a real customer request (ticket #3521) from a team running autonomous AI agents and needing to restrict egress to Anthropic, GitHub, npm, Linear, etc.

## Test plan

- [ ] Preview renders correctly on Mintlify
- [ ] Nav entry appears under Networking & Access Control
- [ ] All code blocks and accordions render as expected