### PR TITLE
docs: enhance cluster and service advanced settings

### DIFF
--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -325,8 +325,12 @@ Changing this setting will only affect new ECR repositories created after the ch
 **Description:** Allows you to specify the [image mirroring mode](/configuration/deployment/image-mirroring) to be used for each image deployed on this cluster.
 
 **Valid values:**
-- `Service` — each service gets its own ECR repository. Provides better isolation and per-service retention policies, but creates more repositories.
-- `Cluster` — all services share a single ECR repository. Reduces the number of repositories but images from different services are mixed together.
+- `Service` — each service gets its own mirror repository (`qovery-mirror-{service_id}`). Provides better isolation but creates more repositories. Works on **all** cluster types.
+- `Cluster` — all services in the cluster share a single mirror repository (`qovery-mirror-cluster-{cluster_id}`). Fewer repositories, but requires registry lifecycle policy support for automated image cleanup.
+
+<Warning>
+`Cluster` mode is only available on cluster types that support registry lifecycle policies: **EKS**, **GKE**, **AKS** (and their self-managed variants). It is not supported on DOKS, Scaleway Kapsule, or full self-managed clusters.
+</Warning>
 
 **Default Value:** `Service`
 

--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -207,7 +207,7 @@ Enabling this setting creates 3 additional Elastic IPs in your AWS account. Each
 
 **Type:** `integer`
 
-**Description:** Maximum retention period (in weeks) for application logs collected by Loki. This applies to all pod logs (applications, containers, jobs, and cronjobs) stored in the Loki instance running on your cluster.
+**Description:** Maximum retention period (in weeks) for application logs collected by Loki and displayed in the Qovery console log viewer. Retention is enforced both at the Loki compactor level and via object storage lifecycle policies.
 
 **Use Case:** Increase for compliance requirements or debugging long-running issues. Decrease to save storage costs on the underlying object storage bucket.
 

--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -105,7 +105,7 @@ resource "qovery_cluster" "my_cluster" {
 
 ## Cluster sizing
 
-<a id="aws-cloudwatch-eks-logs-retention-days"></a>
+<a id="cluster-profile"></a>
 
 ### cluster.profile
 
@@ -165,7 +165,9 @@ resource "qovery_cluster" "my_cluster" {
 
 **Type:** `boolean`
 
-**Description:** Enable flow logs on the cluster VPC and store them in an S3 bucket.
+**Description:** Enable flow logs on the cluster VPC and store them in an S3 bucket. VPC flow logs capture information about IP traffic going to and from network interfaces in your VPC.
+
+**Use Case:** Required for compliance frameworks (SOC 2, PCI-DSS, HIPAA) that mandate network traffic logging. Also useful for security investigations and troubleshooting connectivity issues.
 
 **Default Value:** `false`
 
@@ -205,7 +207,9 @@ Enabling this setting creates 3 additional Elastic IPs in your AWS account. Each
 
 **Type:** `integer`
 
-**Description:** Maximum Kubernetes pods (containers/applications/jobs/cronjobs) retention logs in weeks.
+**Description:** Maximum retention period (in weeks) for application logs collected by Loki. This applies to all pod logs (applications, containers, jobs, and cronjobs) stored in the Loki instance running on your cluster.
+
+**Use Case:** Increase for compliance requirements or debugging long-running issues. Decrease to save storage costs on the underlying object storage bucket.
 
 **Default Value:** `12` (84 days)
 
@@ -257,18 +261,38 @@ Enabling this setting creates 3 additional Elastic IPs in your AWS account. Each
 
 **Type:** `string`
 
-**Description:** Additional configuration to add to CoreDNS. This can be used to customize DNS resolution rules on the cluster.
+**Description:** Additional configuration to add to CoreDNS. This can be used to customize DNS resolution rules on the cluster. The value is appended to the default CoreDNS Corefile.
+
+**Use Case:** Forward specific domains to internal DNS servers (split-horizon DNS), resolve private hosted zones, or add custom caching rules.
 
 **Default Value:** `null`
 
-**Example:**
-```corefile
-example.com:53 {
-    errors
-    cache 30
-    forward . 8.8.8.8 8.8.4.4
-}
-```
+**Examples:**
+
+<Tabs>
+  <Tab title="Forward to internal DNS">
+    Route queries for your internal domain to a private DNS server:
+
+    ```corefile
+    corp.internal:53 {
+        errors
+        cache 30
+        forward . 10.0.0.2
+    }
+    ```
+  </Tab>
+  <Tab title="Forward to public resolver">
+    Use Google Public DNS for a specific domain:
+
+    ```corefile
+    example.com:53 {
+        errors
+        cache 30
+        forward . 8.8.8.8 8.8.4.4
+    }
+    ```
+  </Tab>
+</Tabs>
 
 ---
 
@@ -300,7 +324,9 @@ Changing this setting will only affect new ECR repositories created after the ch
 
 **Description:** Allows you to specify the [image mirroring mode](/configuration/deployment/image-mirroring) to be used for each image deployed on this cluster.
 
-**Valid values:** `Service`, `Cluster`
+**Valid values:**
+- `Service` — each service gets its own ECR repository. Provides better isolation and per-service retention policies, but creates more repositories.
+- `Cluster` — all services share a single ECR repository. Reduces the number of repositories but images from different services are mixed together.
 
 **Default Value:** `Service`
 
@@ -1109,7 +1135,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `boolean`
 
-**Description:** Deny any access to all PostgreSQL databases.
+**Description:** Deny any access to all PostgreSQL databases. When enabled, **no** CIDR (including `allowed_cidrs`) can reach the database — this is a hard deny that overrides everything.
 
 <Warning>
 - Managed databases: Access is removed instantly
@@ -1126,9 +1152,14 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `string`
 
-**Description:** List of allowed CIDR ranges for PostgreSQL database access.
+**Description:** List of allowed CIDR ranges for PostgreSQL database access. Only traffic from these CIDRs can reach the database. Ignored if `database.postgresql.deny_any_access` is `true`.
 
 **Default Value:** `["0.0.0.0/0"]`
+
+**Example:** Restrict to your VPN and office IPs:
+```json
+["10.0.0.0/8", "203.0.113.0/24"]
+```
 
 <a id="database-mysql-deny-any-access"></a>
 
@@ -1138,7 +1169,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `boolean`
 
-**Description:** Deny any access to all MySQL databases.
+**Description:** Deny any access to all MySQL databases. When enabled, this overrides `allowed_cidrs`.
 
 <Warning>
 - Managed databases: Access is removed instantly
@@ -1155,7 +1186,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `string`
 
-**Description:** List of allowed CIDR ranges for MySQL database access.
+**Description:** List of allowed CIDR ranges for MySQL database access. Ignored if `database.mysql.deny_any_access` is `true`.
 
 **Default Value:** `["0.0.0.0/0"]`
 
@@ -1167,7 +1198,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `boolean`
 
-**Description:** Deny any access to all MongoDB databases.
+**Description:** Deny any access to all MongoDB databases. When enabled, this overrides `allowed_cidrs`.
 
 <Warning>
 - Managed databases: Access is removed instantly
@@ -1184,7 +1215,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `string`
 
-**Description:** List of allowed CIDR ranges for MongoDB database access.
+**Description:** List of allowed CIDR ranges for MongoDB database access. Ignored if `database.mongodb.deny_any_access` is `true`.
 
 **Default Value:** `["0.0.0.0/0"]`
 
@@ -1196,7 +1227,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `boolean`
 
-**Description:** Deny any access to all Redis databases.
+**Description:** Deny any access to all Redis databases. When enabled, this overrides `allowed_cidrs`.
 
 <Warning>
 - Managed databases: Access is removed instantly
@@ -1213,7 +1244,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `string`
 
-**Description:** List of allowed CIDR ranges for Redis database access.
+**Description:** List of allowed CIDR ranges for Redis database access. Ignored if `database.redis.deny_any_access` is `true`.
 
 **Default Value:** `["0.0.0.0/0"]`
 
@@ -1229,13 +1260,13 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 
 **Type:** `boolean`
 
-**Description:** Authorize CPU overcommit (limit > request) for services deployed within this cluster.
+**Description:** Authorize CPU overcommit (limit > request) for services deployed within this cluster. When enabled, pods can burst above their CPU request up to the configured limit when spare capacity is available on the node.
 
 <Warning>
-Using overcommit on pod resources can lead to instability on your cluster and we strongly discourage it. Be careful when using this feature.
+CPU overcommit can cause CPU throttling and unpredictable latency when nodes are under pressure. Use with caution in production.
 </Warning>
 
-**Use Case:** Once enabled, you can update the service advanced setting `resources.override.limit.cpu_in_mib`.
+**Use Case:** Once enabled, you can update the service advanced setting `resources.override.limit.cpu_in_milli` to set a CPU limit higher than the request.
 
 **Default Value:** `false`
 
@@ -1247,13 +1278,13 @@ Using overcommit on pod resources can lead to instability on your cluster and we
 
 **Type:** `boolean`
 
-**Description:** Authorize memory overcommit (limit > request) for services deployed within this cluster.
+**Description:** Authorize memory overcommit (limit > request) for services deployed within this cluster. When enabled, pods can use more memory than their request up to the configured limit.
 
 <Warning>
-Using overcommit on pod resources can lead to instability on your cluster and we strongly discourage it. Be careful when using this feature.
+Memory overcommit is riskier than CPU overcommit. Unlike CPU (which is throttled), exceeding memory limits causes the pod to be **OOM-killed**. If multiple pods on the same node exceed their requests simultaneously, the node can become unstable.
 </Warning>
 
-**Use Case:** Once enabled, you can update the service advanced setting `resources.override.limit.ram_in_mib`.
+**Use Case:** Once enabled, you can update the service advanced setting `resources.override.limit.ram_in_mib` to set a memory limit higher than the request.
 
 **Default Value:** `false`
 
@@ -1341,13 +1372,18 @@ It won't be possible to go back once this feature is activated.
 
 **Type:** `string`
 
-**Description:** Contains additional CIDRs that should be whitelisted to access the Kubernetes API.
+**Description:** Contains additional CIDRs that should be whitelisted to access the Kubernetes API. Use this to allow your team or CI/CD pipelines to reach the K8s API when `qovery.static_ip_mode` is enabled.
 
 <Info>
 `qovery.static_ip_mode` should be set to `true` to make this setting effective.
 </Info>
 
 **Default Value:** `[]`
+
+**Example:**
+```json
+["203.0.113.0/24", "198.51.100.10/32"]
+```
 
 ---
 
@@ -1363,7 +1399,9 @@ It won't be possible to go back once this feature is activated.
 
 **Description:** Specify the [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) version you want to use.
 
-**Valid values:** `required` (IMDS v2 only), `optional` (IMDS v1 and v2)
+**Valid values:**
+- `required` — IMDSv2 only (recommended). Forces all metadata requests to use session tokens, which protects against SSRF attacks that try to steal instance credentials.
+- `optional` — IMDSv1 and v2. Use only if you have legacy workloads that don't support IMDSv2.
 
 **Default Value:** `required`
 
@@ -1429,11 +1467,30 @@ If you need to connect to the Kubernetes cluster from your network, make sure to
 
 ### storageclass.fast_ssd
 
+**Cloud Provider:** <img src="/images/logos/cloud-providers/aws-icon.svg" alt="AWS" width="20"  style={{display: "inline", verticalAlign: "middle", marginRight: "4px"}} /> <img src="/images/logos/cloud-providers/scaleway-icon.svg" alt="Scaleway" width="20"  style={{display: "inline", verticalAlign: "middle", marginRight: "4px"}} /> <img src="/images/logos/cloud-providers/gcp-icon.svg" alt="GCP" width="20"  style={{display: "inline", verticalAlign: "middle", marginRight: "4px"}} /> <img src="/images/logos/cloud-providers/azure-icon.svg" alt="Azure" width="20"  style={{display: "inline", verticalAlign: "middle", marginRight: "4px"}} />
+
 **Type:** `string`
 
-**Description:** Specify the Kubernetes storageClass to be used for storage attached to your container databases and applications.
+**Description:** Specify the Kubernetes storageClass to be used for storage attached to your container databases and applications. Override this if you need a custom storageClass (e.g., for encryption, specific IOPS, or a different disk type).
 
-**Default Value:** Cloud provider specific
+**Default Value:** `""` (empty — each cloud provider uses its own default)
+
+When left empty, Qovery uses the following storageClasses per provider:
+
+| Cloud Provider | StorageClass | Disk Type |
+|---|---|---|
+| AWS | `aws-ebs-gp3-0` | General Purpose SSD (GP3) |
+| GCP | `gcp-pd-balanced` | Balanced persistent disk |
+| Azure | `azure-standard-ssd-zrs` | Standard SSD with zone-redundant storage |
+| Scaleway | `scw-sbv-ssd-0` | Block Storage SSD |
+
+<Info>
+**AWS GP2 → GP3 migration:** If your cluster still uses `aws-ebs-gp2-0` (legacy), we recommend migrating to `aws-ebs-gp3-0`. GP3 offers better baseline performance (3,000 IOPS and 125 MB/s included) at a lower cost than GP2. Set `storageclass.fast_ssd` to `aws-ebs-gp3-0` and redeploy your cluster.
+</Info>
+
+<Info>
+GCP also supports `gcp-pd-ssd` for higher IOPS. Azure supports `azure-premium-lrs`, `azure-premium-v2-lrs`, `azure-premium-zrs`, `azure-ultra-ssd-lrs`, and `azure-standard-ssd-lrs`.
+</Info>
 
 ---
 

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -117,7 +117,13 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 **Type:** `integer`
 
-**Description:** Allows you to specify the time in seconds that Kubernetes waits for a pod to gracefully shut down before forcefully terminating it.
+**Description:** Allows you to specify the time in seconds that Kubernetes waits for a pod to gracefully shut down before forcefully terminating it. This timer starts as soon as the pod receives a `SIGTERM` signal (or the `pre_stop` hook begins, if configured). If the pod is still running after this period, Kubernetes sends a `SIGKILL`.
+
+**Use Case:** Increase this value for services that need extra time to drain connections, finish background jobs, or flush data to disk. Keep it low for stateless workers that can restart quickly.
+
+<Warning>
+This value must be **greater than** the time your `deployment.lifecycle.pre_stop_exec_command` takes to complete. Otherwise Kubernetes will kill the pod before the pre-stop hook finishes.
+</Warning>
 
 **Default Value:** `60`
 
@@ -129,11 +135,47 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 **Type:** `Map<String, String>`
 
-**Description:** Allows you to define Kubernetes node affinity requirements to control pod placement on specific nodes based on labels.
+**Description:** Allows you to define Kubernetes node affinity requirements to control pod placement on specific nodes based on labels. Each key/value pair maps to a Kubernetes `nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` rule — pods **will not be scheduled** unless a node matches **all** the specified labels.
 
-**Use Case:** Use this to ensure your services run on nodes with specific characteristics (e.g., SSD storage, specific instance types).
+**Use Case:** Use this to pin services to specific node pools, instance families, architectures, or capacity types.
 
 **Default Value:** `{}`
+
+<Tabs>
+  <Tab title="AWS — Karpenter on-demand stable pool">
+    Force pods onto the `stable` Karpenter NodePool using on-demand instances only:
+
+    ```json
+    {
+      "karpenter.sh/capacity-type": "on-demand",
+      "karpenter.sh/nodepool": "stable"
+    }
+    ```
+  </Tab>
+  <Tab title="AWS — Graviton (ARM64)">
+    Schedule on ARM64 Graviton instances for better price/performance:
+
+    ```json
+    {
+      "kubernetes.io/arch": "arm64"
+    }
+    ```
+  </Tab>
+  <Tab title="GCP Autopilot — ARM64 Performance">
+    Run on ARM64 nodes with the GCP Autopilot `Performance` compute class:
+
+    ```json
+    {
+      "kubernetes.io/arch": "arm64",
+      "cloud.google.com/compute-class": "Performance"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>
+If no node matches the required labels, your pods will stay in `Pending` state. Make sure the target node pool or nodes exist before applying this setting.
+</Warning>
 
 <a id="deployment-antiaffinity-pod"></a>
 
@@ -145,7 +187,11 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 **Description:** Allows you to define pod anti-affinity to control how pods are distributed across nodes. Options are `Preferred` or `Required`.
 
-**Use Case:** Use `Required` to ensure pods are never scheduled on the same node (hard requirement), or `Preferred` for a soft preference that can be overridden if necessary.
+**Use Case:** Use `Required` to guarantee that no two replicas of the same service land on the same node — critical for high-availability setups where a single node failure must not take down the entire service. Use `Preferred` (default) when you want Kubernetes to spread pods across nodes on a best-effort basis without blocking scheduling if not enough nodes are available.
+
+<Info>
+With `Required`, you need **at least as many nodes as replicas**. If your cluster doesn't have enough nodes, excess pods will stay `Pending`.
+</Info>
 
 **Default Value:** `Preferred`
 
@@ -159,7 +205,12 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 **Description:** Allows you to specify the deployment update strategy type. Options are `RollingUpdate` or `Recreate`.
 
-**Use Case:** `RollingUpdate` ensures zero-downtime deployments by gradually replacing pods. `Recreate` terminates all pods before creating new ones.
+**Use Case:**
+- **`RollingUpdate`** (default) — gradually replaces pods for zero-downtime deployments. Best for stateless services.
+- **`Recreate`** — terminates all existing pods before creating new ones. Use this when:
+  - Your service uses a **ReadWriteOnce (RWO) volume** that cannot be mounted by two pods simultaneously.
+  - You need to run a **database migration** at startup and cannot have two versions of the schema running at the same time.
+  - Your application does not support running two versions concurrently.
 
 **Default Value:** `RollingUpdate`
 
@@ -199,15 +250,20 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 **Type:** `string`
 
-**Description:** Allows you to specify a command to execute immediately after a container starts.
+**Description:** Allows you to specify a command to execute immediately after a container starts. The command runs **in parallel** with the container's main process and the readiness probe — it does **not** block traffic on its own.
 
-**Use Case:** Use this for initialization tasks that must run after the container starts but before it receives traffic.
+**Use Case:** Use this for initialization side-effects like warming a local cache, registering the instance with a service mesh, or writing a marker file that a readiness probe checks.
 
 **Default Value:** `""`
 
-**Example:**
+**Examples:**
 ```json
-["/bin/sh", "-c", "echo 'Container started' > /tmp/started"]
+// Warm the application cache at startup
+["/bin/sh", "-c", "curl -s http://localhost:8080/warmup || true"]
+```
+```json
+// Write a marker file for a readiness probe
+["/bin/sh", "-c", "touch /tmp/ready"]
 ```
 
 <a id="deployment-lifecycle-pre-stop-exec-command"></a>
@@ -218,15 +274,24 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 **Type:** `string`
 
-**Description:** Allows you to specify a command to execute before a container is terminated.
+**Description:** Allows you to specify a command to execute before a container is terminated. Kubernetes calls this hook when a pod is about to be stopped (scale-down, deployment, node drain). The main process receives `SIGTERM` **at the same time** as the hook starts.
 
-**Use Case:** Use this for graceful shutdown procedures, such as finishing in-flight requests or closing connections cleanly.
+**Use Case:** Use this to give your service time to drain in-flight requests, close database connections, or deregister from a load balancer before the pod disappears.
+
+<Info>
+The default `sleep 15` gives Kubernetes networking time to remove the pod from service endpoints before the process exits. If your service handles its own graceful shutdown, you may still want a short sleep to avoid receiving traffic after `SIGTERM`.
+</Info>
 
 **Default Value:** `["/bin/sh", "-c", "sleep 15"]`
 
-**Example:**
+**Examples:**
 ```json
-["/bin/sh", "-c", "kill -SIGTERM 1 && sleep 30"]
+// Notify the app to drain, then wait for connections to close
+["/bin/sh", "-c", "curl -s http://localhost:8080/drain && sleep 20"]
+```
+```json
+// Simple sleep to let LB deregister the pod
+["/bin/sh", "-c", "sleep 30"]
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **Service Advanced Settings:**
  - `deployment.affinity.node.required`: added practical examples (Karpenter on-demand/stable pool, Graviton ARM64, GCP Autopilot ARM64) with tabs + warning on Pending pods
  - `deployment.termination_grace_period_seconds`: explained SIGTERM/SIGKILL lifecycle + warning about pre_stop hook timing
  - `deployment.antiaffinity.pod`: clarified Required vs Preferred behavior with node count constraint
  - `deployment.update_strategy.type`: detailed when to use Recreate (RWO volumes, DB migrations)
  - `deployment.lifecycle.post_start_exec_command`: clarified parallel execution + practical examples
  - `deployment.lifecycle.pre_stop_exec_command`: explained SIGTERM timing + drain examples

- **Cluster Advanced Settings:**
  - `storageclass.fast_ssd`: documented actual defaults per cloud provider from engine code (GP3 for AWS), added GP2→GP3 migration recommendation
  - `dns.coredns.extra_config`: added use case + tabbed examples (internal DNS, public resolver)
  - `loki.log_retention_in_week`: rewrote description for clarity
  - `aws.vpc.enable_s3_flow_logs`: added compliance use case
  - `registry.mirroring_mode`: clarified Service vs Cluster mode differences
  - `allow_service_cpu_overcommit`: fixed typo (`cpu_in_mib` → `cpu_in_milli`), better CPU throttling explanation
  - `allow_service_ram_overcommit`: explained OOM-kill risk vs CPU throttling
  - `k8s.api.allowed_public_access_cidrs`: added example
  - Database access control (PostgreSQL, MySQL, MongoDB, Redis): clarified deny_any_access overrides allowed_cidrs
  - `aws.eks.ec2.metadata_imds`: explained IMDSv2 security benefits (SSRF protection)
  - Fixed duplicate anchor id on `cluster.profile`

## Test plan

- [ ] Verify pages render correctly in Mintlify preview
- [ ] Check tabbed examples display properly on `deployment.affinity.node.required` and `dns.coredns.extra_config`
- [ ] Confirm storageclass table renders correctly