### PR TITLE
feat: add deployment.topology_spread.zone documentation

### DIFF
--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -7,10 +7,10 @@ info:
     - ℹ️ The API is stable and still in development.
   contact:
     name: Qovery Product Team
-    url: "https://www.qovery.com"
+    url: 'https://www.qovery.com'
     email: support+api+documentation@qovery.com
   x-logo:
-    url: "https://console.qovery.com/assets/logos/logo-white.svg"
+    url: 'https://console.qovery.com/assets/logos/logo-white.svg'
     altText: Qovery
 tags:
   - name: Account
@@ -258,7 +258,7 @@ x-tagGroups:
       - Alert Receivers
       - Alert Rules
 servers:
-  - url: "https://api.qovery.com"
+  - url: 'https://api.qovery.com'
 paths:
   /organization:
     get:
@@ -267,18 +267,18 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: List organizations
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an organization
       operationId: createOrganization
@@ -288,151 +288,151 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationRequest"
+              $ref: '#/components/schemas/OrganizationRequest'
       responses:
-        "201":
+        '201':
           description: Create organization
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Organization"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Organization'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Organization name is already taken
-  "/organization/{organizationId}":
+  '/organization/{organizationId}':
     get:
       summary: Get organization by ID
       operationId: getOrganization
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Get organization by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Organization"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/Organization'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an organization
       description: To edit an organization you must have the admin permission.
       operationId: editOrganization
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationEditRequest"
+              $ref: '#/components/schemas/OrganizationEditRequest'
       responses:
-        "200":
+        '200':
           description: Edit an organization
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Organization"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Organization'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Organization name is already taken
     delete:
       summary: Delete an organization
       description: To delete an organization you must have the admin permission
       operationId: deleteOrganization
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/apiToken":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/apiToken':
     get:
       summary: List organization api tokens
       description: List organization api tokens
       operationId: listOrganizationApiTokens
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Api Token
       responses:
-        "200":
+        '200':
           description: List organization api tokens
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationApiTokenResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationApiTokenResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an organization api token
       description: Create an organization api token. You can use the generated token to interact in a programmatic way with our API.
       operationId: createOrganizationApiToken
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Api Token
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationApiTokenCreateRequest"
+              $ref: '#/components/schemas/OrganizationApiTokenCreateRequest'
       responses:
-        "201":
+        '201':
           description: Organization api token created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationApiTokenCreate"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/OrganizationApiTokenCreate'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Organization Api Token name is already taken
-  "/organization/{organizationId}/apiToken/{apiTokenId}":
+  '/organization/{organizationId}/apiToken/{apiTokenId}':
     delete:
       summary: Delete organization api token
       description: Delete organization api token
       operationId: deleteOrganizationApiToken
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - name: apiTokenId
           in: path
           description: Organization Api Token ID
@@ -443,176 +443,176 @@ paths:
       tags:
         - Organization Api Token
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/availableRole":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/availableRole':
     get:
       summary: List organization available roles
       description: List organization available roles
       operationId: listOrganizationAvailableRoles
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: List organization available roles
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationAvailableRoleList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/gitToken":
+                $ref: '#/components/schemas/OrganizationAvailableRoleList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/gitToken':
     get:
       summary: List organization git tokens
       description: List organization git tokens
       operationId: listOrganizationGitTokens
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: List organization git tokens
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitTokenResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/GitTokenResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a git token
       description: Create a new git token to be used as a git provider by a service
       operationId: createGitToken
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GitTokenRequest"
+              $ref: '#/components/schemas/GitTokenRequest'
       responses:
-        "201":
+        '201':
           description: Git token created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitTokenResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/gitToken/{gitTokenId}":
+                $ref: '#/components/schemas/GitTokenResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/gitToken/{gitTokenId}':
     get:
       summary: Get organization git token
       description: Get organization git token
       operationId: getOrganizationGitToken
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/gitTokenId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/gitTokenId'
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Get organization git token
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitTokenResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/GitTokenResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a git token
       operationId: editGitToken
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/gitTokenId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/gitTokenId'
       tags:
         - Organization Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GitTokenRequest"
+              $ref: '#/components/schemas/GitTokenRequest'
       responses:
-        "200":
+        '200':
           description: Git token edited
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitTokenResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/GitTokenResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a git token
       operationId: deleteGitToken
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/gitTokenId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/gitTokenId'
       tags:
         - Organization Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/gitToken/{gitTokenId}/associatedServices":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/gitToken/{gitTokenId}/associatedServices':
     get:
       summary: Get organization git token associated services
       description: Get organization git tokens associated services
       operationId: getGitTokenAssociatedServices
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/gitTokenId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/gitTokenId'
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Get organization git token associated services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitTokenAssociatedServicesResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/listDirectoriesFromGitRepository":
+                $ref: '#/components/schemas/GitTokenAssociatedServicesResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/listDirectoriesFromGitRepository':
     post:
       summary: List directories from a git repository
       description: |
@@ -621,16 +621,16 @@ paths:
         and select the appropriate root path.
       operationId: listDirectoriesFromGitRepository
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Git repositories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+              $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
       responses:
-        "200":
+        '200':
           description: List of directories at the specified path
           content:
             application/json:
@@ -645,64 +645,64 @@ paths:
                       - infra
                       - terraform
                       - .github
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/member":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/member':
     get:
       summary: Get organization members
       operationId: getOrganizationMembers
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Members
       responses:
-        "200":
+        '200':
           description: Get members
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MemberResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/MemberResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an organization member role
       description: Edit an organization member role
       operationId: editOrganizationMemberRole
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Members
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MemberRoleUpdateRequest"
+              $ref: '#/components/schemas/MemberRoleUpdateRequest'
       responses:
-        "200":
+        '200':
           description: Edit an organization member role
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Remove a member
       operationId: deleteMember
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       requestBody:
         content:
           application/json:
@@ -717,226 +717,226 @@ paths:
       tags:
         - Members
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/inviteMember":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/inviteMember':
     get:
       summary: Get invited members
       operationId: getOrganizationInvitedMembers
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Members
       responses:
-        "200":
+        '200':
           description: Get invited members
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InviteMemberResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/InviteMemberResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Invite someone in the organization
       operationId: postInviteMember
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Members
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/InviteMemberRequest"
+              $ref: '#/components/schemas/InviteMemberRequest'
       responses:
-        "201":
+        '201':
           description: User invited
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InviteMember"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/InviteMember'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: User already invited
-  "/organization/{organizationId}/inviteMember/{inviteId}":
+  '/organization/{organizationId}/inviteMember/{inviteId}':
     get:
       summary: Get member invitation
       operationId: getMemberInvitation
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/inviteId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/inviteId'
       tags:
         - Members
       responses:
-        "200":
+        '200':
           description: Get member invitation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InviteMember"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/InviteMember'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Accept Invite in the organization
       operationId: postAcceptInviteMember
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/inviteId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/inviteId'
       tags:
         - Members
       responses:
-        "201":
+        '201':
           description: User invited
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InviteMember"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/InviteMember'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: User already invited
     delete:
       summary: Remove an invited member
       operationId: deleteInviteMember
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/inviteId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/inviteId'
       tags:
         - Members
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/transferOwnership":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/transferOwnership':
     post:
       summary: Transfer organization ownership to another user
       operationId: postOrganizationTransferOwnership
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Members
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransferOwnershipRequest"
+              $ref: '#/components/schemas/TransferOwnershipRequest'
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/currentCost":
+        '204':
+          $ref: '#/components/responses/204'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/currentCost':
     get:
       summary: Get organization current cost
       operationId: getOrganizationCurrentCost
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get Cost
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationCurrentCost"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/creditCode":
+                $ref: '#/components/schemas/OrganizationCurrentCost'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/creditCode':
     post:
       summary: Add credit code
       operationId: addCreditCode
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationCreditCodeRequest"
+              $ref: '#/components/schemas/OrganizationCreditCodeRequest'
       responses:
-        "200":
+        '200':
           description: add credit code
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/changePlan":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/changePlan':
     post:
       summary: Change organization plan
       operationId: changePlan
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationChangePlanRequest"
+              $ref: '#/components/schemas/OrganizationChangePlanRequest'
       responses:
-        "200":
+        '200':
           description: plan has been successfully changed
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Organization"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/currentCost":
+                $ref: '#/components/schemas/Organization'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/currentCost':
     get:
       summary: Get cluster current cost
       operationId: getClusterCurrentCost
@@ -944,72 +944,72 @@ paths:
         Get your cluster cost range. We are unable to give a precise cost of your infrastructure at the moment.
         But Qovery guarantees that the cost of your cluster will not exceed the max range.
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get cluster cost
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CostRange"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/billingInfo":
+                $ref: '#/components/schemas/CostRange'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/billingInfo':
     get:
       summary: Get organization billing info
       operationId: getOrganizationBillingInfo
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get Billing Info
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BillingInfo"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/BillingInfo'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit Organization Billing Info
       operationId: editOrganizationBillingInfo
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BillingInfoRequest"
+              $ref: '#/components/schemas/BillingInfoRequest'
       responses:
-        "200":
+        '200':
           description: Edit billing info
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BillingInfo"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/billingStatus":
+                $ref: '#/components/schemas/BillingInfo'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/billingStatus':
     get:
       summary: Get organization billing status
       description: |
@@ -1019,491 +1019,491 @@ paths:
         - For Community organization, it returns false if there is no credit left
       operationId: getOrganizationBillingStatus
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get Billing Status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BillingStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/billingUsageReport":
+                $ref: '#/components/schemas/BillingStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/billingUsageReport':
     post:
       summary: Generate organization billing usage report
       operationId: generateBillingUsageReport
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationBillingUsageReportRequest"
+              $ref: '#/components/schemas/OrganizationBillingUsageReportRequest'
       responses:
-        "200":
+        '200':
           description: billing usage report has been successfully generated
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationBillingUsageReportResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/billingExternalId":
+                $ref: '#/components/schemas/OrganizationBillingUsageReportResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/billingExternalId':
     get:
       summary: Get organization billing external ID
       description: |
         This endpoint returns the external ID of the organization's billing account
       operationId: getOrganizationBillingExternalId
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get Billing External ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BillingExternalId"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/invoice":
+                $ref: '#/components/schemas/BillingExternalId'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/invoice':
     get:
       summary: List organization invoices
       operationId: listOrganizationInvoice
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: List Invoices
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InvoiceResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/invoice/{invoiceId}":
+                $ref: '#/components/schemas/InvoiceResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/invoice/{invoiceId}':
     get:
       summary: Get organization invoice
       operationId: getOrganizationInvoice
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/invoiceId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/invoiceId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get Invoice
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Invoice"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/invoice/{invoiceId}/download":
+                $ref: '#/components/schemas/Invoice'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/invoice/{invoiceId}/download':
     get:
       summary: Get invoice link
       description: This will return URL of the invoice PDF
       operationId: getOrganizationInvoicePDF
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/invoiceId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/invoiceId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: Get invoice PDF
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Link"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/downloadInvoices":
+                $ref: '#/components/schemas/Link'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/downloadInvoices':
     post:
       summary: Download all invoices
       operationId: organizationDownloadAllInvoices
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "202":
+        '202':
           description: You will receive an email containing your invoices
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/creditCard":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/creditCard':
     get:
       summary: List organization credit cards
       operationId: listOrganizationCreditCards
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       responses:
-        "200":
+        '200':
           description: List cfredit cards
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreditCardResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CreditCardResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add credit card
       operationId: addCreditCard
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreditCardRequest"
+              $ref: '#/components/schemas/CreditCardRequest'
       responses:
-        "201":
+        '201':
           description: Add credit card
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreditCard"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/creditCard/{creditCardId}":
+                $ref: '#/components/schemas/CreditCard'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/creditCard/{creditCardId}':
     delete:
       summary: Delete credit card
       operationId: deleteCreditCard
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/creditCardId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/creditCardId'
       tags:
         - Billing
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/project":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/project':
     get:
       summary: List projects
       operationId: listProject
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Projects
       responses:
-        "200":
+        '200':
           description: List projects
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ProjectResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a project
       operationId: createProject
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Projects
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProjectRequest"
+              $ref: '#/components/schemas/ProjectRequest'
       responses:
-        "200":
+        '200':
           description: Create project
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Project"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Project'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Project name within the organization is already taken
-  "/organization/{organizationId}/project/stats":
+  '/organization/{organizationId}/project/stats':
     get:
       summary: List total number of services and environments for each project of the organization
-      description: "Returns a list of project ids, and for each its total numberof services and environments"
+      description: 'Returns a list of project ids, and for each its total numberof services and environments'
       operationId: getOrganizationProjectStats
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Projects
       responses:
-        "200":
+        '200':
           description: Get number of services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectStatsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster":
+                $ref: '#/components/schemas/ProjectStatsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster':
     get:
       summary: List organization clusters
       operationId: listOrganizationCluster
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: List clusters
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a cluster
       operationId: createCluster
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterRequest"
+              $ref: '#/components/schemas/ClusterRequest'
       responses:
-        "201":
+        '201':
           description: Create cluster
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Cluster"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/status":
+                $ref: '#/components/schemas/Cluster'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/status':
     get:
       summary: List all clusters statuses
       description: Returns a list of clusters with only their id and status.
       operationId: getOrganizationClusterStatus
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Get statuses
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}":
+                $ref: '#/components/schemas/ClusterStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}':
     delete:
       summary: Delete a cluster
       operationId: deleteCluster
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
         - in: query
           name: deleteMode
           schema:
-            $ref: "#/components/schemas/ClusterDeleteMode"
+            $ref: '#/components/schemas/ClusterDeleteMode'
       tags:
         - Clusters
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a cluster
       operationId: editCluster
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterRequest"
+              $ref: '#/components/schemas/ClusterRequest'
       responses:
-        "200":
+        '200':
           description: Edited the cluster
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Cluster"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/status":
+                $ref: '#/components/schemas/Cluster'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/status':
     get:
       summary: Get cluster status
       operationId: getClusterStatus
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/installationHelmValues":
+                $ref: '#/components/schemas/ClusterStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/installationHelmValues':
     get:
       summary: Get cluster helm values for self managed installation
       operationId: getInstallationHelmValues
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Helm values
           content:
             application/x-yaml:
               schema:
                 type: string
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/kubeconfig":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/kubeconfig':
     get:
       summary: Get cluster kubeconfig
       operationId: getClusterKubeconfig
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
         - schema:
             type: boolean
           in: query
           name: with_token_from_cli
-          description: "If true, the user auth part will have an exec command with qovery cli"
+          description: 'If true, the user auth part will have an exec command with qovery cli'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Get kubeconfig of the cluster
           content:
             application/x-yaml:
               schema:
                 type: string
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit cluster kubeconfig
       operationId: editClusterKubeconfig
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       requestBody:
@@ -1512,15 +1512,15 @@ paths:
             schema:
               type: string
       responses:
-        "204":
+        '204':
           description: edit kubeconfig of the cluster
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/advancedSettings":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/advancedSettings':
     get:
       summary: Get advanced settings
       description: |
@@ -1528,625 +1528,625 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/cluster-advanced-settings/)
       operationId: getClusterAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editClusterAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterAdvancedSettings"
+              $ref: '#/components/schemas/ClusterAdvancedSettings'
       responses:
-        "201":
+        '201':
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterAdvancedSettings"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/routingTable":
+                $ref: '#/components/schemas/ClusterAdvancedSettings'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/routingTable':
     get:
       summary: Get routing table
       description: Retrieve network routing table where each line corresponds to a route between a destination and a target.
       operationId: getRoutingTable
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Routing table
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterRoutingTable"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterRoutingTable'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit routing table
       description: Edit routing table by returning updated table.
       operationId: editRoutingTable
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterRoutingTableRequest"
+              $ref: '#/components/schemas/ClusterRoutingTableRequest'
       responses:
-        "201":
+        '201':
           description: Updated routing table
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterRoutingTable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/logs":
+                $ref: '#/components/schemas/ClusterRoutingTable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/logs':
     get:
       summary: List Cluster Logs
       description: List Cluster Logs
       operationId: listClusterLogs
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: list cluster logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterLogsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/aws/credentials":
+                $ref: '#/components/schemas/ClusterLogsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/aws/credentials':
     get:
       summary: List AWS credentials
       operationId: listAWSCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentialsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentialsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create AWS credentials set
       operationId: createAWSCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AwsCredentialsRequest"
+              $ref: '#/components/schemas/AwsCredentialsRequest'
       responses:
-        "201":
+        '201':
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/aws/credentials/{credentialsId}":
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/aws/credentials/{credentialsId}':
     get:
       summary: Get a set of AWS credentials
       operationId: getAWSCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: Get a set of AWS credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a set of AWS credentials
       operationId: editAWSCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AwsCredentialsRequest"
+              $ref: '#/components/schemas/AwsCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Edit a set of AWS credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a set of AWS credentials
       operationId: deleteAWSCredentials
       parameters:
-        - $ref: "#/components/parameters/credentialsId"
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/credentialsId'
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/onPremise/credentials":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/onPremise/credentials':
     get:
       summary: List OnPremise credentials
       operationId: listOnPremiseCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentialsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentialsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create OnPremise credentials set
       operationId: createOnPremiseCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OnPremiseCredentialsRequest"
+              $ref: '#/components/schemas/OnPremiseCredentialsRequest'
       responses:
-        "201":
+        '201':
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/onPremise/credentials/{credentialsId}":
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/onPremise/credentials/{credentialsId}':
     get:
       summary: Get a set of OnPremise credentials
       operationId: getOnPremiseCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: Get a set of OnPremise credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a set of OnPremise credentials
       operationId: editOnPremiseCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OnPremiseCredentialsRequest"
+              $ref: '#/components/schemas/OnPremiseCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Edit a set of OnPremise credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a set of OnPremise credentials
       operationId: deleteOnPremiseCredentials
       parameters:
-        - $ref: "#/components/parameters/credentialsId"
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/credentialsId'
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/scaleway/credentials":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/scaleway/credentials':
     get:
       summary: List Scaleway credentials
       operationId: listScalewayCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentialsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentialsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create Scaleway credentials set
       operationId: createScalewayCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ScalewayCredentialsRequest"
+              $ref: '#/components/schemas/ScalewayCredentialsRequest'
       responses:
-        "201":
+        '201':
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/scaleway/credentials/{credentialsId}":
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/scaleway/credentials/{credentialsId}':
     get:
       summary: Get a set of Scaleway credentials
       operationId: getScalewayCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: Get a set of Scaleway credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a set of Scaleway credentials
       operationId: editScalewayCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ScalewayCredentialsRequest"
+              $ref: '#/components/schemas/ScalewayCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Edit a set of Scaleway credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a set of Scaleway credentials
       operationId: deleteScalewayCredentials
       parameters:
-        - $ref: "#/components/parameters/credentialsId"
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/credentialsId'
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/gcp/credentials":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/gcp/credentials':
     get:
       summary: List GCP credentials
       operationId: listGcpCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentialsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentialsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create GCP credentials set
       operationId: createGcpCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GcpCredentialsRequest"
+              $ref: '#/components/schemas/GcpCredentialsRequest'
       responses:
-        "201":
+        '201':
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/gcp/credentials/{credentialsId}":
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/gcp/credentials/{credentialsId}':
     get:
       summary: Get a set of GCP credentials
       operationId: getGcpCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: Get a set of GCP credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a set of GCP credentials
       operationId: editGcpCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/credentialsId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/credentialsId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GcpCredentialsRequest"
+              $ref: '#/components/schemas/GcpCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Edit a set of GCP credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a set of GCP credentials
       operationId: deleteGcpCredentials
       parameters:
-        - $ref: "#/components/parameters/credentialsId"
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/credentialsId'
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/github/connect":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/github/connect':
     post:
       summary: Connect a github account to an organization
       operationId: organizationGithubAppConnect
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Github App
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationGithubAppConnectRequest"
+              $ref: '#/components/schemas/OrganizationGithubAppConnectRequest'
       responses:
-        "200":
+        '200':
           description: Github App connected
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/github/disconnect":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/github/disconnect':
     delete:
       summary: Disconnect a github account from an organization
       operationId: organizationGithubAppDisconnect
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: force
           schema:
@@ -2155,37 +2155,37 @@ paths:
       tags:
         - Github App
       responses:
-        "204":
+        '204':
           description: Github App disconnected
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/account/gitAuthProvider":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/account/gitAuthProvider':
     get:
       summary: Get git provider accounts
       operationId: getOrganizationGitProviderAccount
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Account Git Repositories
       responses:
-        "200":
+        '200':
           description: Get account
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitAuthProviderResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/account/github/repository":
+                $ref: '#/components/schemas/GitAuthProviderResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/account/github/repository':
     get:
       summary: Get github repositories of the connected user
       operationId: getOrganizationGithubRepositories
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: gitTokenId
           schema:
@@ -2195,22 +2195,22 @@ paths:
       tags:
         - Organization Account Git Repositories
       responses:
-        "200":
+        '200':
           description: Get github repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/account/github/repository/branch":
+                $ref: '#/components/schemas/GitRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/account/github/repository/branch':
     get:
       summary: Get github branches of the specified repository
       operationId: getOrganizationGithubRepositoryBranches
       tags:
         - Organization Account Git Repositories
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: name
           schema:
@@ -2223,20 +2223,20 @@ paths:
             format: uuid
           description: The git token id that must be used for the application
       responses:
-        "200":
+        '200':
           description: Get github repository branches
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/account/gitlab/repository":
+                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/account/gitlab/repository':
     get:
       summary: Get gitlab repositories of the connected user
       operationId: getOrganizationGitlabRepositories
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: gitTokenId
           schema:
@@ -2246,22 +2246,22 @@ paths:
       tags:
         - Organization Account Git Repositories
       responses:
-        "200":
+        '200':
           description: Get gitlab repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/account/gitlab/repository/branch":
+                $ref: '#/components/schemas/GitRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/account/gitlab/repository/branch':
     get:
       summary: Get gitlab branches of the specified repository
       operationId: getOrganizationGitlabRepositoryBranches
       tags:
         - Organization Account Git Repositories
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: name
           schema:
@@ -2274,20 +2274,20 @@ paths:
             format: uuid
           description: The git token id that must be used for the application
       responses:
-        "200":
+        '200':
           description: Get gitlab repository branches
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/account/bitbucket/repository":
+                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/account/bitbucket/repository':
     get:
       summary: Get bitbucket repositories of the connected user
       operationId: getOrganizationBitbucketRepositories
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: gitTokenId
           schema:
@@ -2297,22 +2297,22 @@ paths:
       tags:
         - Organization Account Git Repositories
       responses:
-        "200":
+        '200':
           description: Get bitbucket repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/account/bitbucket/repository/branch":
+                $ref: '#/components/schemas/GitRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/account/bitbucket/repository/branch':
     get:
       summary: Get bitbucket branches of the specified repository
       operationId: getOrganizationBitbucketRepositoryBranches
       tags:
         - Organization Account Git Repositories
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: name
           schema:
@@ -2325,282 +2325,282 @@ paths:
             format: uuid
           description: The git token id that must be used for the application
       responses:
-        "200":
+        '200':
           description: Get bitbucket repository branches
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-  "/organization/{organizationId}/webhook":
+                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+  '/organization/{organizationId}/webhook':
     get:
       summary: List organization webhooks
       description: List organization webhooks
       operationId: listOrganizationWebHooks
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Webhook
       responses:
-        "200":
+        '200':
           description: List organization webhooks
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationWebhookResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationWebhookResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an organization webhook
       description: Create an organization webhook.
       operationId: createOrganizationWebhook
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Webhook
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationWebhookCreateRequest"
+              $ref: '#/components/schemas/OrganizationWebhookCreateRequest'
       responses:
-        "201":
+        '201':
           description: Organization webhook created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationWebhookCreateResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/OrganizationWebhookCreateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
       x-stoplight:
         id: ihun7iwf9rffw
-  "/organization/{organizationId}/webhook/{webhookId}/event":
+  '/organization/{organizationId}/webhook/{webhookId}/event':
     get:
       summary: List events of a webhook
       description: List events of a webhooks
       operationId: listWebhookEvent
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/webhookId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/webhookId'
       tags:
         - Organization Webhook
       responses:
-        "200":
+        '200':
           description: List of event for the webhook
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WebhookEventResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/webhook/{webhookId}":
+                $ref: '#/components/schemas/WebhookEventResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/webhook/{webhookId}':
     get:
       summary: Get an Organization webhook
       description: Get an Organization webhook
       operationId: getOrganizationWebhook
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/webhookId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/webhookId'
       tags:
         - Organization Webhook
       responses:
-        "200":
+        '200':
           description: Get organization webhook
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationWebhookResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationWebhookResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an organization webhook
       description: Edit an organization webhook
       operationId: editOrganizationWebhook
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/webhookId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/webhookId'
       tags:
         - Organization Webhook
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationWebhookCreateRequest"
+              $ref: '#/components/schemas/OrganizationWebhookCreateRequest'
       responses:
-        "200":
+        '200':
           description: Edit an organization webhook
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationWebhookCreateResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationWebhookCreateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete organization webhook
       description: Delete organization webhook
       operationId: deleteOrganizationWebhook
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/webhookId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/webhookId'
       tags:
         - Organization Webhook
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/customRole":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/customRole':
     get:
       summary: List organization custom roles
       description: List organization custom roles
       operationId: listOrganizationCustomRoles
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Custom Role
       responses:
-        "200":
+        '200':
           description: List organization custom roles
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationCustomRoleList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationCustomRoleList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an organization custom role
       description: Create an organization custom role
       operationId: createOrganizationCustomRole
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Custom Role
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationCustomRoleCreateRequest"
+              $ref: '#/components/schemas/OrganizationCustomRoleCreateRequest'
       responses:
-        "201":
+        '201':
           description: Organization custom role created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationCustomRole"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-  "/organization/{organizationId}/customRole/{customRoleId}":
+                $ref: '#/components/schemas/OrganizationCustomRole'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+  '/organization/{organizationId}/customRole/{customRoleId}':
     get:
-      summary: "Get an organization custom role "
-      description: "Get an organization custom role "
+      summary: 'Get an organization custom role '
+      description: 'Get an organization custom role '
       operationId: getOrganizationCustomRole
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/customRoleId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/customRoleId'
       tags:
         - Organization Custom Role
       responses:
-        "200":
-          description: "Get an organization custom role "
+        '200':
+          description: 'Get an organization custom role '
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationCustomRole"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationCustomRole'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an organization custom role
       description: Edit an organization custom role
       operationId: editOrganizationCustomRole
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/customRoleId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/customRoleId'
       tags:
         - Organization Custom Role
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationCustomRoleUpdateRequest"
+              $ref: '#/components/schemas/OrganizationCustomRoleUpdateRequest'
       responses:
-        "200":
+        '200':
           description: Edit an organization custom role
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationCustomRole"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationCustomRole'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete organization custom role
       description: Delete organization custom role
       operationId: deleteOrganizationCustomRole
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/customRoleId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/customRoleId'
       tags:
         - Organization Custom Role
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/events":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/events':
     get:
       summary: Get all events inside the organization
       description: Get all events inside the organization
       operationId: getOrganizationEvents
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: pageSize
           description: The number of events to display in the current page
@@ -2643,11 +2643,11 @@ paths:
         - in: query
           name: eventType
           schema:
-            $ref: "#/components/schemas/OrganizationEventType"
+            $ref: '#/components/schemas/OrganizationEventType'
         - in: query
           name: targetType
           schema:
-            $ref: "#/components/schemas/OrganizationEventTargetType"
+            $ref: '#/components/schemas/OrganizationEventTargetType'
         - in: query
           name: targetId
           description: |
@@ -2660,7 +2660,7 @@ paths:
         - in: query
           name: subTargetType
           schema:
-            $ref: "#/components/schemas/OrganizationEventSubTargetType"
+            $ref: '#/components/schemas/OrganizationEventSubTargetType'
         - in: query
           name: triggeredBy
           description: Information about the owner of the event (user name / apitoken / automatic action)
@@ -2669,7 +2669,7 @@ paths:
         - in: query
           name: origin
           schema:
-            $ref: "#/components/schemas/OrganizationEventOrigin"
+            $ref: '#/components/schemas/OrganizationEventOrigin'
         - in: query
           name: serviceProjectId
           description: The project chosen when filtering on a service type
@@ -2683,25 +2683,25 @@ paths:
       tags:
         - Organization Event
       responses:
-        "200":
+        '200':
           description: Get organization events
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationEventResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/targets":
+                $ref: '#/components/schemas/OrganizationEventResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/targets':
     get:
       summary: Get available event targets to filter events
       description: Get available event targets to filter events
       operationId: getOrganizationEventTargets
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
         - in: query
           name: fromTimestamp
           description: |
@@ -2723,11 +2723,11 @@ paths:
         - in: query
           name: eventType
           schema:
-            $ref: "#/components/schemas/OrganizationEventType"
+            $ref: '#/components/schemas/OrganizationEventType'
         - in: query
           name: targetType
           schema:
-            $ref: "#/components/schemas/OrganizationEventTargetType"
+            $ref: '#/components/schemas/OrganizationEventTargetType'
         - in: query
           name: triggeredBy
           description: Information about the owner of the event (user name / apitoken / automatic action)
@@ -2736,7 +2736,7 @@ paths:
         - in: query
           name: origin
           schema:
-            $ref: "#/components/schemas/OrganizationEventOrigin"
+            $ref: '#/components/schemas/OrganizationEventOrigin'
         - in: query
           name: projectId
           description: Mandatory when requesting an environment or a service
@@ -2753,33 +2753,33 @@ paths:
           name: targetLevelToFetch
           description: Used only to retrieve projects or environments linked to service typed events
           schema:
-            $ref: "#/components/schemas/OrganizationEventTargetLevel"
+            $ref: '#/components/schemas/OrganizationEventTargetLevel'
       tags:
         - Organization Event
       responses:
-        "200":
+        '200':
           description: Get organization event targets
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationEventTargetResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/annotationsGroups":
+                $ref: '#/components/schemas/OrganizationEventTargetResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/annotationsGroups':
     get:
       summary: List organization annotations group
       description: List organization annotations group
       operationId: listOrganizationAnnotationsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Annotations Group
       responses:
-        "200":
+        '200':
           description: List organization annotations groups
           content:
             application/json:
@@ -2787,141 +2787,141 @@ paths:
                 type: object
                 properties:
                   results:
-                    $ref: "#/components/schemas/OrganizationAnnotationsGroupEnrichedResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                    $ref: '#/components/schemas/OrganizationAnnotationsGroupEnrichedResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an organization annotations group
       description: Create an organization annotations group
       operationId: createOrganizationAnnotationsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Annotations Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupCreateRequest"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupCreateRequest'
       responses:
-        "201":
+        '201':
           description: Organization annotations group created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-  "/organization/{organizationId}/annotationsGroups/{annotationsGroupId}":
+                $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+  '/organization/{organizationId}/annotationsGroups/{annotationsGroupId}':
     get:
       summary: Get organization annotations group
       description: Get organization annotations group
       operationId: getOrganizationAnnotationsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/annotationsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/annotationsGroupId'
       tags:
         - Organization Annotations Group
       responses:
-        "200":
+        '200':
           description: List organization annotations groups
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit organization annotations group
       description: Edit organization annotations group
       operationId: editOrganizationAnnotationsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/annotationsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/annotationsGroupId'
       tags:
         - Organization Annotations Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupCreateRequest"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupCreateRequest'
       responses:
-        "200":
+        '200':
           description: Edit organization annotations groups
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete organization annotations group
       description: Delete organization annotations group
       operationId: deleteOrganizationAnnotationsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/annotationsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/annotationsGroupId'
       tags:
         - Organization Annotations Group
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/annotationsGroups/{annotationsGroupId}/associatedItems":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/annotationsGroups/{annotationsGroupId}/associatedItems':
     get:
       summary: Get organization annotations group associated items
       description: Get organization annotations group associated items
       operationId: getOrganizationAnnotationsGroupAssociatedItems
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/annotationsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/annotationsGroupId'
       tags:
         - Organization Annotations Group
       responses:
-        "200":
+        '200':
           description: Get organization annotations group token associated items
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationAnnotationsGroupAssociatedItemsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/labelsGroups":
+                $ref: '#/components/schemas/OrganizationAnnotationsGroupAssociatedItemsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/labelsGroups':
     get:
       summary: List organization labels group
       description: List organization labels group
       operationId: listOrganizationLabelsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Labels Group
       responses:
-        "200":
+        '200':
           description: List organization labels groups
           content:
             application/json:
@@ -2929,130 +2929,130 @@ paths:
                 type: object
                 properties:
                   results:
-                    $ref: "#/components/schemas/OrganizationLabelsGroupEnrichedResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                    $ref: '#/components/schemas/OrganizationLabelsGroupEnrichedResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an organization labels group
       description: Create an organization labels group
       operationId: createOrganizationLabelsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Labels Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationLabelsGroupCreateRequest"
+              $ref: '#/components/schemas/OrganizationLabelsGroupCreateRequest'
       responses:
-        "201":
+        '201':
           description: Organization labels group created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-  "/organization/{organizationId}/labelsGroups/{labelsGroupId}":
+                $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+  '/organization/{organizationId}/labelsGroups/{labelsGroupId}':
     get:
       summary: Get organization labels group
       description: Get organization labels group
       operationId: getOrganizationLabelssGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/labelsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/labelsGroupId'
       tags:
         - Organization Labels Group
       responses:
-        "200":
+        '200':
           description: List organization labels groups
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit organization labels group
       description: Edit organization labels group
       operationId: editOrganizationLabelsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/labelsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/labelsGroupId'
       tags:
         - Organization Labels Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationLabelsGroupCreateRequest"
+              $ref: '#/components/schemas/OrganizationLabelsGroupCreateRequest'
       responses:
-        "200":
+        '200':
           description: Edit organization labels groups
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete organization labels group
       description: Delete organization labels group
       operationId: deleteOrganizationLabelsGroup
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/labelsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/labelsGroupId'
       tags:
         - Organization Labels Group
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/labelsGroups/{labelsGroupId}/associatedItems":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/labelsGroups/{labelsGroupId}/associatedItems':
     get:
       summary: Get organization labels group associated items
       description: Get organization labels group associated items
       operationId: getOrganizationLabelsGroupAssociatedItems
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/labelsGroupId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/labelsGroupId'
       tags:
         - Organization Labels Group
       responses:
-        "200":
+        '200':
           description: Get organization labels group token associated items
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationLabelsGroupAssociatedItemsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/OrganizationLabelsGroupAssociatedItemsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /cloudProvider:
     get:
       summary: List Cloud providers available
@@ -3060,18 +3060,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list cloud providers
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CloudProviderResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CloudProviderResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /aws/region:
     get:
       summary: List AWS regions
@@ -3079,18 +3079,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list regions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterRegionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterRegionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /aws/clusterFeature:
     get:
       summary: List AWS features available
@@ -3098,18 +3098,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list features available for AWS cloud provider
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterFeatureResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterFeatureResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /aws/instanceType:
     get:
       summary: List AWS available instance types
@@ -3117,18 +3117,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list the instance types available for AWS cloud provider
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /aws/managedDatabase/type:
     get:
       summary: List AWS available managed database types
@@ -3136,46 +3136,46 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list AWS available managed database types
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ManagedDatabaseTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/aws/managedDatabase/instanceType/{region}/{databaseType}":
+                $ref: '#/components/schemas/ManagedDatabaseTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/aws/managedDatabase/instanceType/{region}/{databaseType}':
     get:
       summary: List AWS available managed database instance types
       operationId: listAWSManagedDatabaseInstanceType
       parameters:
-        - $ref: "#/components/parameters/region"
-        - $ref: "#/components/parameters/databaseType"
+        - $ref: '#/components/parameters/region'
+        - $ref: '#/components/parameters/databaseType'
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list AWS available managed database instance types
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ManagedDatabaseInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/azure/aks/instanceType/{region}":
+                $ref: '#/components/schemas/ManagedDatabaseInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/azure/aks/instanceType/{region}':
     get:
       summary: List Azure AKS available instance types
       operationId: listAzureAKSInstanceType
       parameters:
-        - $ref: "#/components/parameters/region"
+        - $ref: '#/components/parameters/region'
         - schema:
             type: boolean
           in: query
@@ -3184,7 +3184,7 @@ paths:
             type: boolean
           in: query
           name: with_gpu
-          description: "deprecated field, use `gpu` instead"
+          description: 'deprecated field, use `gpu` instead'
           deprecated: true
         - schema:
             type: string
@@ -3198,24 +3198,24 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list the instance types available for Azure AKS by region
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/aws/eks/instanceType/{region}":
+                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/aws/eks/instanceType/{region}':
     get:
       summary: List AWS EKS available instance types
       operationId: listAWSEKSInstanceType
       parameters:
-        - $ref: "#/components/parameters/region"
+        - $ref: '#/components/parameters/region'
         - schema:
             type: boolean
           in: query
@@ -3224,7 +3224,7 @@ paths:
             type: boolean
           in: query
           name: with_gpu
-          description: "deprecated field, use `gpu` instead"
+          description: 'deprecated field, use `gpu` instead'
           deprecated: true
         - schema:
             type: string
@@ -3239,18 +3239,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list the instance types available for AWS EKS by region
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /scaleway/region:
     get:
       summary: List Scaleway regions
@@ -3258,18 +3258,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list regions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterRegionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterRegionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /scaleway/clusterFeature:
     get:
       summary: List Scaleway features available
@@ -3277,18 +3277,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list features available for Scaleway cloud provider
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterFeatureResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterFeatureResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /scaleway/instanceType:
     get:
       summary: List Scaleway available instance types
@@ -3296,18 +3296,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list the instance types available for Scaleway cloud provider
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /scaleway/managedDatabase/type:
     get:
       summary: List Scaleway available managed database types
@@ -3315,19 +3315,19 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list Scaleway available managed database types
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ManagedDatabaseTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/scaleway/instanceType/{zone}":
+                $ref: '#/components/schemas/ManagedDatabaseTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/scaleway/instanceType/{zone}':
     get:
       summary: List Scaleway Kapsule available instance types
       operationId: listScalewayKapsuleInstanceType
@@ -3342,18 +3342,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list the instance types available for Scaleway Kapsule by region
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /gcp/region:
     get:
       summary: List GCP regions
@@ -3361,18 +3361,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list regions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterRegionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterRegionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /gcp/clusterFeature:
     get:
       summary: List GCP features available
@@ -3380,148 +3380,148 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list features available for GCP cloud provider
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterFeatureResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/gcp/instanceType/{region}":
+                $ref: '#/components/schemas/ClusterFeatureResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/gcp/instanceType/{region}':
     get:
       summary: List GCP GKE available instance types
       operationId: listGcpGkeInstanceType
       parameters:
-        - $ref: "#/components/parameters/region"
+        - $ref: '#/components/parameters/region'
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list the instance types available for GCP GKE by region
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/cloudProviderInfo":
+                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/cloudProviderInfo':
     get:
       summary: Get cluster cloud provider info and credentials
       operationId: getOrganizationCloudProviderInfo
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: get cloud provider info and credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCloudProviderInfo"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCloudProviderInfo'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Specify cluster cloud provider info and credentials
       operationId: specifyClusterCloudProviderInfo
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterCloudProviderInfoRequest"
+              $ref: '#/components/schemas/ClusterCloudProviderInfoRequest'
       responses:
-        "201":
+        '201':
           description: Create cluster
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCloudProviderInfo"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/isReady":
+                $ref: '#/components/schemas/ClusterCloudProviderInfo'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/isReady':
     get:
       summary: Know if a cluster is ready to be deployed or not
       operationId: getClusterReadinessStatus
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Get Cluster Readiness Status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterReadinessStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/deploy":
+                $ref: '#/components/schemas/ClusterReadinessStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/deploy':
     post:
       summary: Deploy a cluster
       description: allows to deploy a cluster
       operationId: deployCluster
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
         - schema:
             type: boolean
           in: query
           name: dry_run
-          description: "default: false. Decide if the deployment of the cluster should be done in dry_run mode. Avoiding any changes"
+          description: 'default: false. Decide if the deployment of the cluster should be done in dry_run mode. Avoiding any changes'
       tags:
         - Clusters
       responses:
-        "201":
+        '201':
           description: Deploy cluster
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterStatus"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/cluster/{clusterId}/argoCdConfig":
+                $ref: '#/components/schemas/ClusterStatus'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/cluster/{clusterId}/argoCdConfig':
     post:
       summary: Save ArgoCD credentials for a cluster
       description: Save or update the ArgoCD URL and authentication token for a cluster. Requires ADMIN role.
       operationId: saveArgoCdCredentials
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - ArgoCD
       requestBody:
@@ -3529,61 +3529,61 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ArgoCdCredentialsRequest"
+              $ref: '#/components/schemas/ArgoCdCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: ArgoCD credentials saved
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ArgoCdCredentialsResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ArgoCdCredentialsResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     get:
       summary: Get ArgoCD credentials for a cluster
       description: Retrieve the stored ArgoCD configuration for a cluster. The token is always returned as REDACTED. Requires VIEWER role.
       operationId: getArgoCdCredentials
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - ArgoCD
       responses:
-        "200":
+        '200':
           description: ArgoCD credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ArgoCdCredentialsResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ArgoCdCredentialsResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete ArgoCD credentials for a cluster
       description: Remove the stored ArgoCD configuration for a cluster. Requires ADMIN role.
       operationId: deleteArgoCdCredentials
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - ArgoCD
       responses:
-        "204":
+        '204':
           description: ArgoCD credentials deleted
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/cluster/{clusterId}/argoCdConfig/check":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/cluster/{clusterId}/argoCdConfig/check':
     post:
       summary: Check ArgoCD connection
       description: |
@@ -3591,7 +3591,7 @@ paths:
         Always returns HTTP 200 — check the `status` field for the connection outcome. Requires ADMIN role.
       operationId: checkArgoCdConnection
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - ArgoCD
       requestBody:
@@ -3599,259 +3599,259 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ArgoCdCredentialsRequest"
+              $ref: '#/components/schemas/ArgoCdCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Connection check result
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ArgoCdConnectionCheckResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/cluster/{clusterId}/upgrade":
+                $ref: '#/components/schemas/ArgoCdConnectionCheckResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/cluster/{clusterId}/upgrade':
     post:
       summary: Upgrade a cluster
       description: allows to upgrade a cluster to next available kubernetes version
       operationId: upgradeCluster
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "201":
+        '201':
           description: Upgrade cluster
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterStatus"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/karpenterPrivateSubnetIds":
+                $ref: '#/components/schemas/ClusterStatus'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/karpenterPrivateSubnetIds':
     put:
       summary: Update karpenter private fargate subnet ids
       description: Update karpenter private fargate subnet ids
       operationId: updateKarpenterPrivateFargateSubnetIds
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterKarpenterPrivateSubnetIdsPutRequest"
+              $ref: '#/components/schemas/ClusterKarpenterPrivateSubnetIdsPutRequest'
       responses:
-        "200":
+        '200':
           description: Updated
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/cluster/{clusterId}/stop":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/cluster/{clusterId}/stop':
     post:
       summary: Stop cluster
       description: Cluster stop has been requester.
       operationId: StopCluster
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/clusterId'
       tags:
         - Clusters
       responses:
-        "202":
+        '202':
           description: Update cluster
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/ClusterStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Cluster is already stopped or an operation is in progress
-  "/organization/{organizationId}/containerRegistry":
+  '/organization/{organizationId}/containerRegistry':
     get:
       summary: List organization container registries
       operationId: listContainerRegistry
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Container Registries
       responses:
-        "200":
+        '200':
           description: List container registries
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerRegistryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ContainerRegistryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a container registry
       operationId: createContainerRegistry
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Container Registries
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerRegistryRequest"
+              $ref: '#/components/schemas/ContainerRegistryRequest'
       responses:
-        "201":
+        '201':
           description: Create a Container Registry
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerRegistryResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/containerRegistry/{containerRegistryId}":
+                $ref: '#/components/schemas/ContainerRegistryResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/containerRegistry/{containerRegistryId}':
     get:
       summary: Get a container registry
       operationId: getContainerRegistry
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/containerRegistryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/containerRegistryId'
       tags:
         - Container Registries
       responses:
-        "200":
+        '200':
           description: The container registry
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerRegistryResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ContainerRegistryResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a container registry
       operationId: deleteContainerRegistry
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/containerRegistryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/containerRegistryId'
       tags:
         - Container Registries
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a container registry
       operationId: editContainerRegistry
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/containerRegistryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/containerRegistryId'
       tags:
         - Container Registries
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerRegistryRequest"
+              $ref: '#/components/schemas/ContainerRegistryRequest'
       responses:
-        "200":
+        '200':
           description: Edited the container registry
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerRegistryResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/containerRegistry/{containerRegistryId}/images":
+                $ref: '#/components/schemas/ContainerRegistryResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/containerRegistry/{containerRegistryId}/images':
     get:
       summary: List image version for a container registry
       operationId: getContainerVersions
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/containerRegistryId"
-        - $ref: "#/components/parameters/imageName"
-        - $ref: "#/components/parameters/searchImageName"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/containerRegistryId'
+        - $ref: '#/components/parameters/imageName'
+        - $ref: '#/components/parameters/searchImageName'
       tags:
         - Container Registries
       responses:
-        "200":
+        '200':
           description: The container registry versions list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerVersionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/containerRegistry/{containerRegistryId}/container/status":
+                $ref: '#/components/schemas/ContainerVersionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/containerRegistry/{containerRegistryId}/container/status':
     get:
       summary: List all container registry container statuses
       description: Returns a list of containers with only their id and status.
       operationId: getContainerRegistryContainerStatus
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/containerRegistryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/containerRegistryId'
       tags:
         - Containers
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /availableContainerRegistry:
     get:
       summary: List supported container registries
@@ -3860,18 +3860,18 @@ paths:
       tags:
         - Container Registries
       responses:
-        "200":
+        '200':
           description: supported container registries
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AvailableContainerRegistryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AvailableContainerRegistryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /availableHelmRepository:
     get:
       summary: List supported helm repository
@@ -3880,420 +3880,420 @@ paths:
       tags:
         - Helm Repositories
       responses:
-        "200":
+        '200':
           description: supported helm repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AvailableHelmRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/helmRepository":
+                $ref: '#/components/schemas/AvailableHelmRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/helmRepository':
     get:
       summary: List organization helm repositories
       operationId: listHelmRepository
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Helm Repositories
       responses:
-        "200":
+        '200':
           description: List helm repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a helm repository
       operationId: createHelmRepository
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Helm Repositories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmRepositoryRequest"
+              $ref: '#/components/schemas/HelmRepositoryRequest'
       responses:
-        "201":
+        '201':
           description: Create a helm repository
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmRepositoryResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/helmRepository/{helmRepositoryId}":
+                $ref: '#/components/schemas/HelmRepositoryResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/helmRepository/{helmRepositoryId}':
     get:
       summary: Get a helm repository
       operationId: getHelmRepository
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/helmRepositoryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/helmRepositoryId'
       tags:
         - Helm Repositories
       responses:
-        "200":
+        '200':
           description: The helm repository
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmRepositoryResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmRepositoryResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a helm repository
       operationId: deleteHelmRepository
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/helmRepositoryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/helmRepositoryId'
       tags:
         - Helm Repositories
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a helm repository
       operationId: editHelmRepository
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/helmRepositoryId"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/helmRepositoryId'
       tags:
         - Helm Repositories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmRepositoryRequest"
+              $ref: '#/components/schemas/HelmRepositoryRequest'
       responses:
-        "200":
+        '200':
           description: Edited the helm repository
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmRepositoryResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/helmRepository/{helmRepositoryId}/charts":
+                $ref: '#/components/schemas/HelmRepositoryResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/helmRepository/{helmRepositoryId}/charts':
     get:
       summary: List helm charts contained inside the repository
       operationId: getHelmCharts
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/helmRepositoryId"
-        - $ref: "#/components/parameters/chartName"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/helmRepositoryId'
+        - $ref: '#/components/parameters/chartName'
       tags:
         - Helm Repositories
       responses:
-        "200":
+        '200':
           description: The helm repository versions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmVersionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}":
+                $ref: '#/components/schemas/HelmVersionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}':
     get:
       summary: Get project by ID
       operationId: getProject
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Main Calls
       responses:
-        "200":
+        '200':
           description: Get project by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Project"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/Project'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a project
       description: To edit a project you must have the admin permission
       operationId: editProject
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProjectRequest"
+              $ref: '#/components/schemas/ProjectRequest'
       responses:
-        "200":
+        '200':
           description: Edit a project
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Project"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Project'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Project name within the organization is already taken
     delete:
       summary: Delete a project
       description: To delete a project you must have the admin permission
       operationId: deleteProject
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/deploymentRule":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/deploymentRule':
     get:
       summary: List project deployment rules
       description: List project deployment rules
       operationId: listProjectDeploymentRules
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Deployment Rule
       responses:
-        "200":
+        '200':
           description: Get project deployment rules
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectDeploymentRuleResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ProjectDeploymentRuleResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a deployment rule
       description: Create a deployment rule
       operationId: createDeploymentRule
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProjectDeploymentRuleRequest"
+              $ref: '#/components/schemas/ProjectDeploymentRuleRequest'
       responses:
-        "201":
+        '201':
           description: Create deployment rule
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectDeploymentRule"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/deploymentRule/{deploymentRuleId}":
+                $ref: '#/components/schemas/ProjectDeploymentRule'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/deploymentRule/{deploymentRuleId}':
     get:
       summary: Get a project deployment rule
       description: Get a project deployment rule
       operationId: getProjectDeploymentRule
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/deploymentRuleId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/deploymentRuleId'
       tags:
         - Project Deployment Rule
       responses:
-        "200":
+        '200':
           description: Get project deployment rule
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectDeploymentRule"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ProjectDeploymentRule'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a project deployment rule
       description: Edit a project deployment rule
       operationId: editProjectDeployemtnRule
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/deploymentRuleId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/deploymentRuleId'
       tags:
         - Project Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProjectDeploymentRuleRequest"
+              $ref: '#/components/schemas/ProjectDeploymentRuleRequest'
       responses:
-        "200":
+        '200':
           description: Edit a project deployment rule
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectDeploymentRule"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ProjectDeploymentRule'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a project deployment rule
       description: Delete a project deployment rule
       operationId: deleteProjectDeploymentRule
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/deploymentRuleId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/deploymentRuleId'
       tags:
         - Project Deployment Rule
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/deploymentRule/order":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/deploymentRule/order':
     put:
       summary: Update deployment rules priority order
       description: Update deployment rules priority order
       operationId: updateDeploymentRulesPriorityOrder
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProjectDeploymentRulesPriorityOrderRequest"
+              $ref: '#/components/schemas/ProjectDeploymentRulesPriorityOrderRequest'
       responses:
-        "200":
+        '200':
           description: Update deployment rules priority order
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environment":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environment':
     get:
       summary: List environments
       operationId: listEnvironment
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Environments
       responses:
-        "200":
+        '200':
           description: List environments
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnvironmentResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an environment
       operationId: createEnvironment
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Environments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateEnvironmentRequest"
+              $ref: '#/components/schemas/CreateEnvironmentRequest'
       responses:
-        "201":
+        '201':
           description: Create environment
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Environment"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Environment'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Environment name within the project is already taken
-  "/project/{projectId}/environmentVariable":
+  '/project/{projectId}/environmentVariable':
     post:
       summary: Add an environment variable to the project
       description: |
@@ -4302,50 +4302,50 @@ paths:
           - If the environment variable value points toward an existing environment variable key, it will be considered as an alias.
       operationId: createProjectEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableRequest"
+              $ref: '#/components/schemas/EnvironmentVariableRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     get:
       summary: List project environment variables
       operationId: listProjectEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Environment Variable
       responses:
-        "200":
+        '200':
           description: List project environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariableResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environmentVariable/{environmentVariableId}":
+                $ref: '#/components/schemas/EnvironmentVariableResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environmentVariable/{environmentVariableId}':
     delete:
       summary: Delete an environment variable from a project
       description: |
@@ -4354,19 +4354,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteProjectEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Project Environment Variable
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an environment variable belonging to the project
       description: |
@@ -4376,8 +4376,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editProjectEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Project Environment Variable
       requestBody:
@@ -4385,23 +4385,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
+              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environmentVariable/{environmentVariableId}/override":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environmentVariable/{environmentVariableId}/override':
     post:
       summary: Create an environment variable override at the project level
       description: |
@@ -4412,31 +4412,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createProjectEnvironmentVariableOverride
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Project Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environmentVariable/{environmentVariableId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environmentVariable/{environmentVariableId}/alias':
     post:
       summary: Create an environment variable alias at the project level
       description: |
@@ -4448,51 +4448,51 @@ paths:
         - You can't create an alias on an alias
       operationId: createProjectEnvironmentVariableAlias
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Project Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/secret":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/secret':
     get:
       summary: List project secrets
       operationId: listProjectSecrets
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Secret
       responses:
-        "200":
+        '200':
           description: List project secrets
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SecretResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/SecretResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add a secret to the project
       description: |
@@ -4501,30 +4501,30 @@ paths:
           - If the secret value points toward an existing secret key, it will be considered as an alias.
       operationId: createProjectSecret
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Project Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretRequest"
+              $ref: '#/components/schemas/SecretRequest'
       responses:
-        "201":
+        '201':
           description: Added a secret
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/secret/{secretId}":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/secret/{secretId}':
     delete:
       summary: Delete a secret from a project
       description: |
@@ -4533,19 +4533,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well  operationId: deleteProjectSecret
       operationId: deleteProjectSecret
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Project Secret
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a secret belonging to the project
       description: |
@@ -4555,8 +4555,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editProjectSecret
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Project Secret
       requestBody:
@@ -4564,23 +4564,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretEditRequest"
+              $ref: '#/components/schemas/SecretEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/secret/{secretId}/override":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/secret/{secretId}/override':
     post:
       summary: Create a secret override at the project level
       description: |
@@ -4591,31 +4591,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createProjectSecretOverride
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Project Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/secret/{secretId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/secret/{secretId}/alias':
     post:
       summary: Create a secret alias at the project level
       description: |
@@ -4627,343 +4627,343 @@ paths:
         - You can't create an alias on an alias
       operationId: createProjectSecretAlias
       parameters:
-        - $ref: "#/components/parameters/projectId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Project Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environment/status":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environment/status':
     get:
       summary: List environments statuses
       description: Returns a list of environments with only their id and status.
       operationId: getProjectEnvironmentsStatus
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Environments
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatusList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environment/stats":
+                $ref: '#/components/schemas/EnvironmentStatusList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environment/stats':
     get:
       summary: List total number of services for each environment of the project
-      description: "Returns a list of environment ids, and for each its total numberof services"
+      description: 'Returns a list of environment ids, and for each its total numberof services'
       operationId: getProjectEnvironmentServiceNumber
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Environments
       responses:
-        "200":
+        '200':
           description: Get number of services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/project/{projectId}/environmentOverview":
+                $ref: '#/components/schemas/EnvironmentStatsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/project/{projectId}/environmentOverview':
     get:
       summary: List environments overview
-      description: "Returns a list of environments with their overview information including deployment status, service count, and cluster details."
+      description: 'Returns a list of environments with their overview information including deployment status, service count, and cluster details.'
       operationId: getProjectEnvironmentsOverview
       parameters:
-        - $ref: "#/components/parameters/projectId"
+        - $ref: '#/components/parameters/projectId'
       tags:
         - Environments
       responses:
-        "200":
+        '200':
           description: List environments overview
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentOverviewResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}":
+                $ref: '#/components/schemas/EnvironmentOverviewResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}':
     get:
       summary: Get environment by ID
       operationId: getEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: Get environment by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Environment"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/Environment'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an environment
       description: To edit an environment you must have the admin permission
       operationId: editEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentEditRequest"
+              $ref: '#/components/schemas/EnvironmentEditRequest'
       responses:
-        "200":
+        '200':
           description: Edit an environment
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Environment"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Environment'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Environment name within the project is already taken
     delete:
       summary: Delete an environment
       description: To delete an environment you must have the admin permission
       operationId: deleteEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/status":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/status':
     get:
       summary: Get environment status
       operationId: getEnvironmentStatus
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/statuses":
+                $ref: '#/components/schemas/EnvironmentStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/statuses':
     get:
       summary: Get environment statuses with services status
       operationId: getEnvironmentStatuses
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: Get statuses
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatuses"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/statusesWithStages":
+                $ref: '#/components/schemas/EnvironmentStatuses'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/statusesWithStages':
     get:
       summary: Get environment statuses with stages
       operationId: getEnvironmentStatusesWithStages
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: Get statuses with stages
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatusesWithStages"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploymentStage":
+                $ref: '#/components/schemas/EnvironmentStatusesWithStages'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploymentStage':
     get:
       summary: List environment deployment stage
       operationId: ListEnvironmentDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "200":
+        '200':
           description: List deployment stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentStageResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create environment deployment stage
       operationId: CreateEnvironmentDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Deployment Stage Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeploymentStageRequest"
+              $ref: '#/components/schemas/DeploymentStageRequest'
       responses:
-        "200":
+        '200':
           description: created deployment stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/deploymentStage/{deploymentStageId}":
+                $ref: '#/components/schemas/DeploymentStageResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/deploymentStage/{deploymentStageId}':
     get:
       summary: Get Deployment Stage
       operationId: getDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/deploymentStageId"
+        - $ref: '#/components/parameters/deploymentStageId'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "200":
+        '200':
           description: Get Deployment Stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentStageResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete deployment stage
       operationId: DeleteDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/deploymentStageId"
+        - $ref: '#/components/parameters/deploymentStageId'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit deployment stage
       operationId: EditDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/deploymentStageId"
+        - $ref: '#/components/parameters/deploymentStageId'
       tags:
         - Deployment Stage Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeploymentStageRequest"
+              $ref: '#/components/schemas/DeploymentStageRequest'
       responses:
-        "200":
+        '200':
           description: created deployment stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/deploymentStage/{deploymentStageId}/service/{serviceId}":
+                $ref: '#/components/schemas/DeploymentStageResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/deploymentStage/{deploymentStageId}/service/{serviceId}':
     put:
       summary: Attach service to deployment stage
-      description: "Moves the service to the specified deployment stage. To skip a service from environment-level deployments while keeping it in its current stage, set `is_skipped: true` in the request body. Moving the service to a different stage automatically un-skips it (sets `is_skipped: false`)."
+      description: 'Moves the service to the specified deployment stage. To skip a service from environment-level deployments while keeping it in its current stage, set `is_skipped: true` in the request body. Moving the service to a different stage automatically un-skips it (sets `is_skipped: false`).'
       operationId: AttachServiceToDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/deploymentStageId"
-        - $ref: "#/components/parameters/serviceId"
+        - $ref: '#/components/parameters/deploymentStageId'
+        - $ref: '#/components/parameters/serviceId'
       requestBody:
         content:
           application/json:
@@ -4972,164 +4972,164 @@ paths:
               properties:
                 is_skipped:
                   type: boolean
-                  description: "When true, marks the service as skipped (excluded from environment-level bulk deployments) while keeping it in the specified stage. When false or omitted, the service is moved to the specified stage and un-skipped."
+                  description: 'When true, marks the service as skipped (excluded from environment-level bulk deployments) while keeping it in the specified stage. When false or omitted, the service is moved to the specified stage and un-skipped.'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "200":
+        '200':
           description: List of deployment stages for the env
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/deploymentStage/{deploymentStageId}/moveBefore/{stageId}":
+                $ref: '#/components/schemas/DeploymentStageResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/deploymentStage/{deploymentStageId}/moveBefore/{stageId}':
     put:
       summary: Move deployment stage before requested stage
       operationId: MoveBeforeDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/deploymentStageId"
-        - $ref: "#/components/parameters/stageId"
+        - $ref: '#/components/parameters/deploymentStageId'
+        - $ref: '#/components/parameters/stageId'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "200":
+        '200':
           description: List deployment stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/deploymentStage/{deploymentStageId}/moveAfter/{stageId}":
+                $ref: '#/components/schemas/DeploymentStageResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/deploymentStage/{deploymentStageId}/moveAfter/{stageId}':
     put:
       summary: Move deployment stage after requested stage
       operationId: MoveAfterDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/deploymentStageId"
-        - $ref: "#/components/parameters/stageId"
+        - $ref: '#/components/parameters/deploymentStageId'
+        - $ref: '#/components/parameters/stageId'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "200":
+        '200':
           description: List deployment stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploymentRule":
+                $ref: '#/components/schemas/DeploymentStageResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploymentRule':
     get:
       summary: Get environment deployment rule
       operationId: getEnvironmentDeploymentRule
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Deployment Rule
       responses:
-        "200":
+        '200':
           description: Get deployment rule
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentDeploymentRule"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploymentRule/{deploymentRuleId}":
+                $ref: '#/components/schemas/EnvironmentDeploymentRule'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploymentRule/{deploymentRuleId}':
     put:
       summary: Edit an environment deployment rule
       operationId: editEnvironmentDeploymentRule
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/deploymentRuleId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/deploymentRuleId'
       tags:
         - Environment Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentDeploymentRuleEditRequest"
+              $ref: '#/components/schemas/EnvironmentDeploymentRuleEditRequest'
       responses:
-        "200":
+        '200':
           description: Edit environment deployment rule
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentDeploymentRule"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploy":
+                $ref: '#/components/schemas/EnvironmentDeploymentRule'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploy':
     post:
       summary: Deploy environment
       description: This will deploy all the services of this environment to their latest version.
       operationId: deployEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       responses:
-        "202":
+        '202':
           description: Deploy environment
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/uninstall":
+  '/environment/{environmentId}/uninstall':
     post:
       summary: Uninstall environment
       description: This will uninstall all the services of this environment.
       operationId: uninstallEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       responses:
-        "202":
+        '202':
           description: uninstall environment
           content:
             application/json:
               schema:
                 type: object
                 properties: {}
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: g57d57j59zihv
@@ -5139,75 +5139,75 @@ paths:
         name: environmentId
         in: path
         required: true
-  "/environment/{environmentId}/stop":
+  '/environment/{environmentId}/stop':
     post:
       summary: Stop environment
       operationId: stopEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       responses:
-        "202":
+        '202':
           description: Environment stop has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/EnvironmentStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Environment is already stopped or an operation is in progress
-  "/environment/{environmentId}/redeploy":
+  '/environment/{environmentId}/redeploy':
     post:
       summary: Redeploy environment
       operationId: redeployEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       responses:
-        "202":
+        '202':
           description: Environment redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/EnvironmentStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/cancelDeployment":
+  '/environment/{environmentId}/cancelDeployment':
     post:
       summary: Cancel environment deployment
       description: Cancel the current deployment of your environment.
       operationId: cancelEnvironmentDeployment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       responses:
-        "202":
+        '202':
           description: environment deployment cancelling has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatus"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/EnvironmentStatus'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Environment deployment is already cancelled or an operation is in progress
       requestBody:
         content:
@@ -5221,7 +5221,7 @@ paths:
                     id: c5k0n6yafpsig
                   default: false
                   description: Force cancel everything running in this environment if set to true (e.q lifecycle jobs triggered during the deployment).
-  "/deploymentQueue/{deploymentRequestId}/cancelDeployment":
+  '/deploymentQueue/{deploymentRequestId}/cancelDeployment':
     post:
       summary: Cancel deployment request
       description: Cancel the a deployment request.
@@ -5229,16 +5229,16 @@ paths:
       tags:
         - Deployment Queue Actions
       responses:
-        "202":
+        '202':
           description: deployment request cancelling has been requested
           content: {}
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Deployment request is already cancelled or an operation is in progress
       requestBody:
         content:
@@ -5255,322 +5255,322 @@ paths:
         name: deploymentRequestId
         in: path
         required: true
-  "/environment/{environmentId}/clone":
+  '/environment/{environmentId}/clone':
     post:
       summary: Clone environment
-      description: "You must provide a name. This will create a new environment, with the same configuration, and same applications and databases. Database data is not cloned."
+      description: 'You must provide a name. This will create a new environment, with the same configuration, and same applications and databases. Database data is not cloned.'
       operationId: cloneEnvironment
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneEnvironmentRequest"
+              $ref: '#/components/schemas/CloneEnvironmentRequest'
       responses:
-        "202":
+        '202':
           description: Environment clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Environment"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Environment'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/application":
+  '/environment/{environmentId}/application':
     get:
       summary: List applications
       operationId: listApplication
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1'
       tags:
         - Applications
       responses:
-        "200":
+        '200':
           description: List applications
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ApplicationResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an application
       operationId: createApplication
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Applications
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationRequest"
+              $ref: '#/components/schemas/ApplicationRequest'
       responses:
-        "201":
+        '201':
           description: Create application
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Application"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Application'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Application name within the environment is already taken
-  "/environment/{environmentId}/application/status":
+  '/environment/{environmentId}/application/status':
     get:
       summary: List all environment applications statuses
       description: Returns a list of applications with only their id and status.
       operationId: getEnvironmentApplicationStatus
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Applications
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/container":
+                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/container':
     get:
       summary: List containers
       operationId: listContainer
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Containers
       responses:
-        "200":
+        '200':
           description: List containers
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ContainerResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a container
       operationId: createContainer
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerRequest"
+              $ref: '#/components/schemas/ContainerRequest'
       responses:
-        "201":
+        '201':
           description: Create container
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/ContainerResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Container name within the environment is already taken
-  "/environment/{environmentId}/container/status":
+  '/environment/{environmentId}/container/status':
     get:
       summary: List all environment container statuses
       description: Returns a list of containers with only their id and status.
       operationId: getEnvironmentContainerStatus
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Containers
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/service/deploy":
+                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/service/deploy':
     post:
       summary: Deploy services
       description: Update and deploy the selected services
       operationId: deployAllServices
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeployAllRequest"
+              $ref: '#/components/schemas/DeployAllRequest'
       responses:
-        "202":
+        '202':
           description: Deployed services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentStatus"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/EnvironmentStatus'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/service/restart-service":
+  '/environment/{environmentId}/service/restart-service':
     post:
       summary: Reboot services
       description: Update and reboot the selected services
       operationId: rebootServices
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RebootServicesRequest"
+              $ref: '#/components/schemas/RebootServicesRequest'
       responses:
-        "202":
+        '202':
           description: Reboot services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/service/stop":
+  '/environment/{environmentId}/service/stop':
     post:
       summary: Stop services
       description: Stop selected services
       operationId: stopSelectedServices
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentServiceIdsAllRequest"
+              $ref: '#/components/schemas/EnvironmentServiceIdsAllRequest'
       responses:
-        "200":
+        '200':
           description: Services have been triggered to be deleted
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/service/delete":
+  '/environment/{environmentId}/service/delete':
     post:
       summary: Delete services
       description: Delete selected services
       operationId: deleteSelectedServices
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentServiceIdsAllRequest"
+              $ref: '#/components/schemas/EnvironmentServiceIdsAllRequest'
       responses:
-        "200":
+        '200':
           description: Services have been triggered to be deleted
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/service/uninstall":
+  '/environment/{environmentId}/service/uninstall':
     post:
       summary: Uninstall services
       description: uninstall selected services
       operationId: uninstallSelectedServices
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentServiceIdsAllRequest"
+              $ref: '#/components/schemas/EnvironmentServiceIdsAllRequest'
       responses:
-        "200":
+        '200':
           description: Services have been triggered to be uninstalled
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: m4lfkqr1n8s97
@@ -5580,7 +5580,7 @@ paths:
         name: environmentId
         in: path
         required: true
-  "/organization/{organizationId}/container/deploy":
+  '/organization/{organizationId}/container/deploy':
     post:
       summary: Auto deploy containers
       description: |
@@ -5589,32 +5589,32 @@ paths:
         - the container should have the same image name and a different tag
       operationId: autoDeployContainerEnvironments
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationContainerAutoDeployRequest"
+              $ref: '#/components/schemas/OrganizationContainerAutoDeployRequest'
       responses:
-        "202":
+        '202':
           description: Deployed containers
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/organization/{organizationId}/container/preview":
+  '/organization/{organizationId}/container/preview':
     post:
       summary: Preview container environments
       description: |
@@ -5623,32 +5623,32 @@ paths:
         - the container should have the same image name and a different tag
       operationId: previewContainerEnvironments
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationContainerPreviewRequest"
+              $ref: '#/components/schemas/OrganizationContainerPreviewRequest'
       responses:
-        "202":
+        '202':
           description: Preview environments processing
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/organization/{organizationId}/job/deploy":
+  '/organization/{organizationId}/job/deploy':
     post:
       summary: Auto deploy jobs
       description: |
@@ -5657,60 +5657,60 @@ paths:
         - the job should have the same image name and a different tag
       operationId: autoDeployJobEnvironments
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Jobs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationJobAutoDeployRequest"
+              $ref: '#/components/schemas/OrganizationJobAutoDeployRequest'
       responses:
-        "202":
+        '202':
           description: Deployed jobs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/log":
+  '/environment/{environmentId}/log':
     get:
       summary: List environment deployment logs
       operationId: listEnvironmentLog
       description: This returns the last 1000 environment deployment logs.
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Logs
       responses:
-        "200":
+        '200':
           description: List logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentLogResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/logs":
+                $ref: '#/components/schemas/EnvironmentLogResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/logs':
     get:
       summary: List environment deployment logs v2
       operationId: listEnvironmentLogs
       description: This returns the last 1000 environment deployment logs v2
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
         - in: query
           name: version
           schema:
@@ -5718,45 +5718,45 @@ paths:
       tags:
         - Environment Logs
       responses:
-        "200":
+        '200':
           description: List logs v2
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentLogsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploymentHistory":
+                $ref: '#/components/schemas/EnvironmentLogsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploymentHistory':
     get:
       summary: List environment deployments
-      description: "List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter"
+      description: 'List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter'
       operationId: listEnvironmentDeploymentHistory
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/startId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/startId'
       tags:
         - Environment Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploymentHistoryV2":
+                $ref: '#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploymentHistoryV2':
     get:
       summary: List environment deployments
-      description: "List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter"
+      description: 'List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter'
       operationId: listEnvironmentDeploymentHistoryV2
       parameters:
         - in: query
@@ -5769,18 +5769,18 @@ paths:
       tags:
         - Environment Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: pqsu5pghhay1j
     parameters:
@@ -5790,56 +5790,56 @@ paths:
         name: environmentId
         in: path
         required: true
-  "/environment/{environmentId}/deploymentBuildUsageReport":
+  '/environment/{environmentId}/deploymentBuildUsageReport':
     post:
       summary: Generate a Grafana snapshot report showing build runner pod usage for a specific deployment
       description: Generate a Grafana snapshot report that shows the resource usage (CPU, memory) of build runner pods for a specific deployment execution. The report is publicly accessible for the specified duration.
       operationId: generateDeploymentBuildUsageReport
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Deployment History
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeploymentBuildUsageReportRequest"
+              $ref: '#/components/schemas/DeploymentBuildUsageReportRequest'
       responses:
-        "201":
+        '201':
           description: Build usage report snapshot has been successfully generated
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentBuildUsageReportResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/environmentVariable":
+                $ref: '#/components/schemas/DeploymentBuildUsageReportResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/environmentVariable':
     get:
       summary: List environment variables
       operationId: listEnvironmentEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Variable
       responses:
-        "200":
+        '200':
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariableResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnvironmentVariableResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add an environment variable to the environment
       description: |
@@ -5848,30 +5848,30 @@ paths:
           - If the environment variable value points toward an existing environment variable key, it will be considered as an alias.
       operationId: createEnvironmentEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableRequest"
+              $ref: '#/components/schemas/EnvironmentVariableRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/environmentVariable/{environmentVariableId}":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/environmentVariable/{environmentVariableId}':
     delete:
       summary: Delete an environment variable from an environment
       description: |
@@ -5880,19 +5880,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteEnvironmentEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Environment Variable
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an environment variable belonging to the environment
       description: |
@@ -5902,8 +5902,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editEnvironmentEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Environment Variable
       requestBody:
@@ -5911,23 +5911,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
+              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/environmentVariable/{environmentVariableId}/override":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/environmentVariable/{environmentVariableId}/override':
     post:
       summary: Create an environment variable override at the environment level
       description: |
@@ -5938,31 +5938,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createEnvironmentEnvironmentVariableOverride
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/environmentVariable/{environmentVariableId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/environmentVariable/{environmentVariableId}/alias':
     post:
       summary: Create an environment variable alias at the environment level
       description: |
@@ -5974,51 +5974,51 @@ paths:
         - You can't create an alias on an alias
       operationId: createEnvironmentEnvironmentVariableAlias
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/secret":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/secret':
     get:
       summary: List environment secrets
       operationId: listEnvironmentSecrets
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Secret
       responses:
-        "200":
+        '200':
           description: List environment secrets
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SecretResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/SecretResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add a secret to the environment
       description: |
@@ -6027,30 +6027,30 @@ paths:
           - If the secret value points toward an existing secret key, it will be considered as an alias.
       operationId: createEnvironmentSecret
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretRequest"
+              $ref: '#/components/schemas/SecretRequest'
       responses:
-        "201":
+        '201':
           description: Added a secret
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/secret/{secretId}":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/secret/{secretId}':
     delete:
       summary: Delete a secret from the environment
       description: |
@@ -6059,19 +6059,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well  operationId: deleteEnvironmentSecret
       operationId: deleteEnvironmentSecret
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Environment Secret
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a secret belonging to the environment
       description: |
@@ -6081,8 +6081,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editEnvironmentSecret
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Environment Secret
       requestBody:
@@ -6090,23 +6090,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretEditRequest"
+              $ref: '#/components/schemas/SecretEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/secret/{secretId}/override":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/secret/{secretId}/override':
     post:
       summary: Create a secret override at the environment level
       description: |
@@ -6117,31 +6117,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createEnvironmentSecretOverride
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Environment Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/secret/{secretId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/secret/{secretId}/alias':
     post:
       summary: Create a secret alias at the environment level
       description: |
@@ -6153,57 +6153,57 @@ paths:
         - You can't create an alias on an alias
       operationId: createEnvironmentSecretAlias
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Environment Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/databaseConfiguration":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/databaseConfiguration':
     get:
-      summary: "List eligible database types, versions and modes for the environment"
+      summary: 'List eligible database types, versions and modes for the environment'
       operationId: listEnvironmentDatabaseConfig
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Databases
       responses:
-        "200":
+        '200':
           description: List eligible database
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DatabaseConfigurationResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/terraformExport":
+                $ref: '#/components/schemas/DatabaseConfigurationResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/terraformExport':
     get:
       summary: Export full environment and its resources into Terraform manifests
       operationId: exportEnvironmentConfigurationIntoTerraform
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
         - name: exportSecrets
           in: query
           description: export Secrets from configuration and include them into Terraform export
@@ -6214,91 +6214,91 @@ paths:
       tags:
         - Environment Export
       responses:
-        "200":
+        '200':
           description: Export full environment and its resources into Terraform manifests (ZIP file)
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /defaultApplicationAdvancedSettings:
     get:
       summary: List default application advanced settings
       operationId: getDefaultApplicationAdvancedSettings
-      description: "Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)"
+      description: 'Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)'
       tags:
         - Applications
       responses:
-        "200":
+        '200':
           description: Default application advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/ApplicationAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
   /defaultClusterAdvancedSettings:
     get:
       summary: List default cluster advanced settings
-      description: "Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/cluster-advanced-settings/)"
+      description: 'Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/cluster-advanced-settings/)'
       operationId: getDefaultClusterAdvancedSettings
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: Default cluster advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/ClusterAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
   /defaultContainerAdvancedSettings:
     get:
       summary: List default container advanced settings
-      description: "Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)"
+      description: 'Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)'
       operationId: getDefaultContainerAdvancedSettings
       tags:
         - Containers
       responses:
-        "200":
+        '200':
           description: Default container advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/ContainerAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
   /defaultJobAdvancedSettings:
     get:
       summary: List default job advanced settings
-      description: "Default values for each setting is available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)"
+      description: 'Default values for each setting is available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)'
       operationId: getDefaultJobAdvancedSettings
       tags:
         - Jobs
       responses:
-        "200":
+        '200':
           description: Default job advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/JobAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
   /defaultHelmAdvancedSettings:
     get:
       summary: List default helm advanced settings
@@ -6306,37 +6306,37 @@ paths:
       tags:
         - Helms
       responses:
-        "200":
+        '200':
           description: Default helm advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-  "/application/{applicationId}":
+                $ref: '#/components/schemas/HelmAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+  '/application/{applicationId}':
     get:
       summary: Get application by ID
       operationId: getApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Main Calls
       responses:
-        "200":
+        '200':
           description: Get application by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Application"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/Application'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit application
       description: |
@@ -6345,251 +6345,251 @@ paths:
         - For storage edition, if you provide a storage id, we will update the corresponding storage. If you don't we will create a new one. If you remove a storage from the payload, we will delete it.
       operationId: editApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationEditRequest"
+              $ref: '#/components/schemas/ApplicationEditRequest'
       responses:
-        "200":
+        '200':
           description: Edit application
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Application"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Application'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Application name within the environment is already taken
     delete:
       summary: Delete application
       description: To delete the application you must have the admin permission
       operationId: deleteApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/status":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/status':
     get:
       summary: Get application status
       operationId: getApplicationStatus
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Main Calls
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/deploymentRestriction":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/deploymentRestriction':
     get:
       summary: Get application deployment restrictions
       description: Get application deployment restrictions
       operationId: getApplicationDeploymentRestrictions
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Deployment Restriction
       responses:
-        "200":
+        '200':
           description: Get application deployment restrictions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationDeploymentRestrictionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ApplicationDeploymentRestrictionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create an application deployment restriction
       description: Create an application deployment restriction
       operationId: createApplicationDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/ApplicationDeploymentRestrictionRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationDeploymentRestriction"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "409":
+                $ref: '#/components/schemas/ApplicationDeploymentRestriction'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '409':
           description: An application deployment restriction with same properties already exists for this application
-  "/application/{applicationId}/deploymentRestriction/{deploymentRestrictionId}":
+  '/application/{applicationId}/deploymentRestriction/{deploymentRestrictionId}':
     put:
       summary: Edit an application deployment restriction
       description: Edit an application deployment restriction
       operationId: editApplicationDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/deploymentRestrictionId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/deploymentRestrictionId'
       tags:
         - Application Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/ApplicationDeploymentRestrictionRequest'
       responses:
-        "200":
+        '200':
           description: Edit an application deployment restriction
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationDeploymentRestriction"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ApplicationDeploymentRestriction'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete an application deployment restriction
       description: Delete an application deployment restriction
       operationId: deleteApplicationDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/deploymentRestrictionId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/deploymentRestrictionId'
       tags:
         - Application Deployment Restriction
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/contributor":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/contributor':
     get:
       summary: List contributors
       operationId: listApplicationContributor
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Main Calls
       responses:
-        "200":
+        '200':
           description: List application contributors
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/commit":
+                $ref: '#/components/schemas/UserResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/commit':
     get:
       summary: List last commits
       description: Returns list of the last 100 commits made on the repository linked to the application
       operationId: listApplicationCommit
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/startId"
-        - $ref: "#/components/parameters/gitCommitId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/startId'
+        - $ref: '#/components/parameters/gitCommitId'
       tags:
         - Application Main Calls
       responses:
-        "200":
+        '200':
           description: List commits
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CommitResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/deploy":
+                $ref: '#/components/schemas/CommitResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/deploy':
     post:
       summary: Deploy application
       description: You must provide a git commit id
       operationId: deployApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeployRequest"
+              $ref: '#/components/schemas/DeployRequest'
       responses:
-        "202":
+        '202':
           description: Deploy application
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/application/{applicationId}/uninstall":
+  '/application/{applicationId}/uninstall':
     post:
       summary: Uninstall application
       description: |
         Delete the resources of an application but keep the Qovery config.
       operationId: uninstallApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Actions
       requestBody:
@@ -6599,23 +6599,23 @@ paths:
               type: object
               properties: {}
       responses:
-        "202":
-          description: "Delete the compute and data of the service, but keep Qovery configuration"
+        '202':
+          description: 'Delete the compute and data of the service, but keep Qovery configuration'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "204":
+                $ref: '#/components/schemas/Status'
+        '204':
           description: No deployment has been triggered
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: vrnx0mllgta48
@@ -6625,102 +6625,102 @@ paths:
         name: applicationId
         in: path
         required: true
-  "/application/{applicationId}/stop":
+  '/application/{applicationId}/stop':
     post:
       summary: Stop application
       operationId: stopApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Actions
       responses:
-        "202":
+        '202':
           description: Application stop has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Application is already stopped or an operation is in progress
-  "/application/{applicationId}/redeploy":
+  '/application/{applicationId}/redeploy':
     post:
       summary: Redeploy application
       operationId: redeployApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Actions
       responses:
-        "202":
+        '202':
           description: Application redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/application/{applicationId}/restart-service":
+  '/application/{applicationId}/restart-service':
     post:
       summary: Reboot application
       operationId: rebootApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Actions
       responses:
-        "202":
+        '202':
           description: Application reboot has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/application/{applicationId}/deploymentHistory":
+  '/application/{applicationId}/deploymentHistory':
     get:
       summary: List application deploys
-      description: "By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id"
+      description: 'By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id'
       operationId: listApplicationDeploymentHistory
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/startId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/startId'
       tags:
         - Application Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryPaginatedResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/deploymentHistoryV2":
+                $ref: '#/components/schemas/DeploymentHistoryPaginatedResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/deploymentHistoryV2':
     get:
       summary: List application deploys
-      description: "By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id"
+      description: 'By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id'
       operationId: listApplicationDeploymentHistoryV2
       parameters:
         - in: query
@@ -6733,18 +6733,18 @@ paths:
       tags:
         - Application Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: 59xza5oe7uvet
     parameters:
@@ -6753,86 +6753,86 @@ paths:
         name: applicationId
         in: path
         required: true
-  "/application/{applicationId}/environmentVariable":
+  '/application/{applicationId}/environmentVariable':
     get:
       summary: List environment variables
       operationId: listApplicationEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Environment Variable
       responses:
-        "200":
+        '200':
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariableResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnvironmentVariableResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add an environment variable to the application
       description: |
         - Add an environment variable to the application.
       operationId: createApplicationEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableRequest"
+              $ref: '#/components/schemas/EnvironmentVariableRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/environmentVariable/import":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/environmentVariable/import':
     post:
       summary: Import variables
-      description: "Import environment variables in a defined scope, with a defined visibility."
+      description: 'Import environment variables in a defined scope, with a defined visibility.'
       operationId: importEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableImportRequest"
+              $ref: '#/components/schemas/VariableImportRequest'
       responses:
-        "201":
+        '201':
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableImport"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/environmentVariable/{environmentVariableId}":
+                $ref: '#/components/schemas/VariableImport'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/environmentVariable/{environmentVariableId}':
     delete:
       summary: Delete an environment variable from an application
       description: |
@@ -6841,19 +6841,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteApplicationEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Application Environment Variable
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an environment variable belonging to the application
       description: |
@@ -6863,8 +6863,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editApplicationEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Application Environment Variable
       requestBody:
@@ -6872,23 +6872,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
+              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/environmentVariable/{environmentVariableId}/override":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/environmentVariable/{environmentVariableId}/override':
     post:
       summary: Create an environment variable override at the application level
       description: |
@@ -6899,31 +6899,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createApplicationEnvironmentVariableOverride
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/environmentVariable/{environmentVariableId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/environmentVariable/{environmentVariableId}/alias':
     post:
       summary: Create an environment variable alias at the application level
       description: |
@@ -6935,82 +6935,82 @@ paths:
         - You can't create an alias on an alias
       operationId: createApplicationEnvironmentVariableAlias
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/secret":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/secret':
     get:
       summary: List application secrets
-      description: "Secrets are like environment variables, but they are secured and can't be revealed."
+      description: 'Secrets are like environment variables, but they are secured and can''t be revealed.'
       operationId: listApplicationSecrets
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Secret
       responses:
-        "200":
+        '200':
           description: List secrets
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SecretResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/SecretResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add a secret to the application
       description: |
         - Add a secret to the application.
       operationId: createApplicationSecret
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretRequest"
+              $ref: '#/components/schemas/SecretRequest'
       responses:
-        "201":
+        '201':
           description: Add a secret
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/secret/{secretId}":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/secret/{secretId}':
     delete:
       summary: Delete a secret from an application
       description: |
@@ -7019,19 +7019,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well
       operationId: deleteApplicationSecret
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Application Secret
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a secret belonging to the application
       description: |
@@ -7041,8 +7041,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editApplicationSecret
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Application Secret
       requestBody:
@@ -7050,23 +7050,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretEditRequest"
+              $ref: '#/components/schemas/SecretEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/secret/{secretId}/override":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/secret/{secretId}/override':
     post:
       summary: Create a secret override at the application level
       description: |
@@ -7077,31 +7077,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createApplicationSecretOverride
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Application Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/secret/{secretId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/secret/{secretId}/alias':
     post:
       summary: Create a secret alias at the application level
       description: |
@@ -7113,265 +7113,265 @@ paths:
         - You can't create an alias on an alias
       operationId: createApplicationSecretAlias
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Application Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/customDomain":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/customDomain':
     get:
       summary: List application custom domains
       operationId: listApplicationCustomDomain
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Custom Domain
       responses:
-        "200":
+        '200':
           description: List custom domains
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomainResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CustomDomainResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add custom domain to the application.
       description: Add a custom domain to this application in order not to use qovery autogenerated domain
       operationId: createApplicationCustomDomain
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CustomDomainRequest"
+              $ref: '#/components/schemas/CustomDomainRequest'
       responses:
-        "201":
+        '201':
           description: Added application custom domain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/customDomain/{customDomainId}":
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/customDomain/{customDomainId}':
     put:
       summary: Edit a Custom Domain
       description: To edit a Custom Domain you must have the project user permission
       operationId: editCustomDomain
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Application Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CustomDomainRequest"
+              $ref: '#/components/schemas/CustomDomainRequest'
       responses:
-        "200":
+        '200':
           description: Edit a CustomDomain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a Custom Domain
       description: To delete an CustomDomain you must have the project user permission
       operationId: deleteCustomDomain
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Application Custom Domain
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/customDomain/{customDomainId}/status":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/customDomain/{customDomainId}/status':
     get:
       summary: Get Custom Domain status
       operationId: getCustomDomainStatus
       parameters:
-        - $ref: "#/components/parameters/applicationId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/applicationId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Application Custom Domain
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/checkCustomDomain":
+                $ref: '#/components/schemas/CustomDomain'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/checkCustomDomain':
     get:
       summary: Check Application Custom Domain
       operationId: checkApplicationCustomDomain
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Custom Domain
       responses:
-        "200":
+        '200':
           description: Check Application Custom Domain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CheckedCustomDomainsResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/log":
+                $ref: '#/components/schemas/CheckedCustomDomainsResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/log':
     get:
       summary: List logs
       operationId: listApplicationLog
       description: This will list the last 1000 logs of the application
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Logs
       responses:
-        "200":
+        '200':
           description: List logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LogResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/network":
+                $ref: '#/components/schemas/LogResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/network':
     get:
       summary: Get Application Network information
       description: Get status of the application network settings.
       operationId: getApplicationNetwork
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Configuration
       responses:
-        "200":
+        '200':
           description: Network information
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationNetwork"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ApplicationNetwork'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit Application Network
       description: Edit the Network settings of the application.
       operationId: editApplicationNetwork
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationNetworkRequest"
+              $ref: '#/components/schemas/ApplicationNetworkRequest'
       responses:
-        "201":
+        '201':
           description: Updated application network setting
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationNetwork"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/link":
+                $ref: '#/components/schemas/ApplicationNetwork'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/link':
     get:
       summary: List all URLs of the application
       description: This will return all the custom domains and Qovery autogenerated domain for the given application
       operationId: listApplicationLinks
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Main Calls
       responses:
-        "200":
+        '200':
           description: List links
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LinkResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/advancedSettings":
+                $ref: '#/components/schemas/LinkResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/advancedSettings':
     get:
       summary: Get advanced settings
       description: |
@@ -7379,100 +7379,100 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)
       operationId: getAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Configuration
       responses:
-        "200":
+        '200':
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ApplicationAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Application Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationAdvancedSettings"
+              $ref: '#/components/schemas/ApplicationAdvancedSettings'
       responses:
-        "201":
+        '201':
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationAdvancedSettings"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/application/{applicationId}/clone":
+                $ref: '#/components/schemas/ApplicationAdvancedSettings'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/application/{applicationId}/clone':
     post:
       summary: Clone application
       description: This will create a new application with the same configuration on the targeted environment Id.
       operationId: cloneApplication
       parameters:
-        - $ref: "#/components/parameters/applicationId"
+        - $ref: '#/components/parameters/applicationId'
       tags:
         - Applications
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneServiceRequest"
+              $ref: '#/components/schemas/CloneServiceRequest'
       responses:
-        "202":
+        '202':
           description: Application clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Application"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Application'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/container/{containerId}":
+  '/container/{containerId}':
     get:
       summary: Get container by ID
       operationId: getContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Main Calls
       responses:
-        "200":
+        '200':
           description: Get container by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ContainerResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit container
       description: |
@@ -7481,105 +7481,105 @@ paths:
         - For storage edition, if you provide a storage id, we will update the corresponding storage. If you don't we will create a new one. If you remove a storage from the payload, we will delete it.
       operationId: editContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerRequest"
+              $ref: '#/components/schemas/ContainerRequest'
       responses:
-        "200":
+        '200':
           description: Edit container
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/ContainerResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Container name within the environment is already taken
     delete:
       summary: Delete container
       description: To delete the container you must have the admin permission
       operationId: deleteContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/status":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/status':
     get:
       summary: Get container status
       operationId: getContainerStatus
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Main Calls
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/deploymentHistory":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/deploymentHistory':
     get:
       summary: List container deployments
       description: Returns the 20 last container deployments
       operationId: listContainerDeploymentHistory
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/PaginationData"
+                  - $ref: '#/components/schemas/PaginationData'
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: "#/components/schemas/DeploymentHistoryContainer"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/deploymentHistoryV2":
+                          $ref: '#/components/schemas/DeploymentHistoryContainer'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/deploymentHistoryV2':
     get:
       summary: List container deployments
       description: Returns the 20 last container deployments
       operationId: listContainerDeploymentHistoryV2
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
         - in: query
           name: pageSize
           description: The number of deployments to return in the current page
@@ -7590,21 +7590,21 @@ paths:
       tags:
         - Container Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: qfy5ueb8cyebe
-  "/container/{containerId}/advancedSettings":
+  '/container/{containerId}/advancedSettings':
     get:
       summary: Get advanced settings
       description: |
@@ -7612,88 +7612,88 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)
       operationId: getContainerAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Configuration
       responses:
-        "200":
+        '200':
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ContainerAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editContainerAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerAdvancedSettings"
+              $ref: '#/components/schemas/ContainerAdvancedSettings'
       responses:
-        "201":
+        '201':
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerAdvancedSettings"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/deploy":
+                $ref: '#/components/schemas/ContainerAdvancedSettings'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/deploy':
     post:
       summary: Deploy container
       description: You must provide a container image tag
       operationId: deployContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerDeployRequest"
+              $ref: '#/components/schemas/ContainerDeployRequest'
       responses:
-        "202":
+        '202':
           description: Deploy container
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/container/{containerId}/uninstall":
+  '/container/{containerId}/uninstall':
     post:
       summary: Uninstall container
       description: Delete the resources of the container but keep Qovery configuration
       operationId: uninstallContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Actions
       requestBody:
@@ -7703,23 +7703,23 @@ paths:
               type: object
               properties: {}
       responses:
-        "202":
-          description: "Delete the compute and data of the service, but keep Qovery configuration"
+        '202':
+          description: 'Delete the compute and data of the service, but keep Qovery configuration'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "204":
+                $ref: '#/components/schemas/Status'
+        '204':
           description: No deployment has been triggered
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: tyqhmv3tdihmm
@@ -7729,155 +7729,155 @@ paths:
         name: containerId
         in: path
         required: true
-  "/container/{containerId}/stop":
+  '/container/{containerId}/stop':
     post:
       summary: Stop container
       operationId: stopContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Actions
       responses:
-        "202":
+        '202':
           description: Container stop has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Container is already stopped or an operation is in progress
-  "/container/{containerId}/redeploy":
+  '/container/{containerId}/redeploy':
     post:
       summary: Redeploy container
       operationId: redeployContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Actions
       responses:
-        "202":
+        '202':
           description: Container redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/container/{containerId}/restart-service":
+  '/container/{containerId}/restart-service':
     post:
       summary: Reboot container
       operationId: rebootContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Actions
       responses:
-        "202":
+        '202':
           description: Container reboot has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/container/{containerId}/environmentVariable":
+  '/container/{containerId}/environmentVariable':
     get:
       summary: List environment variables
       operationId: listContainerEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Environment Variable
       responses:
-        "200":
+        '200':
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariableResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnvironmentVariableResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add an environment variable to the container
       description: |
         - Add an environment variable to the container.
       operationId: createContainerEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableRequest"
+              $ref: '#/components/schemas/EnvironmentVariableRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/environmentVariable/import":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/environmentVariable/import':
     post:
       summary: Import variables
-      description: "Import environment variables in a defined scope, with a defined visibility."
+      description: 'Import environment variables in a defined scope, with a defined visibility.'
       operationId: importContainerEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableImportRequest"
+              $ref: '#/components/schemas/VariableImportRequest'
       responses:
-        "201":
+        '201':
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableImport"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/environmentVariable/{environmentVariableId}":
+                $ref: '#/components/schemas/VariableImport'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/environmentVariable/{environmentVariableId}':
     delete:
       summary: Delete an environment variable from a container
       description: |
@@ -7886,19 +7886,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteContainerEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Container Environment Variable
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an environment variable belonging to the container
       description: |
@@ -7908,8 +7908,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editContainerEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Container Environment Variable
       requestBody:
@@ -7917,23 +7917,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
+              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/environmentVariable/{environmentVariableId}/override":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/environmentVariable/{environmentVariableId}/override':
     post:
       summary: Create an environment variable override at the container level
       description: |
@@ -7944,31 +7944,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createContainerEnvironmentVariableOverride
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/environmentVariable/{environmentVariableId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/environmentVariable/{environmentVariableId}/alias':
     post:
       summary: Create an environment variable alias at the container level
       description: |
@@ -7980,82 +7980,82 @@ paths:
         - You can't create an alias on an alias
       operationId: createContainerEnvironmentVariableAlias
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/secret":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/secret':
     get:
       summary: List container secrets
-      description: "Secrets are like environment variables, but they are secured and can't be revealed."
+      description: 'Secrets are like environment variables, but they are secured and can''t be revealed.'
       operationId: listContainerSecrets
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Secret
       responses:
-        "200":
+        '200':
           description: List secrets
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SecretResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/SecretResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add a secret to the container
       description: |
         - Add a secret to the container.
       operationId: createContainerSecret
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretRequest"
+              $ref: '#/components/schemas/SecretRequest'
       responses:
-        "201":
+        '201':
           description: Add a secret
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/secret/{secretId}":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/secret/{secretId}':
     delete:
       summary: Delete a secret from an container
       description: |
@@ -8064,19 +8064,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well
       operationId: deleteContainerSecret
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Container Secret
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a secret belonging to the container
       description: |
@@ -8086,8 +8086,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editContainerSecret
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Container Secret
       requestBody:
@@ -8095,23 +8095,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretEditRequest"
+              $ref: '#/components/schemas/SecretEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/secret/{secretId}/override":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/secret/{secretId}/override':
     post:
       summary: Create a secret override at the container level
       description: |
@@ -8122,31 +8122,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createContainerSecretOverride
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Container Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/secret/{secretId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/secret/{secretId}/alias':
     post:
       summary: Create a secret alias at the container level
       description: |
@@ -8158,568 +8158,568 @@ paths:
         - You can't create an alias on an alias
       operationId: createContainerSecretAlias
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Container Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/customDomain":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/customDomain':
     get:
       summary: List container custom domains
       operationId: listContainerCustomDomain
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Custom Domain
       responses:
-        "200":
+        '200':
           description: List custom domains
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomainResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CustomDomainResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add custom domain to the container.
       description: Add a custom domain to this container in order not to use qovery autogenerated domain
       operationId: createContainerCustomDomain
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CustomDomainRequest"
+              $ref: '#/components/schemas/CustomDomainRequest'
       responses:
-        "201":
+        '201':
           description: Added container custom domain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/customDomain/{customDomainId}":
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/customDomain/{customDomainId}':
     put:
       summary: Edit a Custom Domain
       description: To edit a Custom Domain  you must have the project user permission
       operationId: editContainerCustomDomain
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Container Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CustomDomainRequest"
+              $ref: '#/components/schemas/CustomDomainRequest'
       responses:
-        "200":
+        '200':
           description: Edit a CustomDomain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a Custom Domain
       description: To delete an CustomDomain you must have the project user permission
       operationId: deleteContainerCustomDomain
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Container Custom Domain
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/customDomain/{customDomainId}/status":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/customDomain/{customDomainId}/status':
     get:
       summary: Get Custom Domain status
       operationId: getContainerCustomDomainStatus
       parameters:
-        - $ref: "#/components/parameters/containerId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/containerId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Container Custom Domain
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/checkCustomDomain":
+                $ref: '#/components/schemas/CustomDomain'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/checkCustomDomain':
     get:
       summary: Check Container Custom Domain
       operationId: checkContainerCustomDomain
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Custom Domain
       responses:
-        "200":
+        '200':
           description: Check Container Custom Domain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CheckedCustomDomainsResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/log":
+                $ref: '#/components/schemas/CheckedCustomDomainsResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/log':
     get:
       summary: List logs
       operationId: listContainerLog
       description: This will list the last 1000 logs of the container
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Logs
       responses:
-        "200":
+        '200':
           description: List logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LogResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/network":
+                $ref: '#/components/schemas/LogResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/network':
     get:
       summary: Get Container Network information
       description: Get status of the container network settings.
       operationId: getContainerNetwork
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Configuration
       responses:
-        "200":
+        '200':
           description: Network information
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerNetwork"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ContainerNetwork'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit Container Network
       description: Edit the Network settings of the container.
       operationId: editContainerNetwork
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerNetworkRequest"
+              $ref: '#/components/schemas/ContainerNetworkRequest'
       responses:
-        "201":
+        '201':
           description: Updated container network setting
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerNetwork"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/link":
+                $ref: '#/components/schemas/ContainerNetwork'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/link':
     get:
       summary: List all URLs of the container
       description: This will return all the custom domains and Qovery autogenerated domain for the given container
       operationId: listContainerLinks
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Container Main Calls
       responses:
-        "200":
+        '200':
           description: List links
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LinkResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/container/{containerId}/clone":
+                $ref: '#/components/schemas/LinkResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/container/{containerId}/clone':
     post:
       summary: Clone container
       description: This will create a new container with the same configuration on the targeted environment Id.
       operationId: cloneContainer
       parameters:
-        - $ref: "#/components/parameters/containerId"
+        - $ref: '#/components/parameters/containerId'
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneServiceRequest"
+              $ref: '#/components/schemas/CloneServiceRequest'
       responses:
-        "202":
+        '202':
           description: Container clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/ContainerResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/environment/{environmentId}/database":
+  '/environment/{environmentId}/database':
     get:
       summary: List environment databases
       operationId: listDatabase
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Databases
       responses:
-        "200":
+        '200':
           description: List databases
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DatabaseResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DatabaseResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a database
       operationId: createDatabase
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Databases
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DatabaseRequest"
+              $ref: '#/components/schemas/DatabaseRequest'
       responses:
-        "201":
-          description: "Create database "
+        '201':
+          description: 'Create database '
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Database"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Database'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Database name within the environment is already taken
-  "/environment/{environmentId}/database/status":
+  '/environment/{environmentId}/database/status':
     get:
       summary: List all environment databases statuses
       description: Returns a list of databases with only their id and status.
       operationId: getEnvironmentDatabaseStatus
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Databases
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}":
+                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}':
     get:
       summary: Get database by ID
       operationId: getDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       responses:
-        "200":
+        '200':
           description: Get database  by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Database"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/Database'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
-      summary: "Edit a database "
+      summary: 'Edit a database '
       description: To edit a database  you must have the admin permission
       operationId: editDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DatabaseEditRequest"
+              $ref: '#/components/schemas/DatabaseEditRequest'
       responses:
-        "200":
-          description: "Edit a database "
+        '200':
+          description: 'Edit a database '
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Database"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Database'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Database  name within the environment is already taken
     delete:
-      summary: "Delete a database "
+      summary: 'Delete a database '
       description: To delete a database you must have the admin permission
       operationId: deleteDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/status":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/status':
     get:
       summary: Get database status
       operationId: getDatabaseStatus
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/version":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/version':
     get:
       summary: List eligible versions for the database
       operationId: listDatabaseVersion
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       responses:
-        "200":
+        '200':
           description: List eligible versions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VersionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/masterCredentials":
+                $ref: '#/components/schemas/VersionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/masterCredentials':
     get:
       summary: Get master credentials of the database
       operationId: getDatabaseMasterCredentials
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       responses:
-        "200":
+        '200':
           description: get credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Credentials"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/Credentials'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit database  master credentials
       operationId: editDatabaseCredentials
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CredentialsRequest"
+              $ref: '#/components/schemas/CredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Edit database credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Credentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/application":
+                $ref: '#/components/schemas/Credentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/application':
     get:
       summary: List applications using the database
       operationId: listDatabaseApplication
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Application
       responses:
-        "200":
+        '200':
           description: List linked applications
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApplicationResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/application/{targetApplicationId}":
+                $ref: '#/components/schemas/ApplicationResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/application/{targetApplicationId}':
     delete:
-      summary: "Remove an application from this database "
+      summary: 'Remove an application from this database '
       operationId: removeApplicationFromDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
-        - $ref: "#/components/parameters/targetApplicationId"
+        - $ref: '#/components/parameters/databaseId'
+        - $ref: '#/components/parameters/targetApplicationId'
       tags:
         - Database Application
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/redeploy":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/redeploy':
     post:
       summary: Redeploy database
       operationId: redeployDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
         - in: query
           name: applyImmediately
           schema:
@@ -8729,72 +8729,72 @@ paths:
       tags:
         - Database Actions
       responses:
-        "202":
+        '202':
           description: Database redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/database/{databaseId}/restart-service":
+  '/database/{databaseId}/restart-service':
     post:
       summary: Retart database
       operationId: rebootDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Actions
       responses:
-        "202":
+        '202':
           description: Database reboot has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/database/{databaseId}/stop":
+  '/database/{databaseId}/stop':
     post:
       summary: Stop database
       operationId: stopDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Actions
       responses:
-        "202":
+        '202':
           description: Database  stop has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/database/{databaseId}/deploy":
+  '/database/{databaseId}/deploy':
     post:
-      summary: "Deploy database "
+      summary: 'Deploy database '
       operationId: deployDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
         - in: query
           name: applyImmediately
           schema:
@@ -8804,44 +8804,44 @@ paths:
       tags:
         - Database Actions
       responses:
-        "202":
-          description: "Deploy database "
+        '202':
+          description: 'Deploy database '
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/database/{databaseId}/uninstall":
+  '/database/{databaseId}/uninstall':
     post:
       summary: Uninstall database
       operationId: uninstallDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Database Actions
       responses:
-        "202":
-          description: "Delete the compute and data of the service, but keep Qovery configuration"
+        '202':
+          description: 'Delete the compute and data of the service, but keep Qovery configuration'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "204":
+                $ref: '#/components/schemas/Status'
+        '204':
           description: No deployment has been triggered
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: dn8xf9tcthfqn
@@ -8857,37 +8857,37 @@ paths:
         name: databaseId
         in: path
         required: true
-  "/database/{databaseId}/deploymentHistory":
+  '/database/{databaseId}/deploymentHistory':
     get:
       summary: List database deploys
       description: By default it returns the 20 last results. The response is paginated.
       operationId: listDatabaseDeploymentHistory
       parameters:
-        - $ref: "#/components/parameters/databaseId"
-        - $ref: "#/components/parameters/startId"
+        - $ref: '#/components/parameters/databaseId'
+        - $ref: '#/components/parameters/startId'
       tags:
         - Database Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/PaginationData"
+                  - $ref: '#/components/schemas/PaginationData'
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: "#/components/schemas/DeploymentHistoryDatabase"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/deploymentHistoryV2":
+                          $ref: '#/components/schemas/DeploymentHistoryDatabase'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/deploymentHistoryV2':
     get:
       summary: List database deploys
       description: By default it returns the 20 last results. The response is paginated.
@@ -8903,18 +8903,18 @@ paths:
       tags:
         - Database Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: mzftpr17opgzp
     parameters:
@@ -8924,102 +8924,102 @@ paths:
         name: databaseId
         in: path
         required: true
-  "/database/{databaseId}/backup":
+  '/database/{databaseId}/backup':
     get:
       summary: List database  backups
-      description: "By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter"
+      description: 'By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter'
       operationId: listDatabaseBackup
       parameters:
-        - $ref: "#/components/parameters/databaseId"
-        - $ref: "#/components/parameters/startId"
+        - $ref: '#/components/parameters/databaseId'
+        - $ref: '#/components/parameters/startId'
       tags:
         - Backups
       responses:
-        "200":
+        '200':
           description: List backups
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BackupPaginatedResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/BackupPaginatedResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
-      summary: "Add a backup to the Database "
+      summary: 'Add a backup to the Database '
       operationId: addBackupDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Backups
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BackupRequest"
+              $ref: '#/components/schemas/BackupRequest'
       responses:
-        "201":
+        '201':
           description: Added backup
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Backup"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/backup/{backupId}":
+                $ref: '#/components/schemas/Backup'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/backup/{backupId}':
     delete:
       summary: Remove database  backup
       operationId: removeDatabaseBackup
       parameters:
-        - $ref: "#/components/parameters/databaseId"
-        - $ref: "#/components/parameters/backupId"
+        - $ref: '#/components/parameters/databaseId'
+        - $ref: '#/components/parameters/backupId'
       tags:
         - Backups
       responses:
-        "204":
-          $ref: "#/components/responses/204"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/database/{databaseId}/clone":
+        '204':
+          $ref: '#/components/responses/204'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/database/{databaseId}/clone':
     post:
       summary: Clone database
       description: This will create a new database with the same configuration on the targeted environment Id.
       operationId: cloneDatabase
       parameters:
-        - $ref: "#/components/parameters/databaseId"
+        - $ref: '#/components/parameters/databaseId'
       tags:
         - Databases
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneServiceRequest"
+              $ref: '#/components/schemas/CloneServiceRequest'
       responses:
-        "202":
+        '202':
           description: Database clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Database"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Database'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
   /account:
     get:
@@ -9028,14 +9028,14 @@ paths:
       tags:
         - Account Info
       responses:
-        "200":
+        '200':
           description: Get account info
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AccountInfo"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/AccountInfo'
+        '401':
+          $ref: '#/components/responses/401'
     put:
       summary: Edit account information
       operationId: editAccountInformation
@@ -9045,18 +9045,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AccountInfoEditRequest"
+              $ref: '#/components/schemas/AccountInfoEditRequest'
       responses:
-        "200":
+        '200':
           description: Edit application
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AccountInfo"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/AccountInfo'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
   /account/gitAuthProvider:
     get:
       deprecated: true
@@ -9065,14 +9065,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        "200":
+        '200':
           description: Get account
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitAuthProviderResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitAuthProviderResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/github/repository:
     get:
       deprecated: true
@@ -9081,14 +9081,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        "200":
+        '200':
           description: Get github repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/github/repository/branch:
     get:
       deprecated: true
@@ -9103,14 +9103,14 @@ paths:
             type: string
           description: The name of the repository where to retrieve the branches
       responses:
-        "200":
+        '200':
           description: Get github repository branches
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/gitlab/repository:
     get:
       deprecated: true
@@ -9119,14 +9119,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        "200":
+        '200':
           description: Get gitlab repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/gitlab/repository/branch:
     get:
       deprecated: true
@@ -9141,14 +9141,14 @@ paths:
             type: string
           description: The name of the repository to retrieve the branches
       responses:
-        "200":
+        '200':
           description: Get gitlab repository branches
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/bitbucket/repository:
     get:
       deprecated: true
@@ -9157,14 +9157,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        "200":
+        '200':
           description: Get bitbucket repositories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitRepositoryResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/bitbucket/repository/branch:
     get:
       deprecated: true
@@ -9179,14 +9179,14 @@ paths:
             type: string
           description: The name of the repository where to retrieve the branches
       responses:
-        "200":
+        '200':
           description: Get bitbucket repository branches
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
+        '401':
+          $ref: '#/components/responses/401'
   /account/referral:
     get:
       summary: Get your referral information
@@ -9194,14 +9194,14 @@ paths:
       tags:
         - Referral & Rewards
       responses:
-        "200":
+        '200':
           description: Get referral info
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Referral"
-        "401":
-          $ref: "#/components/responses/401"
+                $ref: '#/components/schemas/Referral'
+        '401':
+          $ref: '#/components/responses/401'
   /account/rewardClaim:
     post:
       summary: Claim a reward
@@ -9213,9 +9213,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RewardClaim"
+              $ref: '#/components/schemas/RewardClaim'
       responses:
-        "200":
+        '200':
           description: Claim reward
   /admin/userSignUp:
     get:
@@ -9225,18 +9225,18 @@ paths:
       tags:
         - User Sign Up
       responses:
-        "200":
-          description: "If a previous sign up request for the same user has been found, the information is returned in the payload"
+        '200':
+          description: 'If a previous sign up request for the same user has been found, the information is returned in the payload'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SignUp"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/SignUp'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Send Sign Up request
       description: Send a Sign Up request containing the user information
@@ -9247,266 +9247,266 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SignUpRequest"
+              $ref: '#/components/schemas/SignUpRequest'
       responses:
-        "200":
+        '200':
           description: Sign up request stored
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/helm":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/helm':
     get:
       summary: List helms
       operationId: listHelms
       parameters:
-        - $ref: "#/components/parameters/environmentId"
-        - $ref: "#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1"
+        - $ref: '#/components/parameters/environmentId'
+        - $ref: '#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1'
       tags:
         - Helms
       responses:
-        "200":
+        '200':
           description: List helms
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a helm
       operationId: createHelm
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Helms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmRequest"
+              $ref: '#/components/schemas/HelmRequest'
       responses:
-        "201":
+        '201':
           description: Create helm
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/HelmResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Helm name within the environment is already taken
-  "/environment/{environmentId}/helmDefaultValues":
+  '/environment/{environmentId}/helmDefaultValues':
     post:
       summary: Get helm default values
       operationId: createHelmDefaultValues
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Helms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmDefaultValuesRequest"
+              $ref: '#/components/schemas/HelmDefaultValuesRequest'
       responses:
-        "201":
+        '201':
           description: helm values
           content:
             text/plain:
               schema:
                 type: string
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/helm/status":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/helm/status':
     get:
       summary: List all environment helm statuses
       description: Returns a list of helms with only their id and status.
       operationId: getEnvironmentHelmStatus
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Helms
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}":
+                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}':
     get:
       summary: Get helm by ID
       operationId: getHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Main Calls
       responses:
-        "200":
+        '200':
           description: Get helm by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit helm
       description: |
         - To edit the helm you must have the admin permission.
       operationId: editHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmRequest"
+              $ref: '#/components/schemas/HelmRequest'
       responses:
-        "200":
+        '200':
           description: Edit helm
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/HelmResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Helm name within the environment is already taken
     delete:
       summary: Delete helm
       description: To delete the helm you must have the admin permission
       operationId: deleteHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/commit":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/commit':
     get:
       summary: List last helm commits
       description: Returns list of the last 100 commits made on the repository linked to helm
       operationId: listHelmCommit
       parameters:
-        - $ref: "#/components/parameters/helmId"
-        - $ref: "#/components/parameters/helmOf"
+        - $ref: '#/components/parameters/helmId'
+        - $ref: '#/components/parameters/helmOf'
       tags:
         - Helm Main Calls
       responses:
-        "200":
+        '200':
           description: List Helm commits
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CommitResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/advancedSettings":
+                $ref: '#/components/schemas/CommitResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/advancedSettings':
     get:
       summary: Get advanced settings
       description: Get list and values of the advanced settings of the helm.
       operationId: getHelmAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Configuration
       responses:
-        "200":
+        '200':
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editHelmAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmAdvancedSettings"
+              $ref: '#/components/schemas/HelmAdvancedSettings'
       responses:
-        "201":
+        '201':
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmAdvancedSettings"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/deploy":
+                $ref: '#/components/schemas/HelmAdvancedSettings'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/deploy':
     post:
       summary: Deploy helm
       description: You must provide a git commit id or a helm version depending on the source location of your code (git vs helm repository).
       operationId: deployHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
         - name: forceEvent
           in: query
           required: false
@@ -9514,38 +9514,38 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned helm hasn't the target event provided, the helm won't be deployed.
           schema:
-            $ref: "#/components/schemas/HelmForceEvent"
+            $ref: '#/components/schemas/HelmForceEvent'
       tags:
         - Helm Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmDeployRequest"
+              $ref: '#/components/schemas/HelmDeployRequest'
       responses:
-        "202":
+        '202':
           description: Deploy helm
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/helm/{helmId}/uninstall":
+  '/helm/{helmId}/uninstall':
     post:
       summary: Uninstall helm
       description: Delete the resources of the helm but keep Qovery configuration
       operationId: uninstallHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Actions
       requestBody:
@@ -9554,23 +9554,23 @@ paths:
             schema:
               type: object
       responses:
-        "202":
-          description: "Delete the compute and data of the service, but keep Qovery configuration"
+        '202':
+          description: 'Delete the compute and data of the service, but keep Qovery configuration'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "204":
+                $ref: '#/components/schemas/Status'
+        '204':
           description: No deployment has been triggered
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: cdps3bcv0l0wa
@@ -9580,12 +9580,12 @@ paths:
         name: helmId
         in: path
         required: true
-  "/helm/{helmId}/redeploy":
+  '/helm/{helmId}/redeploy':
     post:
       summary: Redeploy helm
       operationId: redeployHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
         - name: forceEvent
           in: query
           required: false
@@ -9593,98 +9593,98 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned helm hasn't the target event provided, the helm won't be deployed.
           schema:
-            $ref: "#/components/schemas/HelmForceEvent"
+            $ref: '#/components/schemas/HelmForceEvent'
       tags:
         - Helm Actions
       responses:
-        "202":
+        '202':
           description: Helm redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/helm/{helmId}/stop":
+  '/helm/{helmId}/stop':
     post:
       summary: Stop helm
       operationId: stopHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Actions
       responses:
-        "202":
+        '202':
           description: Helm stop has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Helm is already stopped or an operation is in progress
-  "/helm/{helmId}/status":
+  '/helm/{helmId}/status':
     get:
       summary: Get helm status
       operationId: getHelmStatus
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Main Calls
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/deploymentHistory":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/deploymentHistory':
     get:
       summary: List helm deployments
       description: Returns the 20 last helm deployments
       operationId: listHelmDeploymentHistory
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/PaginationData"
+                  - $ref: '#/components/schemas/PaginationData'
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: "#/components/schemas/DeploymentHistoryHelmResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/deploymentHistoryV2":
+                          $ref: '#/components/schemas/DeploymentHistoryHelmResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/deploymentHistoryV2':
     get:
       summary: List helm deployments
       description: Returns the 20 last helm deployments
@@ -9700,18 +9700,18 @@ paths:
       tags:
         - Helm Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: fn9qd5qn7dhdv
     parameters:
@@ -9721,416 +9721,416 @@ paths:
         name: helmId
         in: path
         required: true
-  "/helm/{helmId}/deploymentRestriction":
+  '/helm/{helmId}/deploymentRestriction':
     get:
       summary: Get helm deployment restrictions
       description: Get helm deployment restrictions
       operationId: getHelmDeploymentRestrictions
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Deployment Restriction
       responses:
-        "200":
+        '200':
           description: Get helm deployment restrictions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmDeploymentRestrictionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmDeploymentRestrictionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a helm deployment restriction
       description: Create a helm deployment restriction
       operationId: createHelmDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/HelmDeploymentRestrictionRequest'
       responses:
-        "201":
+        '201':
           description: Added an helm deployment restriction
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmDeploymentRestrictionResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "409":
+                $ref: '#/components/schemas/HelmDeploymentRestrictionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '409':
           description: A Helm deployment restriction with same properties already exists for this helm
-  "/helm/{helmId}/deploymentRestriction/{deploymentRestrictionId}":
+  '/helm/{helmId}/deploymentRestriction/{deploymentRestrictionId}':
     put:
       summary: Edit a helm deployment restriction
       description: Edit a helm deployment restriction
       operationId: editHelmDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/helmId"
-        - $ref: "#/components/parameters/deploymentRestrictionId"
+        - $ref: '#/components/parameters/helmId'
+        - $ref: '#/components/parameters/deploymentRestrictionId'
       tags:
         - Helm Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/HelmDeploymentRestrictionRequest'
       responses:
-        "200":
+        '200':
           description: Edit a helm deployment restriction
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmDeploymentRestrictionResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HelmDeploymentRestrictionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a helm deployment restriction
       description: Delete a helm deployment restriction
       operationId: deleteHelmDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/helmId"
-        - $ref: "#/components/parameters/deploymentRestrictionId"
+        - $ref: '#/components/parameters/helmId'
+        - $ref: '#/components/parameters/deploymentRestrictionId'
       tags:
         - Helm Deployment Restriction
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/clone":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/clone':
     post:
       summary: Clone helm
       description: This will create a new helm with the same configuration on the targeted environment Id.
       operationId: cloneHelm
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneServiceRequest"
+              $ref: '#/components/schemas/CloneServiceRequest'
       responses:
-        "202":
+        '202':
           description: Helm clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/HelmResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/helm/{helmId}/link":
+  '/helm/{helmId}/link':
     get:
       summary: List all URLs of the helm
       description: This will return all the custom domains and Qovery autogenerated domain for the given helm
       operationId: listHelmLinks
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Main Calls
       responses:
-        "200":
+        '200':
           description: List links
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LinkResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/customDomain":
+                $ref: '#/components/schemas/LinkResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/customDomain':
     get:
       summary: List helm custom domains
       description: List the custom domains of this helm
       operationId: listHelmCustomDomain
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Custom Domain
       responses:
-        "200":
+        '200':
           description: List custom domains
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomainResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CustomDomainResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add custom domain to the helm.
       description: Add a custom domain to this helm in order not to use qovery autogenerated domain
       operationId: createHelmCustomDomain
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CustomDomainRequest"
+              $ref: '#/components/schemas/CustomDomainRequest'
       responses:
-        "201":
+        '201':
           description: Added helm custom domain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/customDomain/{customDomainId}":
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/customDomain/{customDomainId}':
     put:
       summary: Edit a Custom Domain
       description: To edit a Custom Domain you must have the project user permission
       operationId: editHelmCustomDomain
       parameters:
-        - $ref: "#/components/parameters/helmId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/helmId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Helm Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CustomDomainRequest"
+              $ref: '#/components/schemas/CustomDomainRequest'
       responses:
-        "200":
+        '200':
           description: Edit a CustomDomain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a Custom Domain
       description: To delete an CustomDomain you must have the project user permission
       operationId: deleteHelmCustomDomain
       parameters:
-        - $ref: "#/components/parameters/helmId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/helmId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Helm Custom Domain
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     get:
       summary: Get a Custom Domain
       description: Get a custom domain
       operationId: getHelmCustomDomain
       parameters:
-        - $ref: "#/components/parameters/helmId"
-        - $ref: "#/components/parameters/customDomainId"
+        - $ref: '#/components/parameters/helmId'
+        - $ref: '#/components/parameters/customDomainId'
       tags:
         - Helm Custom Domain
       responses:
-        "200":
+        '200':
           description: Get a CustomDomain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CustomDomain"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/helm/{helmId}/checkCustomDomain":
+                $ref: '#/components/schemas/CustomDomain'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/helm/{helmId}/checkCustomDomain':
     get:
       summary: Check Helm Custom Domain
       operationId: checkHelmCustomDomain
       parameters:
-        - $ref: "#/components/parameters/helmId"
+        - $ref: '#/components/parameters/helmId'
       tags:
         - Helm Custom Domain
       responses:
-        "200":
+        '200':
           description: Check Helm Custom Domain
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CheckedCustomDomainsResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/checkDockerfile":
+                $ref: '#/components/schemas/CheckedCustomDomainsResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/checkDockerfile':
     post:
       summary: Check dockerfile configuration is correct
       operationId: checkDockerfile
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DockerfileCheckRequest"
+              $ref: '#/components/schemas/DockerfileCheckRequest'
       responses:
-        "200":
+        '200':
           description: Information about the dockerfile
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DockerfileCheckResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/checkHelmRepository":
+                $ref: '#/components/schemas/DockerfileCheckResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/checkHelmRepository':
     post:
       summary: Check helm repository configuration is correct
       operationId: checkHelmRepository
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HelmCheckRequest"
+              $ref: '#/components/schemas/HelmCheckRequest'
       responses:
-        "200":
+        '200':
           description: Information about the helm repository
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmCheckResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/checkContainerImage":
+                $ref: '#/components/schemas/HelmCheckResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/checkContainerImage':
     post:
       summary: Check container image configuration is correct
       operationId: checkContainerImage
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContainerImageCheckRequest"
+              $ref: '#/components/schemas/ContainerImageCheckRequest'
       responses:
-        "200":
+        '200':
           description: Information about the image
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerImageCheckResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/checkGitFile":
+                $ref: '#/components/schemas/ContainerImageCheckResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/checkGitFile':
     post:
       summary: Check git file configuration is correct
       operationId: checkGitFile
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GitFileCheckRequest"
+              $ref: '#/components/schemas/GitFileCheckRequest'
       responses:
-        "200":
+        '200':
           description: Information about the image
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitFileCheckResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/job":
+                $ref: '#/components/schemas/GitFileCheckResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/job':
     get:
       summary: List jobs
       operationId: listJobs
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
         - name: toUpdate
           in: query
           description: return (or not) results that must be updated
@@ -10141,139 +10141,139 @@ paths:
       tags:
         - Jobs
       responses:
-        "200":
+        '200':
           description: List jobs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/JobResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a job
       operationId: createJob
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Jobs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobRequest"
+              $ref: '#/components/schemas/JobRequest'
       responses:
-        "201":
+        '201':
           description: Create job
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/JobResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Job name within the environment is already taken
-  "/environment/{environmentId}/job/status":
+  '/environment/{environmentId}/job/status':
     get:
       summary: List all environment job statuses
       description: Returns a list of jobs with only their id and status.
       operationId: getEnvironmentJobStatus
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Jobs
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}":
+                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}':
     get:
       summary: Get job by ID
       operationId: getJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Main Calls
       responses:
-        "200":
+        '200':
           description: Get job by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/JobResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit job
       description: |
         - To edit the job you must have the admin permission.
       operationId: editJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobRequest"
+              $ref: '#/components/schemas/JobRequest'
       responses:
-        "200":
+        '200':
           description: Edit job
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/JobResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Job name within the environment is already taken
     delete:
       summary: Delete job
       description: To delete the job you must have the admin permission
       operationId: deleteJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/advancedSettings":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/advancedSettings':
     get:
       summary: Get advanced settings
       description: |
@@ -10281,57 +10281,57 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)
       operationId: getJobAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Configuration
       responses:
-        "200":
+        '200':
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/JobAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editJobAdvancedSettings
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobAdvancedSettings"
+              $ref: '#/components/schemas/JobAdvancedSettings'
       responses:
-        "201":
+        '201':
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobAdvancedSettings"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/deploy":
+                $ref: '#/components/schemas/JobAdvancedSettings'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/deploy':
     post:
       summary: Deploy job
       description: You must provide a git commit id or an image tag depending on the source location of your code (git vs image repository).
       operationId: deployJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
         - name: forceEvent
           in: query
           required: false
@@ -10339,38 +10339,38 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned job hasn't the target event provided, the job won't be deployed.
           schema:
-            $ref: "#/components/schemas/JobForceEvent"
+            $ref: '#/components/schemas/JobForceEvent'
       tags:
         - Job Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobDeployRequest"
+              $ref: '#/components/schemas/JobDeployRequest'
       responses:
-        "202":
+        '202':
           description: Deploy job
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/job/{jobId}/uninstall":
+  '/job/{jobId}/uninstall':
     post:
       summary: Uninstall job
       description: Delete the resources of the job but keep Qovery configuration
       operationId: uninstallJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Actions
       requestBody:
@@ -10380,23 +10380,23 @@ paths:
               type: object
               properties: {}
       responses:
-        "202":
-          description: "Delete the compute and data of the service, but keep Qovery configuration"
+        '202':
+          description: 'Delete the compute and data of the service, but keep Qovery configuration'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "204":
+                $ref: '#/components/schemas/Status'
+        '204':
           description: No deployment has been triggered
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: s4xgct6hdxymt
@@ -10406,12 +10406,12 @@ paths:
         name: jobId
         in: path
         required: true
-  "/job/{jobId}/redeploy":
+  '/job/{jobId}/redeploy':
     post:
       summary: Redeploy job
       operationId: redeployJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
         - name: forceEvent
           in: query
           required: false
@@ -10419,42 +10419,42 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned job hasn't the target event provided, the job won't be deployed.
           schema:
-            $ref: "#/components/schemas/JobForceEvent"
+            $ref: '#/components/schemas/JobForceEvent'
       tags:
         - Job Actions
       responses:
-        "202":
+        '202':
           description: Job redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/terraform/{terraformId}/redeploy":
+  '/terraform/{terraformId}/redeploy':
     post:
       summary: Redeploy terraform
       operationId: redeployTerraform
       responses:
-        "202":
+        '202':
           description: Terraform redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: 69fa5itbg5w43
@@ -10466,80 +10466,80 @@ paths:
         name: terraformId
         in: path
         required: true
-  "/job/{jobId}/stop":
+  '/job/{jobId}/stop':
     post:
       summary: Stop job
       operationId: stopJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Actions
       responses:
-        "202":
+        '202':
           description: Job stop has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Job is already stopped or an operation is in progress
-  "/job/{jobId}/status":
+  '/job/{jobId}/status':
     get:
       summary: Get job status
       operationId: getJobStatus
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Main Calls
       responses:
-        "200":
+        '200':
           description: Get status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/deploymentHistory":
+                $ref: '#/components/schemas/Status'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/deploymentHistory':
     get:
       summary: List job deployments
       description: Returns the 20 last job deployments
       operationId: listJobDeploymentHistory
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/PaginationData"
+                  - $ref: '#/components/schemas/PaginationData'
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: "#/components/schemas/DeploymentHistoryJobResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/deploymentHistoryV2":
+                          $ref: '#/components/schemas/DeploymentHistoryJobResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/deploymentHistoryV2':
     get:
       summary: List job deployments
       description: Returns the 20 last job deployments
@@ -10555,18 +10555,18 @@ paths:
       tags:
         - Job Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: mcu1nwkl3q2bb
     parameters:
@@ -10576,184 +10576,184 @@ paths:
         name: jobId
         in: path
         required: true
-  "/job/{jobId}/deploymentRestriction":
+  '/job/{jobId}/deploymentRestriction':
     get:
       summary: Get job deployment restrictions
       description: Get job deployment restrictions
       operationId: getJobDeploymentRestrictions
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Deployment Restriction
       responses:
-        "200":
+        '200':
           description: Get job deployment restrictions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobDeploymentRestrictionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/JobDeploymentRestrictionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a job deployment restriction
       description: Create a job deployment restriction
       operationId: createJobDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/JobDeploymentRestrictionRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobDeploymentRestrictionResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "409":
+                $ref: '#/components/schemas/JobDeploymentRestrictionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '409':
           description: A Job deployment restriction with same properties already exists for this job
-  "/job/{jobId}/deploymentRestriction/{deploymentRestrictionId}":
+  '/job/{jobId}/deploymentRestriction/{deploymentRestrictionId}':
     put:
       summary: Edit a job deployment restriction
       description: Edit a job deployment restriction
       operationId: editJobDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/deploymentRestrictionId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/deploymentRestrictionId'
       tags:
         - Job Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/JobDeploymentRestrictionRequest'
       responses:
-        "200":
+        '200':
           description: Edit a job deployment restriction
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobDeploymentRestrictionResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/JobDeploymentRestrictionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a job deployment restriction
       description: Delete a job deployment restriction
       operationId: deleteJobDeploymentRestriction
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/deploymentRestrictionId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/deploymentRestrictionId'
       tags:
         - Job Deployment Restriction
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/environmentVariable":
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/environmentVariable':
     get:
       summary: List environment variables
       operationId: listJobEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Environment Variable
       responses:
-        "200":
+        '200':
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariableResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnvironmentVariableResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add an environment variable to the job
       description: |
         - Add an environment variable to the job.
       operationId: createJobEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableRequest"
+              $ref: '#/components/schemas/EnvironmentVariableRequest'
       responses:
-        "201":
+        '201':
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/environmentVariable/import":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/environmentVariable/import':
     post:
       summary: Import variables
-      description: "Import environment variables in a defined scope, with a defined visibility."
+      description: 'Import environment variables in a defined scope, with a defined visibility.'
       operationId: importJobEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableImportRequest"
+              $ref: '#/components/schemas/VariableImportRequest'
       responses:
-        "201":
+        '201':
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableImport"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/environmentVariable/{environmentVariableId}":
+                $ref: '#/components/schemas/VariableImport'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/environmentVariable/{environmentVariableId}':
     delete:
       summary: Delete an environment variable from a job
       description: |
@@ -10762,19 +10762,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteJobEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Job Environment Variable
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit an environment variable belonging to the job
       description: |
@@ -10784,8 +10784,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editJobEnvironmentVariable
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Job Environment Variable
       requestBody:
@@ -10793,23 +10793,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
+              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/environmentVariable/{environmentVariableId}/override":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/environmentVariable/{environmentVariableId}/override':
     post:
       summary: Create an environment variable override at the job level
       description: |
@@ -10820,31 +10820,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createJobEnvironmentVariableOverride
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/environmentVariable/{environmentVariableId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/environmentVariable/{environmentVariableId}/alias':
     post:
       summary: Create an environment variable alias at the job level
       description: |
@@ -10856,82 +10856,82 @@ paths:
         - You can't create an alias on an alias
       operationId: createJobEnvironmentVariableAlias
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/environmentVariableId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/environmentVariableId'
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvironmentVariable"
-        "400":
+                $ref: '#/components/schemas/EnvironmentVariable'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/secret":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/secret':
     get:
       summary: List job secrets
-      description: "Secrets are like environment variables, but they are secured and can't be revealed."
+      description: 'Secrets are like environment variables, but they are secured and can''t be revealed.'
       operationId: listJobSecrets
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Secret
       responses:
-        "200":
+        '200':
           description: List secrets
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SecretResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/SecretResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Add a secret to the job
       description: |
         - Add a secret to the job.
       operationId: createJobSecret
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Job Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretRequest"
+              $ref: '#/components/schemas/SecretRequest'
       responses:
-        "201":
+        '201':
           description: Add a secret
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/secret/{secretId}":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/secret/{secretId}':
     delete:
       summary: Delete a secret from an job
       description: |
@@ -10940,19 +10940,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well
       operationId: deleteJobSecret
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Job Secret
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a secret belonging to the job
       description: |
@@ -10962,8 +10962,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editJobSecret
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Job Secret
       requestBody:
@@ -10971,23 +10971,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SecretEditRequest"
+              $ref: '#/components/schemas/SecretEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/secret/{secretId}/override":
+                $ref: '#/components/schemas/Secret'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/secret/{secretId}/override':
     post:
       summary: Create a secret override at the job level
       description: |
@@ -10998,31 +10998,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createJobSecretOverride
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Job Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Value"
+              $ref: '#/components/schemas/Value'
       responses:
-        "201":
+        '201':
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/secret/{secretId}/alias":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/secret/{secretId}/alias':
     post:
       summary: Create a secret alias at the job level
       description: |
@@ -11034,129 +11034,129 @@ paths:
         - You can't create an alias on an alias
       operationId: createJobSecretAlias
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/secretId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/secretId'
       tags:
         - Job Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Key"
+              $ref: '#/components/schemas/Key'
       responses:
-        "201":
+        '201':
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Secret"
-        "400":
+                $ref: '#/components/schemas/Secret'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/commit":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/commit':
     get:
       summary: List last job commits
       description: Returns list of the last 100 commits made on the repository linked to the job
       operationId: listJobCommit
       parameters:
-        - $ref: "#/components/parameters/jobId"
-        - $ref: "#/components/parameters/startId"
-        - $ref: "#/components/parameters/gitCommitId"
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/startId'
+        - $ref: '#/components/parameters/gitCommitId'
       tags:
         - Job Main Calls
       responses:
-        "200":
+        '200':
           description: List job commits
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CommitResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/job/{jobId}/clone":
+                $ref: '#/components/schemas/CommitResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/job/{jobId}/clone':
     post:
       summary: Clone job
       description: This will create a new job with the same configuration on the targeted environment Id.
       operationId: cloneJob
       parameters:
-        - $ref: "#/components/parameters/jobId"
+        - $ref: '#/components/parameters/jobId'
       tags:
         - Jobs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneServiceRequest"
+              $ref: '#/components/schemas/CloneServiceRequest'
       responses:
-        "202":
+        '202':
           description: Job clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/JobResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/service/{serviceId}/deploymentStage":
+  '/service/{serviceId}/deploymentStage':
     get:
       summary: Get Service Deployment Stage
       operationId: getServiceDeploymentStage
       parameters:
-        - $ref: "#/components/parameters/serviceId"
+        - $ref: '#/components/parameters/serviceId'
       tags:
         - Deployment Stage Main Calls
       responses:
-        "200":
+        '200':
           description: Get Service Deployment Stage
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentStageResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/service/{serviceId}/gitWebhookStatus":
+                $ref: '#/components/schemas/DeploymentStageResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/service/{serviceId}/gitWebhookStatus':
     get:
       summary: Get git webhook status for a service
-      description: "Returns the webhook status for a git-based service. Checks if the Qovery webhook is correctly configured on the git provider (GitHub, GitLab, or Bitbucket)."
+      description: 'Returns the webhook status for a git-based service. Checks if the Qovery webhook is correctly configured on the git provider (GitHub, GitLab, or Bitbucket).'
       operationId: getServiceGitWebhookStatus
       parameters:
-        - $ref: "#/components/parameters/serviceId"
+        - $ref: '#/components/parameters/serviceId'
       tags:
         - Service Main Calls
       responses:
-        "200":
+        '200':
           description: Webhook status
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitWebhookStatusResponse"
-        "400":
+                $ref: '#/components/schemas/GitWebhookStatusResponse'
+        '400':
           description: Service does not have a git source
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/service/{serviceId}/gitWebhook/sync":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/service/{serviceId}/gitWebhook/sync':
     post:
       summary: Synchronize git webhook for a service
       description: |
@@ -11167,27 +11167,27 @@ paths:
         Works with GitHub, GitLab, and Bitbucket repositories.
       operationId: syncServiceGitWebhook
       parameters:
-        - $ref: "#/components/parameters/serviceId"
+        - $ref: '#/components/parameters/serviceId'
       tags:
         - Service Main Calls
       responses:
-        "200":
+        '200':
           description: Webhook synchronized successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GitWebhookStatusResponse"
-        "400":
+                $ref: '#/components/schemas/GitWebhookStatusResponse'
+        '400':
           description: Service does not have a git source
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "422":
-          description: "Cannot configure webhook (provider-specific issues, insufficient permissions)"
-        "429":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          description: 'Cannot configure webhook (provider-specific issues, insufficient permissions)'
+        '429':
           description: Git provider rate limit exceeded
   /variable:
     get:
@@ -11201,13 +11201,13 @@ paths:
           schema:
             type: string
             format: uuid
-          description: "it filters the list by returning only the variables accessible by the selected parent_id. This field shall contain the id of a project, environment or service depending on the selected scope. Example, if scope = APPLICATION and parent_id=<application_id>, the result will contain any variable accessible by the application. The result will contain also any variable declared at an higher scope."
+          description: 'it filters the list by returning only the variables accessible by the selected parent_id. This field shall contain the id of a project, environment or service depending on the selected scope. Example, if scope = APPLICATION and parent_id=<application_id>, the result will contain any variable accessible by the application. The result will contain also any variable declared at an higher scope.'
         - in: query
           name: scope
           required: true
           schema:
-            $ref: "#/components/schemas/APIVariableScopeEnum"
-          description: "the type of the parent_id (application, project, environment etc..)."
+            $ref: '#/components/schemas/APIVariableScopeEnum'
+          description: 'the type of the parent_id (application, project, environment etc..).'
         - in: query
           name: is_secret
           schema:
@@ -11217,18 +11217,18 @@ paths:
       tags:
         - Variable Main Calls
       responses:
-        "200":
+        '200':
           description: List variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/VariableResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create a variable
       description: |
@@ -11240,23 +11240,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableRequest"
+              $ref: '#/components/schemas/VariableRequest'
       responses:
-        "201":
+        '201':
           description: Create a variable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/variable/{variableId}/alias":
+                $ref: '#/components/schemas/VariableResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/variable/{variableId}/alias':
     post:
       summary: Create a variable alias
       description: |
@@ -11268,30 +11268,30 @@ paths:
         - You can't create an alias on an alias
       operationId: createVariableAlias
       parameters:
-        - $ref: "#/components/parameters/variableId"
+        - $ref: '#/components/parameters/variableId'
       tags:
         - Variable Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableAliasRequest"
+              $ref: '#/components/schemas/VariableAliasRequest'
       responses:
-        "201":
+        '201':
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableResponse"
-        "400":
+                $ref: '#/components/schemas/VariableResponse'
+        '400':
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is ORGANIZATION > PROJECT > ENVIRONMENT > CONTAINER
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/variable/{variableId}/override":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/variable/{variableId}/override':
     post:
       summary: Create a variable override
       description: |
@@ -11302,30 +11302,30 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" or in the "overridden_secret" field of the newly created variable
       operationId: createVariableOverride
       parameters:
-        - $ref: "#/components/parameters/variableId"
+        - $ref: '#/components/parameters/variableId'
       tags:
         - Variable Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableOverrideRequest"
+              $ref: '#/components/schemas/VariableOverrideRequest'
       responses:
-        "201":
+        '201':
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableResponse"
-        "400":
+                $ref: '#/components/schemas/VariableResponse'
+        '400':
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is ORGANIZATION > PROJECT > ENVIRONMENT > APPLICATION
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/variable/{variableId}":
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/variable/{variableId}':
     delete:
       summary: Delete a variable
       description: |
@@ -11334,18 +11334,18 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteVariable
       parameters:
-        - $ref: "#/components/parameters/variableId"
+        - $ref: '#/components/parameters/variableId'
       tags:
         - Variable Main Calls
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a variable
       description: |
@@ -11354,7 +11354,7 @@ paths:
         - For an alias, you can't edit the value
       operationId: editVariable
       parameters:
-        - $ref: "#/components/parameters/variableId"
+        - $ref: '#/components/parameters/variableId'
       tags:
         - Variable Main Calls
       requestBody:
@@ -11362,26 +11362,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableEditRequest"
+              $ref: '#/components/schemas/VariableEditRequest'
       responses:
-        "200":
+        '200':
           description: Edited variable value
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/VariableResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /variable/import:
     post:
       summary: Import variables
-      description: "Import environment variables in a defined scope, with a defined visibility."
+      description: 'Import environment variables in a defined scope, with a defined visibility.'
       operationId: importEnvironmentVariables
       parameters:
         - in: query
@@ -11395,7 +11395,7 @@ paths:
           name: service_type
           required: true
           schema:
-            $ref: "#/components/schemas/ServiceTypeForVariableEnum"
+            $ref: '#/components/schemas/ServiceTypeForVariableEnum'
           description: service type
       tags:
         - Variable Main Calls
@@ -11403,23 +11403,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VariableImportRequest"
+              $ref: '#/components/schemas/VariableImportRequest'
       responses:
-        "201":
+        '201':
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableImport"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/cleanFailedJobs":
+                $ref: '#/components/schemas/VariableImport'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/cleanFailedJobs':
     parameters:
       - schema:
           type: string
@@ -11431,7 +11431,7 @@ paths:
       tags:
         - Environment Actions
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -11473,7 +11473,7 @@ paths:
                       id: j5zm35sm6zxp4
                     type: string
                     format: uuid
-  "/job/{jobId}/cleanFailedJob":
+  '/job/{jobId}/cleanFailedJob':
     parameters:
       - schema:
           type: string
@@ -11485,7 +11485,7 @@ paths:
       tags:
         - Job Actions
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -11503,7 +11503,7 @@ paths:
       operationId: cleanFailedJob
       x-stoplight:
         id: eu77thczavme3
-  "/environment/{environmentId}/lifecycleTemplate":
+  '/environment/{environmentId}/lifecycleTemplate':
     parameters:
       - schema:
           type: string
@@ -11518,19 +11518,19 @@ paths:
       x-stoplight:
         id: 597v5i445zf0v
       responses:
-        "200":
+        '200':
           description: List available lifecyle templates for this environment
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LifecycleTemplateListResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/lifecycleTemplate/{lifecycleTemplateId}":
+                $ref: '#/components/schemas/LifecycleTemplateListResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/lifecycleTemplate/{lifecycleTemplateId}':
     parameters:
       - schema:
           type: string
@@ -11550,19 +11550,19 @@ paths:
       x-stoplight:
         id: yatyf4hs2kwc0
       responses:
-        "200":
+        '200':
           description: Lifecycle template
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LifecycleTemplateResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/containerRegistry/{containerRegistryId}/associatedServices":
+                $ref: '#/components/schemas/LifecycleTemplateResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/containerRegistry/{containerRegistryId}/associatedServices':
     parameters:
       - schema:
           type: string
@@ -11579,23 +11579,23 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Get organization container registry associated services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ContainerRegistryAssociatedServicesResponseList"
-        "401":
+                $ref: '#/components/schemas/ContainerRegistryAssociatedServicesResponseList'
+        '401':
           description: Access token is missing or invalid
-        "403":
+        '403':
           description: Access forbidden
-        "404":
+        '404':
           description: Resource not found
       operationId: getContainerRegistryAssociatedServices
       x-stoplight:
         id: dgh8t73nqaetm
       description: Get organization container registry associated services
-  "/organization/{organizationId}/helmRepository/{helmRepositoryId}/associatedServices":
+  '/organization/{organizationId}/helmRepository/{helmRepositoryId}/associatedServices':
     parameters:
       - schema:
           type: string
@@ -11612,23 +11612,23 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Get organization helm repository associated services
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HelmRepositoryAssociatedServicesResponseList"
-        "401":
-          description: " Access token is missing or invalid"
-        "403":
+                $ref: '#/components/schemas/HelmRepositoryAssociatedServicesResponseList'
+        '401':
+          description: ' Access token is missing or invalid'
+        '403':
           description: AccessForbidden
-        "404":
+        '404':
           description: ResourceNot Found
       operationId: getHelmRepositoryAssociatedServices
       x-stoplight:
         id: 5jvrv87m4tk5s
       description: Get organization helm repository associated services
-  "/cluster/{clusterId}/token":
+  '/cluster/{clusterId}/token':
     parameters:
       - schema:
           type: string
@@ -11639,7 +11639,7 @@ paths:
       summary: Get cluster token by clusterId
       tags: []
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -11683,7 +11683,7 @@ paths:
       operationId: get-cluster-token-by-clusterId
       x-stoplight:
         id: zggx5u9ayalz7
-  "/helm/{helmId}/listServices":
+  '/helm/{helmId}/listServices':
     parameters:
       - schema:
           type: string
@@ -11695,24 +11695,24 @@ paths:
       tags:
         - Helm Main Calls
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
                 type: object
-                $ref: "#/components/schemas/KubernetesServiceResponseList"
-        "401":
-          description: " Access token is missing or invalid"
-        "403":
+                $ref: '#/components/schemas/KubernetesServiceResponseList'
+        '401':
+          description: ' Access token is missing or invalid'
+        '403':
           description: Resource not found
-        "404":
+        '404':
           description: Not Found
       operationId: getHelmKubernetesServices
       x-stoplight:
         id: 7cl74u6hzmccd
       description: Get helm kubernetes services
-  "/environment/{environmentId}/services":
+  '/environment/{environmentId}/services':
     parameters:
       - schema:
           type: string
@@ -11724,7 +11724,7 @@ paths:
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: Service List
           content:
             application/json:
@@ -11739,25 +11739,25 @@ paths:
                       x-stoplight:
                         id: lzycmwmefigki
                       oneOf:
-                        - $ref: "#/components/schemas/Application"
-                        - $ref: "#/components/schemas/ContainerResponse"
-                        - $ref: "#/components/schemas/Database"
-                        - $ref: "#/components/schemas/HelmResponse"
-                        - $ref: "#/components/schemas/JobResponse"
-                        - $ref: "#/components/schemas/TerraformResponse"
+                        - $ref: '#/components/schemas/Application'
+                        - $ref: '#/components/schemas/ContainerResponse'
+                        - $ref: '#/components/schemas/Database'
+                        - $ref: '#/components/schemas/HelmResponse'
+                        - $ref: '#/components/schemas/JobResponse'
+                        - $ref: '#/components/schemas/TerraformResponse'
                       discriminator:
                         propertyName: service_type
                         mapping:
-                          APPLICATION: "#/components/schemas/Application"
-                          CONTAINER: "#/components/schemas/ContainerResponse"
-                          DATABASE: "#/components/schemas/Database"
-                          HELM: "#/components/schemas/HelmResponse"
-                          JOB: "#/components/schemas/JobResponse"
-                          TERRAFORM: "#/components/schemas/TerraformResponse"
+                          APPLICATION: '#/components/schemas/Application'
+                          CONTAINER: '#/components/schemas/ContainerResponse'
+                          DATABASE: '#/components/schemas/Database'
+                          HELM: '#/components/schemas/HelmResponse'
+                          JOB: '#/components/schemas/JobResponse'
+                          TERRAFORM: '#/components/schemas/TerraformResponse'
       operationId: listServicesByEnvironmentId
       x-stoplight:
         id: 9adquhr5t6qx3
-  "/cluster/{clusterId}/lock":
+  '/cluster/{clusterId}/lock':
     parameters:
       - schema:
           type: string
@@ -11769,17 +11769,17 @@ paths:
       tags:
         - Clusters
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterLock"
-        "401":
+                $ref: '#/components/schemas/ClusterLock'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not Found
       operationId: lockCluster
       x-stoplight:
@@ -11789,15 +11789,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ClusterLockRequest"
+              $ref: '#/components/schemas/ClusterLockRequest'
     delete:
       summary: Unlock Cluster
       tags:
         - Clusters
       responses:
-        "204":
+        '204':
           description: No Content
-        "401":
+        '401':
           description: |-
             Unauthorized responses:
                     '204':
@@ -11808,15 +11808,15 @@ paths:
                       $ref: '#/components/responses/403'
                     '404':
                       $ref: '#/components/responses/404'
-        "403":
+        '403':
           description: Forbidden
-        "404":
-          description: ""
+        '404':
+          description: ''
       operationId: unlock-cluster
       x-stoplight:
         id: vkn00s3mt1vew
       description: Unlock a cluster
-  "/cluster/{clusterId}/events":
+  '/cluster/{clusterId}/events':
     get:
       summary: List Cluster Kubernetes Events
       description: List Cluster Kubernetes Events
@@ -11824,14 +11824,14 @@ paths:
       tags:
         - Clusters
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
         - in: query
           name: from_date_time
           description: |
             The start date time to fetch events from, following ISO-8601 format.  
             The `+` character must be escaped (`%2B`)
           required: true
-          example: "2025-03-03T09:00:00+00:00"
+          example: '2025-03-03T09:00:00+00:00'
           schema:
             type: string
             nullable: false
@@ -11841,7 +11841,7 @@ paths:
             The end date time to fetch events from, following ISO-8601 format.  
             The `+` character must be escaped (`%2B`)
           required: true
-          example: "2025-03-03T03:00:00+00:00"
+          example: '2025-03-03T03:00:00+00:00'
           schema:
             type: string
             nullable: false
@@ -11861,7 +11861,7 @@ paths:
           name: reporting_component
           description: The name of the reporting component used to filter events.
       responses:
-        "200":
+        '200':
           description: List Cluster Kubernetes Events
           content:
             application/json:
@@ -11913,7 +11913,7 @@ paths:
                           x-stoplight:
                             id: 5pap12d1475w9
                           format: date-time
-  "/cluster/{clusterId}/metrics":
+  '/cluster/{clusterId}/metrics':
     get:
       summary: Fetch cluster metrics
       description: Fetch cluster metrics.
@@ -11921,7 +11921,7 @@ paths:
       tags:
         - Clusters
       parameters:
-        - $ref: "#/components/parameters/clusterId"
+        - $ref: '#/components/parameters/clusterId'
         - in: query
           name: endpoint
           schema:
@@ -11991,13 +11991,13 @@ paths:
           in: query
           name: range
       responses:
-        "200":
+        '200':
           description: Cluster Metrics
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterMetricsResponse"
-  "/organization/{organizationId}/lock":
+                $ref: '#/components/schemas/ClusterMetricsResponse'
+  '/organization/{organizationId}/lock':
     parameters:
       - schema:
           type: string
@@ -12009,18 +12009,18 @@ paths:
       tags:
         - Organization Cluster Lock
       responses:
-        "200":
+        '200':
           description: OK
           headers: {}
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterLockList"
-        "401":
+                $ref: '#/components/schemas/ClusterLockList'
+        '401':
           description: Unauthorized
-        "403":
+        '403':
           description: Forbidden
-        "404":
+        '404':
           description: Not Found
       operationId: list-cluster-lock
       x-stoplight:
@@ -12030,12 +12030,12 @@ paths:
       summary: Get Deployment Status By DeploymentRequestId
       tags: []
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnvDeploymentStatus"
+                $ref: '#/components/schemas/EnvDeploymentStatus'
       operationId: getDeploymentStatusByDeploymentRequestId
       x-stoplight:
         id: dtvjdlz9teqld
@@ -12047,13 +12047,13 @@ paths:
           name: deploymentRequestId
           required: true
     parameters: []
-  "/organization/{organizationId}/services":
+  '/organization/{organizationId}/services':
     get:
       summary: List Services By OrganizationId
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Service List
           content:
             application/json:
@@ -12065,7 +12065,7 @@ paths:
                     x-stoplight:
                       id: gjtgeehwg4lb9
                     items:
-                      $ref: "#/components/schemas/ServiceLightResponse"
+                      $ref: '#/components/schemas/ServiceLightResponse'
       operationId: listServicesByOrganizationId
       x-stoplight:
         id: qvqb4d0bpjy0v
@@ -12090,13 +12090,13 @@ paths:
         name: organizationId
         in: path
         required: true
-  "/organization/{organizationId}/environments":
+  '/organization/{organizationId}/environments':
     get:
       summary: List Environments By OrganizationId
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: Environment List
           content:
             application/json:
@@ -12106,7 +12106,7 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: "#/components/schemas/OrganizationEnvironmentResponse"
+                      $ref: '#/components/schemas/OrganizationEnvironmentResponse'
       operationId: listEnvironmentsByOrganizationId
     parameters:
       - schema:
@@ -12114,12 +12114,12 @@ paths:
         name: organizationId
         in: path
         required: true
-  "/organization/{organizationId}/parseTerraformVariablesFromGitRepo":
+  '/organization/{organizationId}/parseTerraformVariablesFromGitRepo':
     post:
       summary: Parse Terraform variables from Git repository
       operationId: parseTerraformVariablesFromGitRepo
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       requestBody:
@@ -12127,9 +12127,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformVariableParsingRequest"
+              $ref: '#/components/schemas/TerraformVariableParsingRequest'
       responses:
-        "200":
+        '200':
           description: List of Terraform variable definitions
           content:
             application/json:
@@ -12139,21 +12139,21 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: "#/components/schemas/TerraformVariableDefinition"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/listTfVarsFilesFromGitRepo":
+                      $ref: '#/components/schemas/TerraformVariableDefinition'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/listTfVarsFilesFromGitRepo':
     post:
       summary: List Terraform tfvars files from Git repository
       operationId: listTfVarsFilesFromGitRepo
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Main Calls
       requestBody:
@@ -12161,9 +12161,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TfVarsListRequest"
+              $ref: '#/components/schemas/TfVarsListRequest'
       responses:
-        "200":
+        '200':
           description: List of Terraform tfvars files with their variables
           content:
             application/json:
@@ -12173,16 +12173,16 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: "#/components/schemas/TfVarsFileResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/environment/{environmentId}/deploymentQueue":
+                      $ref: '#/components/schemas/TfVarsFileResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/environment/{environmentId}/deploymentQueue':
     parameters:
       - schema:
           type: string
@@ -12195,7 +12195,7 @@ paths:
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -12207,11 +12207,11 @@ paths:
                     x-stoplight:
                       id: zbjhuwhtkvxkj
                     items:
-                      $ref: "#/components/schemas/QueuedDeploymentRequestWithStages"
+                      $ref: '#/components/schemas/QueuedDeploymentRequestWithStages'
       operationId: listDeploymentRequestByEnvironmentId
       x-stoplight:
         id: 0zhr0vfxayg96
-  "/service/{serviceId}/deploymentQueue":
+  '/service/{serviceId}/deploymentQueue':
     parameters:
       - schema:
           type: string
@@ -12224,7 +12224,7 @@ paths:
       tags:
         - Environment Main Calls
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -12234,11 +12234,11 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: "#/components/schemas/QueuedDeploymentRequestForService"
+                      $ref: '#/components/schemas/QueuedDeploymentRequestForService'
       operationId: listDeploymentRequestByServiceId
       x-stoplight:
         id: augmimjz30ix3
-  "/{serviceType}/{serviceId}/ingressDeploymentStatus":
+  '/{serviceType}/{serviceId}/ingressDeploymentStatus':
     parameters:
       - schema:
           type: string
@@ -12260,84 +12260,84 @@ paths:
       tags:
         - service_status
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IngressDeploymentStatusResponse"
+                $ref: '#/components/schemas/IngressDeploymentStatusResponse'
       operationId: getIngressDeploymentStatus
       x-stoplight:
         id: cji3h6qjunupa
-  "/organization/{organizationId}/azure/credentials":
+  '/organization/{organizationId}/azure/credentials':
     get:
       summary: List Azure credentials
       operationId: listAzureCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentialsResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentialsResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     post:
       summary: Create Azure credentials set
       operationId: createAzureCredentials
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AzureCredentialsRequest"
+              $ref: '#/components/schemas/AzureCredentialsRequest'
       responses:
-        "201":
+        '201':
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/azure/credentials/{credentialsId}":
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/azure/credentials/{credentialsId}':
     get:
       summary: Get a set of Azure credentials
       operationId: getAzureCredentials
       tags:
         - Cloud Provider Credentials
       responses:
-        "200":
+        '200':
           description: Get a set of Azure credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit a set of Azure credentials
       operationId: editAzureCredentials
@@ -12347,36 +12347,36 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AzureCredentialsRequest"
+              $ref: '#/components/schemas/AzureCredentialsRequest'
       responses:
-        "200":
+        '200':
           description: Edit a set of Azure credentials
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterCredentials"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterCredentials'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     delete:
       summary: Delete a set of Azure credentials
       operationId: deleteAzureCredentials
       tags:
         - Cloud Provider Credentials
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     parameters:
       - schema:
           type: string
@@ -12399,40 +12399,40 @@ paths:
       x-stoplight:
         id: pccuw0fgrkcyf
       responses:
-        "200":
+        '200':
           description: list regions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterRegionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterRegionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /azure/clusterFeature:
     get:
       summary: List Azure features available
       tags:
         - Cloud Provider
       responses:
-        "200":
+        '200':
           description: list features available for Azure cloud provider
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterFeatureResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/ClusterFeatureResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: listAzureFeatures
       x-stoplight:
         id: gjin553b2f7mz
-  "/environment/{environmentId}/terraform":
+  '/environment/{environmentId}/terraform':
     get:
       summary: List terraforms
       operationId: listTerraforms
@@ -12441,18 +12441,18 @@ paths:
       tags:
         - Terraforms
       responses:
-        "200":
+        '200':
           description: List terraforms
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/TerraformResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     parameters:
       - schema:
           type: string
@@ -12471,51 +12471,51 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformRequest"
+              $ref: '#/components/schemas/TerraformRequest'
       responses:
-        "201":
+        '201':
           description: Create terraform
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/TerraformResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Terraform name within the environment is already taken
-  "/environment/{environmentId}/link":
+  '/environment/{environmentId}/link':
     get:
       summary: List environment services links
       operationId: listEnvironmentServicesLinks
       parameters:
-        - $ref: "#/components/parameters/environmentId"
+        - $ref: '#/components/parameters/environmentId'
       tags:
         - Environment
       responses:
-        "200":
+        '200':
           description: List environment services links
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LinkResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/LinkResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       x-stoplight:
         id: 94az7c0v1enav
       description: List services links of an environment
-  "/terraform/{terraformId}":
+  '/terraform/{terraformId}':
     parameters:
-      - $ref: "#/components/parameters/terraformId"
+      - $ref: '#/components/parameters/terraformId'
     get:
       summary: Get terraform by ID
       tags:
@@ -12524,18 +12524,18 @@ paths:
       x-stoplight:
         id: s1dctms0dixdl
       responses:
-        "200":
+        '200':
           description: Get terrafor by ID
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/TerraformResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Edit Terraform
       tags:
@@ -12547,23 +12547,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformRequest"
+              $ref: '#/components/schemas/TerraformRequest'
       responses:
-        "200":
+        '200':
           description: Edit Terraform
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/TerraformResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Terraform name within the environment is already taken
     delete:
       summary: Delete Terraform
@@ -12573,28 +12573,28 @@ paths:
       x-stoplight:
         id: 518sjlmziel46
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       parameters:
         - in: query
           name: resources_only
           schema:
             type: boolean
             default: false
-          description: "When true, only resources are deleted and Qovery configuration is kept."
+          description: 'When true, only resources are deleted and Qovery configuration is kept.'
         - in: query
           name: force_terraform_action
           required: false
           schema:
-            $ref: "#/components/schemas/DeleteTerraformAction"
+            $ref: '#/components/schemas/DeleteTerraformAction'
           description: Force a specific action to be executed by Terraform during deletion.
-  "/terraform/{terraformId}/advancedSettings":
+  '/terraform/{terraformId}/advancedSettings':
     get:
       summary: Get Advanced settings
       tags:
@@ -12603,18 +12603,18 @@ paths:
       x-stoplight:
         id: hth6esl7sqliu
       responses:
-        "200":
+        '200':
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/TerraformAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     parameters:
       - schema:
           type: string
@@ -12633,65 +12633,65 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformAdvancedSettings"
+              $ref: '#/components/schemas/TerraformAdvancedSettings'
       responses:
-        "201":
+        '201':
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformAdvancedSettings"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/terraform/{terraformId}/deploy":
+                $ref: '#/components/schemas/TerraformAdvancedSettings'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/terraform/{terraformId}/deploy':
     post:
       summary: Deploy terraform
       description: You must provide a git commit id.
       operationId: deployTerraform
       parameters:
-        - $ref: "#/components/parameters/terraformId"
+        - $ref: '#/components/parameters/terraformId'
       tags:
         - Terraform Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformDeployRequest"
+              $ref: '#/components/schemas/TerraformDeployRequest'
       responses:
-        "202":
+        '202':
           description: Deploy terraform
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/Status'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/terraform/{terraformId}/uninstall":
+  '/terraform/{terraformId}/uninstall':
     post:
       summary: Uninstall terraform
       description: Delete the resources of the terraform but keep Qovery configuration
       operationId: uninstallTerraform
       parameters:
-        - $ref: "#/components/parameters/terraformId"
+        - $ref: '#/components/parameters/terraformId'
         - in: query
           name: force_terraform_action
           required: false
           schema:
-            $ref: "#/components/schemas/DeleteTerraformAction"
+            $ref: '#/components/schemas/DeleteTerraformAction'
           description: Force a specific action to be executed by Terraform during uninstall.
       tags:
         - Terraform Actions
@@ -12702,23 +12702,23 @@ paths:
               type: object
               properties: {}
       responses:
-        "202":
-          description: "Delete the compute and data of the service, but keep Qovery configuration"
+        '202':
+          description: 'Delete the compute and data of the service, but keep Qovery configuration'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Status"
-        "204":
+                $ref: '#/components/schemas/Status'
+        '204':
           description: No deployment has been triggered
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
       x-stoplight:
         id: awjvr4y02cr23
@@ -12734,16 +12734,16 @@ paths:
       tags:
         - Terraforms
       responses:
-        "200":
+        '200':
           description: Default terraform advanced settings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformAdvancedSettings"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/TerraformAdvancedSettings'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
       operationId: getDefaultTerraformAdvancedSettings
       x-stoplight:
         id: 5qcyy764ewhk3
@@ -12754,48 +12754,48 @@ paths:
         - Terraform Main Calls
       operationId: listTerraformVersions
       responses:
-        "200":
+        '200':
           description: List available Terraform versions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformVersionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/terraform/{terraformId}/clone":
+                $ref: '#/components/schemas/TerraformVersionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/terraform/{terraformId}/clone':
     post:
       summary: Clone terraform
       description: This will create a new terraform with the same configuration on the targeted environment Id.
       operationId: cloneTerraform
       parameters:
-        - $ref: "#/components/parameters/terraformId"
+        - $ref: '#/components/parameters/terraformId'
       tags:
         - Terraforms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CloneServiceRequest"
+              $ref: '#/components/schemas/CloneServiceRequest'
       responses:
-        "202":
+        '202':
           description: Terraform clone has been requested
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
+                $ref: '#/components/schemas/TerraformResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
           description: Operation is in progress
-  "/terraform/{terraformId}/deploymentHistoryV2":
+  '/terraform/{terraformId}/deploymentHistoryV2':
     parameters:
       - schema:
           type: string
@@ -12817,44 +12817,44 @@ paths:
       tags:
         - Terraform Deployment History
       responses:
-        "200":
+        '200':
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: listTerraformDeploymentHistoryV2
       x-stoplight:
         id: qxm14ubc0l5dq
-  "/terraform/{terraformId}/commit":
+  '/terraform/{terraformId}/commit':
     get:
       summary: List last commits
       description: Returns list of the last 100 commits made on the repository linked to the terraform service
       operationId: listTerraformCommit
       parameters:
-        - $ref: "#/components/parameters/terraformId"
+        - $ref: '#/components/parameters/terraformId'
       tags:
         - Terraform Main Calls
       responses:
-        "200":
+        '200':
           description: List commits
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CommitResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/terraform/{terraformId}/deploymentRestriction":
+                $ref: '#/components/schemas/CommitResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/terraform/{terraformId}/deploymentRestriction':
     parameters:
       - schema:
           type: string
@@ -12867,18 +12867,18 @@ paths:
       tags:
         - Terraform Deployment Restriction
       responses:
-        "200":
+        '200':
           description: Get terraform deployment restrictions
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformDeploymentRestrictionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/TerraformDeploymentRestrictionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: getTerraformDeploymentRestrictions
       x-stoplight:
         id: q3y44x1wdigcd
@@ -12891,26 +12891,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/TerraformDeploymentRestrictionRequest'
       responses:
-        "201":
+        '201':
           description: Added an terraform deployment restriction
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformDeploymentRestrictionResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "409":
+                $ref: '#/components/schemas/TerraformDeploymentRestrictionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '409':
           description: A terraform deployment restriction with same properties already exists for this terraform
       operationId: createTerraformDeploymentRestriction
       x-stoplight:
         id: l6192gxde3sbv
-  "/terraform/{terraformId}/deploymentRestriction/{deploymentRestrictionId}":
+  '/terraform/{terraformId}/deploymentRestriction/{deploymentRestrictionId}':
     parameters:
       - schema:
           type: string
@@ -12933,22 +12933,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TerraformDeploymentRestrictionRequest"
+              $ref: '#/components/schemas/TerraformDeploymentRestrictionRequest'
       responses:
-        "200":
+        '200':
           description: Edit a terraform deployment restriction
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformDeploymentRestrictionResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/TerraformDeploymentRestrictionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: editTerraformDeploymentRestriction
       x-stoplight:
         id: w3jp2xci6bogt
@@ -12958,20 +12958,20 @@ paths:
       tags:
         - Terraform Deployment Restriction
       responses:
-        "204":
-          $ref: "#/components/responses/204-deletion"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '204':
+          $ref: '#/components/responses/204-deletion'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: deleteTerraformDeploymentRestriction
       x-stoplight:
         id: d896flm9ibi54
-  "/terraform/{terraformId}/terraformResources":
+  '/terraform/{terraformId}/terraformResources':
     parameters:
-      - $ref: "#/components/parameters/terraformId"
+      - $ref: '#/components/parameters/terraformId'
     get:
       summary: Get terraform resources from latest deployment
       description: Returns the list of Terraform resources from the most recent deployment execution
@@ -12981,19 +12981,19 @@ paths:
       x-stoplight:
         id: terraform-resources-get
       responses:
-        "200":
+        '200':
           description: List of terraform resources from latest deployment
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TerraformResourcesResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/credentials":
+                $ref: '#/components/schemas/TerraformResourcesResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/credentials':
     parameters:
       - schema:
           type: string
@@ -13005,19 +13005,19 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrganizationCrendentialsResponseList"
-        "400":
+                $ref: '#/components/schemas/OrganizationCrendentialsResponseList'
+        '400':
           description: Bad Request
       operationId: listOrganizationCredentials
       x-stoplight:
         id: 2jm9tyqfhw4xf
       description: List credentials of an organization and their associated clusters
-  "/cluster/{clusterId}/logs":
+  '/cluster/{clusterId}/logs':
     parameters:
       - schema:
           type: string
@@ -13027,12 +13027,12 @@ paths:
     get:
       summary: Fetch cluster logs
       responses:
-        "200":
+        '200':
           description: Cluster Logs
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterLogsResponse"
+                $ref: '#/components/schemas/ClusterLogsResponse'
       operationId: get-cluster-logs
       tags:
         - Clusters
@@ -13082,45 +13082,45 @@ paths:
             type: string
           in: query
           name: time
-  "/organization/{organizationId}/enterpriseconnection":
+  '/organization/{organizationId}/enterpriseconnection':
     get:
       summary: List enterprise connections
       operationId: listOrganizationEnterpriseConnections
       parameters:
-        - $ref: "#/components/parameters/organizationId"
+        - $ref: '#/components/parameters/organizationId'
       tags:
         - Organization Enterprise Connection
       responses:
-        "200":
+        '200':
           description: List enterprise connections
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnterpriseConnectionResponseList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/organization/{organizationId}/alert-receivers":
+                $ref: '#/components/schemas/EnterpriseConnectionResponseList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+  '/organization/{organizationId}/alert-receivers':
     get:
       summary: List alert receivers
       tags:
         - Alert Receivers
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertReceiverList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AlertReceiverList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: getAlertReceivers
       x-stoplight:
         id: 3cqb2xpmir9n8
@@ -13133,72 +13133,72 @@ paths:
         schema:
           type: string
           format: uuid
-  "/organization/{organizationId}/enterpriseconnection/{connectionName}":
+  '/organization/{organizationId}/enterpriseconnection/{connectionName}':
     get:
       summary: Get enterprise connection
       operationId: getOrganizationEnterpriseConnection
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/connectionName"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/connectionName'
       tags:
         - Organization Enterprise Connection
       responses:
-        "200":
+        '200':
           description: Get enterprise connection
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnterpriseConnectionDto"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnterpriseConnectionDto'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
     put:
       summary: Update enterprise connection
       operationId: updateOrganizationEnterpriseConnection
       parameters:
-        - $ref: "#/components/parameters/organizationId"
-        - $ref: "#/components/parameters/connectionName"
+        - $ref: '#/components/parameters/organizationId'
+        - $ref: '#/components/parameters/connectionName'
       tags:
         - Organization Enterprise Connection
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnterpriseConnectionDto"
+              $ref: '#/components/schemas/EnterpriseConnectionDto'
       responses:
-        "200":
+        '200':
           description: Update enterprise connection
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EnterpriseConnectionDto"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/EnterpriseConnectionDto'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
   /alert-receivers:
     post:
       summary: Create alert receiver
       tags:
         - Alert Receivers
       responses:
-        "201":
-          description: " Alert receiver successfully created"
+        '201':
+          description: ' Alert receiver successfully created'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertReceiverResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/AlertReceiverResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
       operationId: createAlertReceiver
       x-stoplight:
         id: 56wdp3pyd4jfy
@@ -13207,27 +13207,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AlertReceiverCreationRequest"
-  "/alert-receivers/{alertReceiverId}":
+              $ref: '#/components/schemas/AlertReceiverCreationRequest'
+  '/alert-receivers/{alertReceiverId}':
     parameters:
-      - $ref: "#/components/parameters/alertReceiverId"
+      - $ref: '#/components/parameters/alertReceiverId'
     get:
       summary: Get alert receiver
       tags:
         - Alert Receivers
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertReceiverResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AlertReceiverResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: getAlertReceiver
       x-stoplight:
         id: z0qs6btegz9c3
@@ -13237,20 +13237,20 @@ paths:
       tags:
         - Alert Receivers
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertReceiverResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AlertReceiverResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: editAlertReceiver
       x-stoplight:
         id: lcy99zdslr1cb
@@ -13259,20 +13259,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AlertReceiverEditRequest"
+              $ref: '#/components/schemas/AlertReceiverEditRequest'
     delete:
       summary: Delete alert receiver
       tags:
         - Alert Receivers
       responses:
-        "204":
+        '204':
           description: Alert receiver successfully deleted
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: deleteAlertReceiver
       x-stoplight:
         id: vwt0mube2wcb6
@@ -13283,18 +13283,18 @@ paths:
       tags:
         - Alert Rules
       responses:
-        "201":
+        '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertRuleResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
+                $ref: '#/components/schemas/AlertRuleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
       operationId: createAlertRule
       x-stoplight:
         id: htbtqo7s45dzg
@@ -13303,27 +13303,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AlertRuleCreationRequest"
-  "/alert-rules/{alertRuleId}":
+              $ref: '#/components/schemas/AlertRuleCreationRequest'
+  '/alert-rules/{alertRuleId}':
     parameters:
-      - $ref: "#/components/parameters/alertRuleId"
+      - $ref: '#/components/parameters/alertRuleId'
     get:
       summary: Get alert rule
       tags:
         - Alert Rules
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertRuleResponse"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AlertRuleResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: getAlertRule
       x-stoplight:
         id: qfitd78wejspk
@@ -13333,20 +13333,20 @@ paths:
       tags:
         - Alert Rules
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertRuleResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AlertRuleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: editAlertRule
       x-stoplight:
         id: cj5a3t08qw1aj
@@ -13355,66 +13355,66 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AlertRuleEditRequest"
+              $ref: '#/components/schemas/AlertRuleEditRequest'
     delete:
       summary: Delete alert rule
       tags:
         - Alert Rules
       responses:
-        "204":
+        '204':
           description: Alert rule successfully deleted
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: deleteAlertRule
       x-stoplight:
         id: 812453spx2l0f
       description: Delete an alert rule
-  "/organization/{organizationId}/alert-rules":
+  '/organization/{organizationId}/alert-rules':
     parameters:
-      - $ref: "#/components/parameters/organizationId"
+      - $ref: '#/components/parameters/organizationId'
     get:
       summary: List alert rules
       tags:
         - Alert Rules
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AlertRuleList"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/AlertRuleList'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: getAlertRules
       x-stoplight:
         id: xkza3tt52gwse
       description: Retrieve all alert rules for a specific organization
-  "/alert-receivers/{alertReceiverId}/validate":
+  '/alert-receivers/{alertReceiverId}/validate':
     parameters:
-      - $ref: "#/components/parameters/alertReceiverId"
+      - $ref: '#/components/parameters/alertReceiverId'
     post:
       summary: Validate Existing Alert Receiver
       tags:
         - Alert Receivers
       responses:
-        "200":
+        '200':
           description: OK
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: validateExistingAlertReceiver
       x-stoplight:
         id: uz8sv9wwxy3ib
@@ -13423,23 +13423,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AlertReceiverValidationRequest"
+              $ref: '#/components/schemas/AlertReceiverValidationRequest'
   /alert-receivers/validate:
     post:
       summary: Validate New Alert Receiver
       tags:
         - Alert Receivers
       responses:
-        "200":
+        '200':
           description: OK
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
       operationId: validateNewAlertReceiver
       x-stoplight:
         id: jqejmmiehaxlm
@@ -13447,7 +13447,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AlertReceiverCreationValidationRequest"
+              $ref: '#/components/schemas/AlertReceiverCreationValidationRequest'
       description: Validate a future alert receiver by sending a test message.
 components:
   parameters:
@@ -13813,7 +13813,7 @@ components:
         argocd_url:
           type: string
           description: The URL of the ArgoCD instance (e.g. https://argocd.example.com)
-          example: "https://argocd.example.com"
+          example: 'https://argocd.example.com'
         argocd_token:
           type: string
           description: ArgoCD API authentication token
@@ -13835,7 +13835,7 @@ components:
           format: uuid
         argocd_url:
           type: string
-          example: "https://argocd.example.com"
+          example: 'https://argocd.example.com'
         argocd_token:
           type: string
           description: Always returned as REDACTED
@@ -13881,13 +13881,13 @@ components:
             - kubernetes
           properties:
             kubernetes:
-              $ref: "#/components/schemas/TerraformBackendKubernetes"
+              $ref: '#/components/schemas/TerraformBackendKubernetes'
         - type: object
           required:
             - user_provided
           properties:
             user_provided:
-              $ref: "#/components/schemas/TerraformBackendUserProvided"
+              $ref: '#/components/schemas/TerraformBackendUserProvided'
       description: Configuration for Terraform backend - exactly one backend type must be specified
     TerraformBackendKubernetes:
       type: object
@@ -13944,9 +13944,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_type:
-          $ref: "#/components/schemas/APIVariableTypeEnum"
+          $ref: '#/components/schemas/APIVariableTypeEnum'
         description:
           type: string
           x-stoplight:
@@ -13982,17 +13982,6 @@ components:
             Define how you want pods affinity to behave:
             * `Preferred` allows, but does not require, pods of a given service are not co-located (or co-hosted) on a single node
             * `Requirred` ensures that the pods of a given service are not co-located (or co-hosted) on a single node (safer in term of availability but can be expensive depending on the number of replicas)
-        deployment.topology_spread.zone:
-          type: string
-          enum:
-            - Disabled
-            - ScheduleAnyway
-            - DoNotSchedule
-          description: |
-            Define how you want pods to be spread across availability zones:
-            * `Disabled` no topology spread constraints are applied
-            * `ScheduleAnyway` pods are spread across zones on a best-effort basis (soft constraint)
-            * `DoNotSchedule` pods must be evenly spread across zones with a maxSkew of 1 (hard constraint)
         deployment.lifecycle.post_start_exec_command:
           type: array
           x-stoplight:
@@ -14042,7 +14031,7 @@ components:
           type: boolean
           x-stoplight:
             id: am7oh5tdono3z
-          description: "When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available"
+          description: 'When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available'
         network.ingress.enable_cors:
           type: boolean
         network.ingress.cors_allow_origin:
@@ -14138,8 +14127,8 @@ components:
             Mounts the container's root filesystem as read-only
     Application:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/ServiceStorage"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/ServiceStorage'
         - type: object
           required:
             - environment
@@ -14149,9 +14138,9 @@ components:
             - service_type
           properties:
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             git_repository:
-              $ref: "#/components/schemas/ApplicationGitRepository"
+              $ref: '#/components/schemas/ApplicationGitRepository'
             maximum_cpu:
               type: integer
               description: Maximum cpu that can be allocated to the application based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu
@@ -14173,7 +14162,7 @@ components:
               type: string
               description: give a description to this application
             build_mode:
-              $ref: "#/components/schemas/BuildModeEnum"
+              $ref: '#/components/schemas/BuildModeEnum'
             dockerfile_path:
               type: string
               description: The path of the associated Dockerfile. Only if you are using build_mode = DOCKER
@@ -14206,7 +14195,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             auto_preview:
               type: boolean
               description: |
@@ -14215,7 +14204,7 @@ components:
                 If not specified, it takes the value of the `auto_preview` property from the associated environment.
               default: true
             ports:
-              $ref: "#/components/schemas/ServicePortResponseList"
+              $ref: '#/components/schemas/ServicePortResponseList'
             arguments:
               type: array
               items:
@@ -14227,9 +14216,9 @@ components:
               type: boolean
               description: Specify if the application will be automatically updated after receiving a new commit.
             annotations_groups:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
             labels_groups:
-              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
             icon_uri:
               type: string
               format: uri
@@ -14237,7 +14226,7 @@ components:
               x-stoplight:
                 id: b8karc43pdxpu
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
             docker_target_build_stage:
               type: string
               x-stoplight:
@@ -14245,11 +14234,11 @@ components:
               description: The target build stage in the Dockerfile to build
               nullable: true
             autoscaling:
-              $ref: "#/components/schemas/AutoscalingPolicyResponse"
+              $ref: '#/components/schemas/AutoscalingPolicyResponse'
     ApplicationDeploymentRestriction:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/ApplicationDeploymentRestrictionRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/ApplicationDeploymentRestrictionRequest'
     ApplicationDeploymentRestrictionRequest:
       type: object
       required:
@@ -14258,12 +14247,12 @@ components:
         - value
       properties:
         mode:
-          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
         type:
-          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
         value:
           type: string
-          description: "For `PATH` restrictions, the value must not start with `/`"
+          description: 'For `PATH` restrictions, the value must not start with `/`'
           example: application1/src/
     ApplicationDeploymentRestrictionResponseList:
       type: object
@@ -14271,10 +14260,10 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ApplicationDeploymentRestriction"
+            $ref: '#/components/schemas/ApplicationDeploymentRestriction'
     ApplicationEditRequest:
       allOf:
-        - $ref: "#/components/schemas/ServiceStorageRequest"
+        - $ref: '#/components/schemas/ServiceStorageRequest'
         - type: object
           required:
             - healthchecks
@@ -14286,9 +14275,9 @@ components:
               type: string
               description: give a description to this application
             git_repository:
-              $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+              $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
             build_mode:
-              $ref: "#/components/schemas/BuildModeEnum"
+              $ref: '#/components/schemas/BuildModeEnum'
             dockerfile_path:
               type: string
               description: The path of the associated Dockerfile
@@ -14324,7 +14313,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             auto_preview:
               type: boolean
               description: |
@@ -14333,7 +14322,7 @@ components:
                 If not specified, it takes the value of the `auto_preview` property from the associated environment.
               default: true
             ports:
-              $ref: "#/components/schemas/ServicePortResponseList"
+              $ref: '#/components/schemas/ServicePortResponseList'
             arguments:
               type: array
               items:
@@ -14346,9 +14335,9 @@ components:
               description: Specify if the application will be automatically updated after receiving a new commit.
               nullable: true
             annotations_groups:
-              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
+              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
             labels_groups:
-              $ref: "#/components/schemas/ServiceLabelsRequestList"
+              $ref: '#/components/schemas/ServiceLabelsRequestList'
             icon_uri:
               type: string
               format: uri
@@ -14358,7 +14347,7 @@ components:
               description: The target build stage in the Dockerfile to build
               nullable: true
             autoscaling:
-              $ref: "#/components/schemas/AutoscalingPolicyRequest"
+              $ref: '#/components/schemas/AutoscalingPolicyRequest'
     ApplicationGitRepository:
       type: object
       required:
@@ -14370,7 +14359,7 @@ components:
         has_access:
           type: boolean
         provider:
-          $ref: "#/components/schemas/GitProviderEnum"
+          $ref: '#/components/schemas/GitProviderEnum'
         owner:
           type: string
           example: John Doe
@@ -14405,7 +14394,7 @@ components:
         git_token_name:
           type: string
           nullable: true
-      title: ""
+      title: ''
     ApplicationGitRepositoryRequest:
       type: object
       required:
@@ -14417,7 +14406,7 @@ components:
         url:
           type: string
           description: application git repository URL
-          example: "https://github.com/Qovery/simple-node-app"
+          example: 'https://github.com/Qovery/simple-node-app'
         branch:
           type: string
           description: |
@@ -14434,7 +14423,7 @@ components:
           description: The git token id on Qovery side
           nullable: true
         provider:
-          $ref: "#/components/schemas/GitProviderEnum"
+          $ref: '#/components/schemas/GitProviderEnum'
     ApplicationNetwork:
       type: object
       properties:
@@ -14481,7 +14470,7 @@ components:
           type: boolean
           description: is the default port to use for domain
         protocol:
-          $ref: "#/components/schemas/PortProtocolEnum"
+          $ref: '#/components/schemas/PortProtocolEnum'
         public_path:
           type: string
           description: |-
@@ -14498,7 +14487,7 @@ components:
     ServicePortResponseList:
       type: array
       items:
-        $ref: "#/components/schemas/ServicePort"
+        $ref: '#/components/schemas/ServicePort'
     ServicePortRequest:
       type: object
       properties:
@@ -14530,7 +14519,7 @@ components:
                 type: boolean
                 description: is the default port to use for domain
               protocol:
-                $ref: "#/components/schemas/PortProtocolEnum"
+                $ref: '#/components/schemas/PortProtocolEnum'
               public_path:
                 type: string
                 description: |-
@@ -14547,7 +14536,7 @@ components:
     ServiceAnnotationsRequestList:
       type: array
       items:
-        $ref: "#/components/schemas/ServiceAnnotationRequest"
+        $ref: '#/components/schemas/ServiceAnnotationRequest'
     ServiceAnnotationRequest:
       type: object
       required:
@@ -14559,7 +14548,7 @@ components:
     ServiceLabelsRequestList:
       type: array
       items:
-        $ref: "#/components/schemas/ServiceLabelRequest"
+        $ref: '#/components/schemas/ServiceLabelRequest'
     ServiceLabelRequest:
       type: object
       required:
@@ -14570,8 +14559,8 @@ components:
           format: uuid
     ApplicationRequest:
       allOf:
-        - $ref: "#/components/schemas/ServiceStorageRequest"
-        - $ref: "#/components/schemas/ServicePortRequest"
+        - $ref: '#/components/schemas/ServiceStorageRequest'
+        - $ref: '#/components/schemas/ServicePortRequest'
         - type: object
           required:
             - name
@@ -14586,9 +14575,9 @@ components:
               description: give a description to this application
               nullable: true
             git_repository:
-              $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+              $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
             build_mode:
-              $ref: "#/components/schemas/BuildModeEnum"
+              $ref: '#/components/schemas/BuildModeEnum'
             dockerfile_path:
               type: string
               description: The path of the associated Dockerfile. Only if you are using build_mode = DOCKER
@@ -14624,7 +14613,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             auto_preview:
               type: boolean
               description: |
@@ -14644,9 +14633,9 @@ components:
               description: Specify if the application will be automatically updated after receiving a new commit.
               nullable: true
             annotations_groups:
-              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
+              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
             labels_groups:
-              $ref: "#/components/schemas/ServiceLabelsRequestList"
+              $ref: '#/components/schemas/ServiceLabelsRequestList'
             icon_uri:
               type: string
               format: uri
@@ -14660,14 +14649,14 @@ components:
               description: The target build stage in the Dockerfile to build
               nullable: true
             autoscaling:
-              $ref: "#/components/schemas/AutoscalingPolicyRequest"
+              $ref: '#/components/schemas/AutoscalingPolicyRequest'
     ApplicationResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Application"
+            $ref: '#/components/schemas/Application'
     ServiceStorage:
       type: object
       properties:
@@ -14685,7 +14674,7 @@ components:
                 type: string
                 format: uuid
               type:
-                $ref: "#/components/schemas/StorageTypeEnum"
+                $ref: '#/components/schemas/StorageTypeEnum'
               size:
                 type: integer
                 description: unit is GB
@@ -14709,7 +14698,7 @@ components:
                 type: string
                 format: uuid
               type:
-                $ref: "#/components/schemas/StorageTypeEnum"
+                $ref: '#/components/schemas/StorageTypeEnum'
               size:
                 type: integer
                 description: |
@@ -14727,7 +14716,7 @@ components:
         - is_mandatory
       properties:
         kind:
-          $ref: "#/components/schemas/ContainerRegistryKindEnum"
+          $ref: '#/components/schemas/ContainerRegistryKindEnum'
         required_config:
           type: object
           additionalProperties: true
@@ -14739,7 +14728,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/AvailableContainerRegistryResponse"
+            $ref: '#/components/schemas/AvailableContainerRegistryResponse'
     AvailableHelmRepositoryResponse:
       type: object
       required:
@@ -14748,7 +14737,7 @@ components:
         - is_mandatory
       properties:
         kind:
-          $ref: "#/components/schemas/HelmRepositoryKindEnum"
+          $ref: '#/components/schemas/HelmRepositoryKindEnum'
         required_config:
           type: object
           additionalProperties: true
@@ -14760,11 +14749,11 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/AvailableHelmRepositoryResponse"
+            $ref: '#/components/schemas/AvailableHelmRepositoryResponse'
     AwsCredentialsRequest:
       oneOf:
-        - $ref: "#/components/schemas/AwsRoleCredentialsRequest"
-        - $ref: "#/components/schemas/AwsStaticCredentialsRequest"
+        - $ref: '#/components/schemas/AwsRoleCredentialsRequest'
+        - $ref: '#/components/schemas/AwsStaticCredentialsRequest'
     AwsStaticCredentialsRequest:
       required:
         - name
@@ -14803,16 +14792,16 @@ components:
           type: string
     Backup:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/BackupRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/BackupRequest'
         - type: object
           properties:
             status:
-              $ref: "#/components/schemas/Status"
+              $ref: '#/components/schemas/Status'
     BackupPaginatedResponseList:
       allOf:
-        - $ref: "#/components/schemas/PaginationData"
-        - $ref: "#/components/schemas/BackupResponseList"
+        - $ref: '#/components/schemas/PaginationData'
+        - $ref: '#/components/schemas/BackupResponseList'
     BackupRequest:
       type: object
       required:
@@ -14829,7 +14818,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Backup"
+            $ref: '#/components/schemas/Backup'
     Base:
       type: object
       required:
@@ -14863,7 +14852,7 @@ components:
           type: string
           format: email
           example: forrest@gump.com
-          description: "email used for billing, and to receive all invoices by email"
+          description: 'email used for billing, and to receive all invoices by email'
           nullable: true
         address:
           type: string
@@ -14875,7 +14864,7 @@ components:
           nullable: true
         zip:
           type: string
-          example: "36744"
+          example: '36744'
           nullable: true
         state:
           type: string
@@ -14915,7 +14904,7 @@ components:
           type: string
           format: email
           example: forrest@gump.com
-          description: "email used for billing, and to receive all invoices by email"
+          description: 'email used for billing, and to receive all invoices by email'
         address:
           type: string
           example: 21 Jenny Street
@@ -14924,7 +14913,7 @@ components:
           example: Greenbow
         zip:
           type: string
-          example: "36744"
+          example: '36744'
         state:
           type: string
           example: Alabama
@@ -14981,7 +14970,7 @@ components:
           type: string
           format: uuid
         mode:
-          $ref: "#/components/schemas/EnvironmentModeEnum"
+          $ref: '#/components/schemas/EnvironmentModeEnum'
         apply_deployment_rule:
           type: boolean
           default: false
@@ -15011,7 +15000,7 @@ components:
         regions:
           type: array
           items:
-            $ref: "#/components/schemas/ClusterRegion"
+            $ref: '#/components/schemas/ClusterRegion'
     CloudProviderEnum:
       type: string
       enum:
@@ -15026,7 +15015,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/CloudProvider"
+            $ref: '#/components/schemas/CloudProvider'
     CloudVendorEnum:
       type: string
       enum:
@@ -15043,7 +15032,7 @@ components:
         - ON_PREMISE
     Cluster:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - organization
@@ -15052,7 +15041,7 @@ components:
             - cloud_provider
           properties:
             organization:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             name:
               type: string
               description: name is case-insensitive
@@ -15061,7 +15050,7 @@ components:
             region:
               type: string
             cloud_provider:
-              $ref: "#/components/schemas/CloudVendorEnum"
+              $ref: '#/components/schemas/CloudVendorEnum'
             min_running_nodes:
               type: integer
               default: 1
@@ -15088,9 +15077,9 @@ components:
             instance_type:
               type: string
               example: T3A_LARGE
-              description: "the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType"
+              description: 'the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType'
             kubernetes:
-              $ref: "#/components/schemas/KubernetesEnum"
+              $ref: '#/components/schemas/KubernetesEnum'
             cpu:
               type: integer
               example: 10000
@@ -15101,9 +15090,9 @@ components:
               description: unit is MB. 1024 MB = 1GB
             estimated_cloud_provider_cost:
               type: integer
-              description: "This is an estimation of the cost this cluster will represent on your cloud proider bill, based on your current configuration"
+              description: 'This is an estimation of the cost this cluster will represent on your cloud proider bill, based on your current configuration'
             status:
-              $ref: "#/components/schemas/ClusterStateEnum"
+              $ref: '#/components/schemas/ClusterStateEnum'
             has_access:
               type: boolean
             version:
@@ -15124,19 +15113,19 @@ components:
             features:
               type: array
               items:
-                $ref: "#/components/schemas/ClusterFeatureResponse"
+                $ref: '#/components/schemas/ClusterFeatureResponse'
             deployment_status:
-              $ref: "#/components/schemas/ClusterDeploymentStatusEnum"
+              $ref: '#/components/schemas/ClusterDeploymentStatusEnum'
             metrics_parameters:
-              $ref: "#/components/schemas/MetricsParameters"
+              $ref: '#/components/schemas/MetricsParameters'
             infrastructure_outputs:
-              $ref: "#/components/schemas/InfrastructureOutputs"
+              $ref: '#/components/schemas/InfrastructureOutputs'
             infrastructure_charts_parameters:
-              $ref: "#/components/schemas/ClusterInfrastructureChartsParameters"
+              $ref: '#/components/schemas/ClusterInfrastructureChartsParameters'
             keda:
-              $ref: "#/components/schemas/ClusterKeda"
+              $ref: '#/components/schemas/ClusterKeda'
             labels_groups:
-              $ref: "#/components/schemas/ClusterLabelsGroupList"
+              $ref: '#/components/schemas/ClusterLabelsGroupList'
     ClusterDeleteMode:
       type: string
       description: |
@@ -15162,7 +15151,7 @@ components:
           type: string
           description: log date creation
           format: date-time
-          example: "2022-06-22T14:20:17.733084815Z"
+          example: '2022-06-22T14:20:17.733084815Z'
         step:
           description: log step
           example: Create
@@ -15238,7 +15227,7 @@ components:
                   description: technical details about the error
         details:
           type: object
-          description: "Present only for `info`, `warning` and `debug` logs"
+          description: 'Present only for `info`, `warning` and `debug` logs'
           properties:
             provider_kind:
               type: string
@@ -15263,7 +15252,7 @@ components:
       type: object
       properties:
         cloud_provider:
-          $ref: "#/components/schemas/CloudProviderEnum"
+          $ref: '#/components/schemas/CloudProviderEnum'
         credentials:
           type: object
           properties:
@@ -15278,7 +15267,7 @@ components:
       type: object
       properties:
         cloud_provider:
-          $ref: "#/components/schemas/CloudProviderEnum"
+          $ref: '#/components/schemas/CloudProviderEnum'
         credentials:
           type: object
           properties:
@@ -15306,21 +15295,21 @@ components:
             type: string
     ClusterCredentials:
       oneOf:
-        - $ref: "#/components/schemas/AwsStaticClusterCredentials"
-        - $ref: "#/components/schemas/ScalewayClusterCredentials"
-        - $ref: "#/components/schemas/GenericClusterCredentials"
-        - $ref: "#/components/schemas/AwsRoleClusterCredentials"
-        - $ref: "#/components/schemas/AzureStaticClusterCredentials"
-        - $ref: "#/components/schemas/GcpStaticClusterCredentials"
+        - $ref: '#/components/schemas/AwsStaticClusterCredentials'
+        - $ref: '#/components/schemas/ScalewayClusterCredentials'
+        - $ref: '#/components/schemas/GenericClusterCredentials'
+        - $ref: '#/components/schemas/AwsRoleClusterCredentials'
+        - $ref: '#/components/schemas/AzureStaticClusterCredentials'
+        - $ref: '#/components/schemas/GcpStaticClusterCredentials'
       discriminator:
         propertyName: object_type
         mapping:
-          AWS: "#/components/schemas/AwsStaticClusterCredentials"
-          AWS_ROLE: "#/components/schemas/AwsRoleClusterCredentials"
-          SCW: "#/components/schemas/ScalewayClusterCredentials"
-          OTHER: "#/components/schemas/GenericClusterCredentials"
-          AZURE: "#/components/schemas/AzureStaticClusterCredentials"
-          GCP: "#/components/schemas/GcpStaticClusterCredentials"
+          AWS: '#/components/schemas/AwsStaticClusterCredentials'
+          AWS_ROLE: '#/components/schemas/AwsRoleClusterCredentials'
+          SCW: '#/components/schemas/ScalewayClusterCredentials'
+          OTHER: '#/components/schemas/GenericClusterCredentials'
+          AZURE: '#/components/schemas/AzureStaticClusterCredentials'
+          GCP: '#/components/schemas/GcpStaticClusterCredentials'
     AwsStaticClusterCredentials:
       x-stoplight:
         id: s0aosg7la96hp
@@ -15430,7 +15419,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ClusterCredentials"
+            $ref: '#/components/schemas/ClusterCredentials'
     ClusterFeatureResponse:
       type: object
       properties:
@@ -15464,7 +15453,7 @@ components:
           example: true
         cloud_provider_feature_documentation:
           type: string
-          example: "https://cloud.provider.doc/feature"
+          example: 'https://cloud.provider.doc/feature'
           nullable: true
         is_qovery_paying_feature:
           type: boolean
@@ -15472,7 +15461,7 @@ components:
           example: true
         qovery_feature_documentation:
           type: string
-          example: "https://qovery.doc/feature"
+          example: 'https://qovery.doc/feature'
           nullable: true
         value_type:
           type: string
@@ -15482,19 +15471,19 @@ components:
         value_object:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/ClusterFeatureStringResponse"
-            - $ref: "#/components/schemas/ClusterFeatureBooleanResponse"
-            - $ref: "#/components/schemas/ClusterFeatureAwsExistingVpcResponse"
-            - $ref: "#/components/schemas/ClusterFeatureGcpExistingVpcResponse"
-            - $ref: "#/components/schemas/ClusterFeatureKarpenterParametersResponse"
+            - $ref: '#/components/schemas/ClusterFeatureStringResponse'
+            - $ref: '#/components/schemas/ClusterFeatureBooleanResponse'
+            - $ref: '#/components/schemas/ClusterFeatureAwsExistingVpcResponse'
+            - $ref: '#/components/schemas/ClusterFeatureGcpExistingVpcResponse'
+            - $ref: '#/components/schemas/ClusterFeatureKarpenterParametersResponse'
           discriminator:
             propertyName: type
             mapping:
-              STRING: "#/components/schemas/ClusterFeatureStringResponse"
-              BOOLEAN: "#/components/schemas/ClusterFeatureBooleanResponse"
-              AWS_USER_PROVIDED_NETWORK: "#/components/schemas/ClusterFeatureAwsExistingVpcResponse"
-              GCP_USER_PROVIDED_NETWORK: "#/components/schemas/ClusterFeatureGcpExistingVpcResponse"
-              KARPENTER: "#/components/schemas/ClusterFeatureKarpenterParametersResponse"
+              STRING: '#/components/schemas/ClusterFeatureStringResponse'
+              BOOLEAN: '#/components/schemas/ClusterFeatureBooleanResponse'
+              AWS_USER_PROVIDED_NETWORK: '#/components/schemas/ClusterFeatureAwsExistingVpcResponse'
+              GCP_USER_PROVIDED_NETWORK: '#/components/schemas/ClusterFeatureGcpExistingVpcResponse'
+              KARPENTER: '#/components/schemas/ClusterFeatureKarpenterParametersResponse'
         is_value_updatable:
           type: boolean
           default: false
@@ -15519,7 +15508,7 @@ components:
         - value
       properties:
         type:
-          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
+          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
         value:
           type: string
     ClusterFeatureBooleanResponse:
@@ -15529,7 +15518,7 @@ components:
         - value
       properties:
         type:
-          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
+          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
         value:
           type: boolean
     ClusterFeatureAwsExistingVpcResponse:
@@ -15539,9 +15528,9 @@ components:
         - value
       properties:
         type:
-          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
+          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
         value:
-          $ref: "#/components/schemas/ClusterFeatureAwsExistingVpc"
+          $ref: '#/components/schemas/ClusterFeatureAwsExistingVpc'
     ClusterFeatureGcpExistingVpcResponse:
       type: object
       required:
@@ -15549,9 +15538,9 @@ components:
         - value
       properties:
         type:
-          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
+          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
         value:
-          $ref: "#/components/schemas/ClusterFeatureGcpExistingVpc"
+          $ref: '#/components/schemas/ClusterFeatureGcpExistingVpc'
     ClusterFeatureAwsExistingVpc:
       type: object
       required:
@@ -15678,7 +15667,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ClusterFeatureResponse"
+            $ref: '#/components/schemas/ClusterFeatureResponse'
     ClusterInstanceTypeResponseList:
       type: object
       properties:
@@ -15708,7 +15697,7 @@ components:
                 example: 8
               bandwidth_in_gbps:
                 type: string
-                example: "5.2"
+                example: '5.2'
               bandwidth_guarantee:
                 type: string
                 example: UpTo
@@ -15716,9 +15705,9 @@ components:
                 type: string
                 example: ARM64
               gpu_info:
-                $ref: "#/components/schemas/ClusterInstanceGpuInfo"
+                $ref: '#/components/schemas/ClusterInstanceGpuInfo'
               attributes:
-                $ref: "#/components/schemas/ClusterInstanceAttributes"
+                $ref: '#/components/schemas/ClusterInstanceAttributes'
     ClusterReadinessStatus:
       type: object
       properties:
@@ -15755,7 +15744,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ClusterRegion"
+            $ref: '#/components/schemas/ClusterRegion'
     ClusterRequest:
       type: object
       required:
@@ -15771,9 +15760,9 @@ components:
         region:
           type: string
         cloud_provider:
-          $ref: "#/components/schemas/CloudVendorEnum"
+          $ref: '#/components/schemas/CloudVendorEnum'
         cloud_provider_credentials:
-          $ref: "#/components/schemas/ClusterCloudProviderInfoRequest"
+          $ref: '#/components/schemas/ClusterCloudProviderInfoRequest'
         min_running_nodes:
           type: integer
           default: 1
@@ -15800,9 +15789,9 @@ components:
         instance_type:
           type: string
           example: T3A_LARGE
-          description: "the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType"
+          description: 'the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType'
         kubernetes:
-          $ref: "#/components/schemas/KubernetesEnum"
+          $ref: '#/components/schemas/KubernetesEnum'
         production:
           type: boolean
           description: specific flag to indicate that this cluster is a production one
@@ -15825,31 +15814,31 @@ components:
                 oneOf:
                   - type: string
                   - type: boolean
-                  - $ref: "#/components/schemas/ClusterFeatureAwsExistingVpc"
-                  - $ref: "#/components/schemas/ClusterFeatureGcpExistingVpc"
-                  - $ref: "#/components/schemas/ClusterFeatureKarpenterParameters"
+                  - $ref: '#/components/schemas/ClusterFeatureAwsExistingVpc'
+                  - $ref: '#/components/schemas/ClusterFeatureGcpExistingVpc'
+                  - $ref: '#/components/schemas/ClusterFeatureKarpenterParameters'
         metrics_parameters:
-          $ref: "#/components/schemas/MetricsParameters"
+          $ref: '#/components/schemas/MetricsParameters'
         infrastructure_charts_parameters:
-          $ref: "#/components/schemas/ClusterInfrastructureChartsParameters"
+          $ref: '#/components/schemas/ClusterInfrastructureChartsParameters'
         keda:
-          $ref: "#/components/schemas/ClusterKeda"
+          $ref: '#/components/schemas/ClusterKeda'
         labels_groups:
-          $ref: "#/components/schemas/ClusterLabelsGroupList"
+          $ref: '#/components/schemas/ClusterLabelsGroupList'
     ClusterResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Cluster"
+            $ref: '#/components/schemas/Cluster'
     ClusterLogsResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ClusterLogs"
+            $ref: '#/components/schemas/ClusterLogs'
     ClusterRoutingTable:
       type: object
       properties:
@@ -15895,29 +15884,29 @@ components:
           type: string
           format: uuid
         status:
-          $ref: "#/components/schemas/ClusterStateEnum"
+          $ref: '#/components/schemas/ClusterStateEnum'
         is_deployed:
           type: boolean
         next_k8s_available_version:
           type: string
           nullable: true
-          example: "1.28"
+          example: '1.28'
         last_execution_id:
           type: string
           example: f73e3833-922a-48a5-9dbd-6163f43f9143-1656410242
         cluster_lock:
-          $ref: "#/components/schemas/ClusterLock"
+          $ref: '#/components/schemas/ClusterLock'
         last_deployment_date:
           type: string
           format: date-time
-          example: "2022-06-22T14:20:17.733084815Z"
+          example: '2022-06-22T14:20:17.733084815Z'
     ClusterStatusResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ClusterStatus"
+            $ref: '#/components/schemas/ClusterStatus'
     ClusterAdvancedSettings:
       type: object
       properties:
@@ -16023,7 +16012,7 @@ components:
           type: integer
           deprecated: true
         registry.mirroring_mode:
-          $ref: "#/components/schemas/RegistryMirroringModeEnum"
+          $ref: '#/components/schemas/RegistryMirroringModeEnum'
         nginx.vcpu.request_in_milli_cpu:
           type: integer
           description: vcpu request in millicores
@@ -16109,7 +16098,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Commit"
+            $ref: '#/components/schemas/Commit'
     CompanySizeEnum:
       type: string
       enum:
@@ -16141,17 +16130,6 @@ components:
             Define how you want pods affinity to behave:
             * `Preferred` allows, but does not require, pods of a given service are not co-located (or co-hosted) on a single node
             * `Requirred` ensures that the pods of a given service are not co-located (or co-hosted) on a single node (safer in term of availability but can be expensive depending on the number of replicas)
-        deployment.topology_spread.zone:
-          type: string
-          enum:
-            - Disabled
-            - ScheduleAnyway
-            - DoNotSchedule
-          description: |
-            Define how you want pods to be spread across availability zones:
-            * `Disabled` no topology spread constraints are applied
-            * `ScheduleAnyway` pods are spread across zones on a best-effort basis (soft constraint)
-            * `DoNotSchedule` pods must be evenly spread across zones with a maxSkew of 1 (hard constraint)
         deployment.update_strategy.type:
           type: string
           enum:
@@ -16172,7 +16150,7 @@ components:
           type: boolean
           x-stoplight:
             id: xrdjy3znm8mpg
-          description: "When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available"
+          description: 'When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available'
         network.ingress.enable_cors:
           type: boolean
         network.ingress.cors_allow_origin:
@@ -16332,7 +16310,7 @@ components:
         name:
           type: string
         kind:
-          $ref: "#/components/schemas/ContainerRegistryKindEnum"
+          $ref: '#/components/schemas/ContainerRegistryKindEnum'
         description:
           type: string
         url:
@@ -16395,7 +16373,7 @@ components:
               type: string
               x-stoplight:
                 id: mzi9w1zsswj47
-              description: "For ECR, you can either set a static access_key or use a role arn that we are going to assume"
+              description: 'For ECR, you can either set a static access_key or use a role arn that we are going to assume'
             azure_tenant_id:
               type: string
               x-stoplight:
@@ -16408,13 +16386,13 @@ components:
               description: Required if kind is `AZURE_CR`.
     ContainerRegistryResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
             kind:
-              $ref: "#/components/schemas/ContainerRegistryKindEnum"
+              $ref: '#/components/schemas/ContainerRegistryKindEnum'
             description:
               type: string
             url:
@@ -16502,24 +16480,24 @@ components:
           type: string
           description: URL of the container registry
         kind:
-          $ref: "#/components/schemas/ContainerRegistryKindEnum"
+          $ref: '#/components/schemas/ContainerRegistryKindEnum'
     ContainerRegistryResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ContainerRegistryResponse"
+            $ref: '#/components/schemas/ContainerRegistryResponse'
     ContainerVersionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ContainerVersionResponse"
+            $ref: '#/components/schemas/ContainerVersionResponse'
     HelmRepositoryResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -16527,7 +16505,7 @@ components:
             name:
               type: string
             kind:
-              $ref: "#/components/schemas/HelmRepositoryKindEnum"
+              $ref: '#/components/schemas/HelmRepositoryKindEnum'
             description:
               type: string
             url:
@@ -16596,7 +16574,7 @@ components:
         name:
           type: string
         kind:
-          $ref: "#/components/schemas/HelmRepositoryKindEnum"
+          $ref: '#/components/schemas/HelmRepositoryKindEnum'
         description:
           type: string
         url:
@@ -16650,14 +16628,14 @@ components:
               description: Required if kind is `AZURE_CR`.
             role_arn:
               type: string
-              description: "For ECR, you can either set a static access_key or use a role arn that we are going to assume"
+              description: 'For ECR, you can either set a static access_key or use a role arn that we are going to assume'
     HelmVersionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/HelmVersionResponse"
+            $ref: '#/components/schemas/HelmVersionResponse'
     HelmVersionResponse:
       type: object
       properties:
@@ -16673,11 +16651,11 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/HelmRepositoryResponse"
+            $ref: '#/components/schemas/HelmRepositoryResponse'
     ContainerRequest:
       allOf:
-        - $ref: "#/components/schemas/ServiceStorageRequest"
-        - $ref: "#/components/schemas/ServicePortRequest"
+        - $ref: '#/components/schemas/ServiceStorageRequest'
+        - $ref: '#/components/schemas/ServicePortRequest'
         - type: object
           required:
             - name
@@ -16744,7 +16722,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             auto_preview:
               type: boolean
               description: |
@@ -16758,9 +16736,9 @@ components:
                 The new image tag shall be communicated via the "Auto Deploy container" endpoint https://api-doc.qovery.com/#tag/Containers/operation/autoDeployContainerEnvironments
               nullable: true
             annotations_groups:
-              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
+              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
             labels_groups:
-              $ref: "#/components/schemas/ServiceLabelsRequestList"
+              $ref: '#/components/schemas/ServiceLabelsRequestList'
             icon_uri:
               type: string
               format: uri
@@ -16768,12 +16746,12 @@ components:
               x-stoplight:
                 id: jiypvl6nd63dm
             autoscaling:
-              $ref: "#/components/schemas/AutoscalingPolicyRequest"
+              $ref: '#/components/schemas/AutoscalingPolicyRequest'
     ContainerResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/ServiceStorage"
-        - $ref: "#/components/schemas/ContainerSource"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/ServiceStorage'
+        - $ref: '#/components/schemas/ContainerSource'
         - type: object
           required:
             - environment
@@ -16792,7 +16770,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             maximum_cpu:
               type: integer
               description: Maximum cpu that can be allocated to the container based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu
@@ -16851,7 +16829,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             auto_preview:
               type: boolean
               description: |
@@ -16859,16 +16837,16 @@ components:
                 If enabled, a preview environment will be automatically cloned when `/preview` endpoint is called.  
                 If not specified, it takes the value of the `auto_preview` property from the associated environment.
             ports:
-              $ref: "#/components/schemas/ServicePortResponseList"
+              $ref: '#/components/schemas/ServicePortResponseList'
             auto_deploy:
               type: boolean
               description: |
                 Specify if the container will be automatically updated after receiving a new image tag. 
                 The new image tag shall be communicated via the "Auto Deploy container" endpoint https://api-doc.qovery.com/#tag/Containers/operation/autoDeployContainerEnvironments
             annotations_groups:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
             labels_groups:
-              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
             icon_uri:
               type: string
               format: uri
@@ -16876,16 +16854,16 @@ components:
               x-stoplight:
                 id: o2bdci7ak3bmz
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
             autoscaling:
-              $ref: "#/components/schemas/AutoscalingPolicyResponse"
+              $ref: '#/components/schemas/AutoscalingPolicyResponse'
     ContainerResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ContainerResponse"
+            $ref: '#/components/schemas/ContainerResponse'
     ContainerSource:
       type: object
       required:
@@ -16908,7 +16886,7 @@ components:
           type: string
           description: tag of the image container
         registry:
-          $ref: "#/components/schemas/ContainerRegistryProviderDetailsResponse"
+          $ref: '#/components/schemas/ContainerRegistryProviderDetailsResponse'
     Cost:
       type: object
       required:
@@ -16998,7 +16976,7 @@ components:
           example: 2025
         last_digit:
           type: string
-          example: "7890"
+          example: '7890'
         is_expired:
           type: boolean
         brand:
@@ -17031,12 +17009,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/CreditCard"
+            $ref: '#/components/schemas/CreditCard'
     CurrentCost:
       type: object
       properties:
         plan:
-          $ref: "#/components/schemas/PlanEnum"
+          $ref: '#/components/schemas/PlanEnum'
         remaining_trial_day:
           type: integer
           description: number of days remaining before the end of the trial period
@@ -17047,18 +17025,18 @@ components:
           nullable: true
           format: date-time
         cost:
-          $ref: "#/components/schemas/Cost"
+          $ref: '#/components/schemas/Cost'
     CustomDomain:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/CustomDomainRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/CustomDomainRequest'
         - type: object
           properties:
             validation_domain:
               type: string
               description: URL provided by Qovery. You must create a CNAME on your DNS provider using that URL
             status:
-              $ref: "#/components/schemas/CustomDomainStatusEnum"
+              $ref: '#/components/schemas/CustomDomainStatusEnum'
             generate_certificate:
               type: boolean
               description: to control if a certificate has to be generated for this custom domain by Qovery. The default value is `true`. This flag should be set to `false` if a CDN or other entities are managing the certificate for the specified domain and the traffic is proxied by the CDN to Qovery.
@@ -17095,7 +17073,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/CustomDomain"
+            $ref: '#/components/schemas/CustomDomain'
     CustomDomainStatusEnum:
       type: string
       enum:
@@ -17103,8 +17081,8 @@ components:
       example: VALIDATION_PENDING
     Database:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/DatabaseRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/DatabaseRequest'
         - type: object
           required:
             - environment
@@ -17112,7 +17090,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             host:
               type: string
             port:
@@ -17132,24 +17110,24 @@ components:
             instance_type:
               type: string
               example: db.t3.medium
-              description: "Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field is null for container DB."
+              description: 'Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field is null for container DB.'
             disk_type:
               type: string
               nullable: true
-              description: "EBS disk type for the database. Only applicable for MANAGED mode (gp2 or gp3). Null for CONTAINER mode."
+              description: 'EBS disk type for the database. Only applicable for MANAGED mode (gp2 or gp3). Null for CONTAINER mode.'
               enum:
                 - gp2
                 - gp3
             annotations_groups:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
             labels_groups:
-              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
             icon_uri:
               type: string
               format: uri
               description: Icon URI representing the database.
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
     DatabaseAccessibilityEnum:
       type: string
       default: PRIVATE
@@ -17160,18 +17138,18 @@ components:
       type: object
       properties:
         database_type:
-          $ref: "#/components/schemas/DatabaseTypeEnum"
+          $ref: '#/components/schemas/DatabaseTypeEnum'
         version:
           type: array
           items:
-            $ref: "#/components/schemas/DatabaseVersionMode"
+            $ref: '#/components/schemas/DatabaseVersionMode'
     DatabaseConfigurationResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/DatabaseConfiguration"
+            $ref: '#/components/schemas/DatabaseConfiguration'
     DatabaseEditRequest:
       type: object
       properties:
@@ -17183,9 +17161,9 @@ components:
           description: give a description to this database
         version:
           type: string
-          example: "10.1"
+          example: '10.1'
         accessibility:
-          $ref: "#/components/schemas/DatabaseAccessibilityEnum"
+          $ref: '#/components/schemas/DatabaseAccessibilityEnum'
         cpu:
           type: integer
           description: |
@@ -17213,11 +17191,11 @@ components:
         instance_type:
           type: string
           example: db.t3.medium
-          description: "Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB."
+          description: 'Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB.'
         annotations_groups:
-          $ref: "#/components/schemas/ServiceAnnotationsRequestList"
+          $ref: '#/components/schemas/ServiceAnnotationsRequestList'
         labels_groups:
-          $ref: "#/components/schemas/ServiceLabelsRequestList"
+          $ref: '#/components/schemas/ServiceLabelsRequestList'
         icon_uri:
           type: string
           format: uri
@@ -17228,7 +17206,7 @@ components:
           enum:
             - gp2
             - gp3
-          description: "EBS disk type for MANAGED AWS databases. Allowed values: gp2, gp3. Only applicable for MANAGED mode."
+          description: 'EBS disk type for MANAGED AWS databases. Allowed values: gp2, gp3. Only applicable for MANAGED mode.'
     DatabaseModeEnum:
       type: string
       enum:
@@ -17249,14 +17227,14 @@ components:
           type: string
           description: give a description to this database
         type:
-          $ref: "#/components/schemas/DatabaseTypeEnum"
+          $ref: '#/components/schemas/DatabaseTypeEnum'
         version:
           type: string
-          example: "10.1"
+          example: '10.1'
         mode:
-          $ref: "#/components/schemas/DatabaseModeEnum"
+          $ref: '#/components/schemas/DatabaseModeEnum'
         accessibility:
-          $ref: "#/components/schemas/DatabaseAccessibilityEnum"
+          $ref: '#/components/schemas/DatabaseAccessibilityEnum'
         cpu:
           type: integer
           description: |
@@ -17267,7 +17245,7 @@ components:
         instance_type:
           type: string
           example: db.t3.medium
-          description: "Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB."
+          description: 'Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB.'
         memory:
           type: integer
           description: |
@@ -17286,9 +17264,9 @@ components:
           description: unit is GB
           default: 10
         annotations_groups:
-          $ref: "#/components/schemas/ServiceAnnotationsRequestList"
+          $ref: '#/components/schemas/ServiceAnnotationsRequestList'
         labels_groups:
-          $ref: "#/components/schemas/ServiceLabelsRequestList"
+          $ref: '#/components/schemas/ServiceLabelsRequestList'
         icon_uri:
           type: string
           format: uri
@@ -17301,7 +17279,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Database"
+            $ref: '#/components/schemas/Database'
     DatabaseTypeEnum:
       type: string
       enum:
@@ -17314,9 +17292,9 @@ components:
       properties:
         name:
           type: string
-          example: "10.1"
+          example: '10.1'
         supported_mode:
-          $ref: "#/components/schemas/DatabaseModeEnum"
+          $ref: '#/components/schemas/DatabaseModeEnum'
     DeployAllRequest:
       type: object
       properties:
@@ -17389,7 +17367,7 @@ components:
         terraforms:
           type: array
           items:
-            $ref: "#/components/schemas/TerraformDeployRequest"
+            $ref: '#/components/schemas/TerraformDeployRequest'
     DeployRequest:
       type: object
       required:
@@ -17400,16 +17378,16 @@ components:
           description: Commit ID to deploy
     DeploymentHistory:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
               description: name of the service
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             status:
-              $ref: "#/components/schemas/DeploymentHistoryStatusEnum"
+              $ref: '#/components/schemas/DeploymentHistoryStatusEnum'
     DeploymentHistoryTriggerAction:
       x-stoplight:
         id: 1hzy6riqo7lq4
@@ -17426,25 +17404,25 @@ components:
         - UNINSTALL
     DeploymentHistoryApplication:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             status:
-              $ref: "#/components/schemas/StateEnum"
+              $ref: '#/components/schemas/StateEnum'
     DeploymentHistoryDatabase:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
               description: name of the service
             status:
-              $ref: "#/components/schemas/StateEnum"
+              $ref: '#/components/schemas/StateEnum'
     DeploymentHistoryAuditingData:
       x-stoplight:
         id: 5oovmby4u1mxw
@@ -17469,17 +17447,17 @@ components:
           x-stoplight:
             id: hf405wx2g73py
         origin:
-          $ref: "#/components/schemas/OrganizationEventOrigin"
+          $ref: '#/components/schemas/OrganizationEventOrigin'
     DeploymentHistoryContainer:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
               description: name of the container
             status:
-              $ref: "#/components/schemas/StateEnum"
+              $ref: '#/components/schemas/StateEnum'
             image_name:
               type: string
             tag:
@@ -17492,35 +17470,35 @@ components:
               type: string
     DeploymentHistoryEnvironment:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             status:
-              $ref: "#/components/schemas/StateEnum"
+              $ref: '#/components/schemas/StateEnum'
             origin:
-              $ref: "#/components/schemas/OrganizationEventOrigin"
+              $ref: '#/components/schemas/OrganizationEventOrigin'
             triggered_by:
               type: string
             applications:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryApplication"
+                $ref: '#/components/schemas/DeploymentHistoryApplication'
             containers:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryContainer"
+                $ref: '#/components/schemas/DeploymentHistoryContainer'
             databases:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryDatabase"
+                $ref: '#/components/schemas/DeploymentHistoryDatabase'
             jobs:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryJobResponse"
+                $ref: '#/components/schemas/DeploymentHistoryJobResponse'
             helms:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryHelmResponse"
+                $ref: '#/components/schemas/DeploymentHistoryHelmResponse'
     DeploymentHistoryEnvironmentV2:
       x-stoplight:
         id: j6o3qzzhhu0me
@@ -17552,11 +17530,11 @@ components:
                 id: 6o54s8cbk0lo6
               format: uuid
         auditing_data:
-          $ref: "#/components/schemas/DeploymentHistoryAuditingData"
+          $ref: '#/components/schemas/DeploymentHistoryAuditingData'
         status:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         trigger_action:
-          $ref: "#/components/schemas/DeploymentHistoryTriggerAction"
+          $ref: '#/components/schemas/DeploymentHistoryTriggerAction'
         total_duration:
           type: string
           x-stoplight:
@@ -17567,9 +17545,9 @@ components:
           x-stoplight:
             id: rz2b0h9r3p6tv
           items:
-            $ref: "#/components/schemas/DeploymentHistoryStage"
+            $ref: '#/components/schemas/DeploymentHistoryStage'
         action_status:
-          $ref: "#/components/schemas/DeploymentHistoryActionStatus"
+          $ref: '#/components/schemas/DeploymentHistoryActionStatus'
     DeploymentHistoryStage:
       type: object
       x-stoplight:
@@ -17585,7 +17563,7 @@ components:
           x-stoplight:
             id: e1fv4x2xo0wo0
         status:
-          $ref: "#/components/schemas/StageStatusEnum"
+          $ref: '#/components/schemas/StageStatusEnum'
         duration:
           type: string
           x-stoplight:
@@ -17596,7 +17574,7 @@ components:
           x-stoplight:
             id: sel4jtb8tbjwz
           items:
-            $ref: "#/components/schemas/DeploymentHistoryService"
+            $ref: '#/components/schemas/DeploymentHistoryService'
     JobLifecyleSchedule:
       type: object
       x-stoplight:
@@ -17670,19 +17648,19 @@ components:
                 id: 0hb95ufaj9z82
               format: uuid
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
             execution_id:
               type: string
               x-stoplight:
                 id: 9ww6nh5lrwg37
         status:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         auditing_data:
-          $ref: "#/components/schemas/DeploymentHistoryAuditingData"
+          $ref: '#/components/schemas/DeploymentHistoryAuditingData'
         details:
-          $ref: "#/components/schemas/DeploymentHistoryServiceDetails"
+          $ref: '#/components/schemas/DeploymentHistoryServiceDetails'
         status_details:
-          $ref: "#/components/schemas/StatusDetails"
+          $ref: '#/components/schemas/StatusDetails'
         icon_uri:
           type: string
           x-stoplight:
@@ -17704,7 +17682,7 @@ components:
             - build_pod_name
           properties:
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             build_pod_name:
               type: string
               description: The build pod name prefix for monitoring build runner usage. Format build-{execution_id}-0
@@ -17737,20 +17715,20 @@ components:
             tag:
               type: string
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             schedule:
               type: object
               properties:
                 on_start:
-                  $ref: "#/components/schemas/JobLifecyleSchedule"
+                  $ref: '#/components/schemas/JobLifecyleSchedule'
                 on_stop:
-                  $ref: "#/components/schemas/JobLifecyleSchedule"
+                  $ref: '#/components/schemas/JobLifecyleSchedule'
                 on_delete:
-                  $ref: "#/components/schemas/JobLifecyleSchedule"
+                  $ref: '#/components/schemas/JobLifecyleSchedule'
                 cron_job:
-                  $ref: "#/components/schemas/JobCronSchedule"
+                  $ref: '#/components/schemas/JobCronSchedule'
                 lifecycle_type:
-                  $ref: "#/components/schemas/JobLifecycleTypeEnum"
+                  $ref: '#/components/schemas/JobLifecycleTypeEnum'
             job_type:
               x-stoplight:
                 id: tz8apy1pqi9c5
@@ -17765,7 +17743,7 @@ components:
           type: object
           properties:
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             repository:
               type: object
               properties:
@@ -17776,44 +17754,44 @@ components:
       type: object
     DeploymentHistoryEnvironmentPaginatedResponseList:
       allOf:
-        - $ref: "#/components/schemas/PaginationData"
+        - $ref: '#/components/schemas/PaginationData'
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryEnvironment"
+                $ref: '#/components/schemas/DeploymentHistoryEnvironment'
     DeploymentHistoryEnvironmentPaginatedResponseListV2:
       allOf:
-        - $ref: "#/components/schemas/PaginationData"
+        - $ref: '#/components/schemas/PaginationData'
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryEnvironmentV2"
+                $ref: '#/components/schemas/DeploymentHistoryEnvironmentV2'
       x-stoplight:
         id: 0anfgzdi689ht
     DeploymentHistoryServicePaginatedResponseListV2:
       allOf:
-        - $ref: "#/components/schemas/PaginationData"
+        - $ref: '#/components/schemas/PaginationData'
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistoryService"
+                $ref: '#/components/schemas/DeploymentHistoryService'
       x-stoplight:
         id: e2g667def2r2z
     DeploymentHistoryPaginatedResponseList:
       allOf:
-        - $ref: "#/components/schemas/PaginationData"
+        - $ref: '#/components/schemas/PaginationData'
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: "#/components/schemas/DeploymentHistory"
+                $ref: '#/components/schemas/DeploymentHistory'
     DeploymentHistoryStatusEnum:
       type: string
       enum:
@@ -17833,7 +17811,7 @@ components:
       example: PATH
     Environment:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -17847,9 +17825,9 @@ components:
               type: string
               description: name is case insensitive
             organization:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             project:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             last_updated_by:
               type: string
               format: uuid
@@ -17864,7 +17842,7 @@ components:
                   type: string
                   example: us-east-2
             mode:
-              $ref: "#/components/schemas/EnvironmentModeEnum"
+              $ref: '#/components/schemas/EnvironmentModeEnum'
             cluster_id:
               type: string
               format: uuid
@@ -17877,14 +17855,14 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Environment"
+            $ref: '#/components/schemas/Environment'
     EnvironmentOverviewResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/EnvironmentOverviewResponse"
+            $ref: '#/components/schemas/EnvironmentOverviewResponse'
     EnvironmentOverviewResponse:
       type: object
       required:
@@ -17907,15 +17885,15 @@ components:
         name:
           type: string
         mode:
-          $ref: "#/components/schemas/EnvironmentModeEnum"
+          $ref: '#/components/schemas/EnvironmentModeEnum'
         cluster:
-          $ref: "#/components/schemas/ClusterOverviewResponse"
+          $ref: '#/components/schemas/ClusterOverviewResponse'
           nullable: true
         service_count:
           type: integer
           format: int32
         deployment_status:
-          $ref: "#/components/schemas/EnvironmentStatus"
+          $ref: '#/components/schemas/EnvironmentStatus'
           nullable: true
     ClusterOverviewResponse:
       type: object
@@ -17931,12 +17909,12 @@ components:
         name:
           type: string
         cloud_provider:
-          $ref: "#/components/schemas/CloudVendorEnum"
+          $ref: '#/components/schemas/CloudVendorEnum'
         is_demo:
           type: boolean
     EnvironmentDeploymentRule:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - timezone
@@ -17959,15 +17937,15 @@ components:
             start_time:
               type: string
               format: date-time
-              example: "1970-01-01T08:00:00.000Z"
+              example: '1970-01-01T08:00:00.000Z'
             stop_time:
               type: string
               format: date-time
-              example: "1970-01-01T19:00:00.000Z"
+              example: '1970-01-01T19:00:00.000Z'
             weekdays:
               type: array
               items:
-                $ref: "#/components/schemas/WeekdayEnum"
+                $ref: '#/components/schemas/WeekdayEnum'
     EnvironmentDeploymentRuleEditRequest:
       type: object
       required:
@@ -17991,22 +17969,22 @@ components:
         start_time:
           type: string
           format: date-time
-          example: "1970-01-01T08:00:00.000Z"
+          example: '1970-01-01T08:00:00.000Z'
         stop_time:
           type: string
           format: date-time
-          example: "1970-01-01T19:00:00.000Z"
+          example: '1970-01-01T19:00:00.000Z'
         weekdays:
           type: array
           items:
-            $ref: "#/components/schemas/WeekdayEnum"
+            $ref: '#/components/schemas/WeekdayEnum'
     EnvironmentEditRequest:
       type: object
       properties:
         name:
           type: string
         mode:
-          $ref: "#/components/schemas/CreateEnvironmentModeEnum"
+          $ref: '#/components/schemas/CreateEnvironmentModeEnum'
     EnvironmentLog:
       type: object
       required:
@@ -18026,14 +18004,14 @@ components:
           type: object
           properties:
             type:
-              $ref: "#/components/schemas/EnvironmentLogTypeEnum"
+              $ref: '#/components/schemas/EnvironmentLogTypeEnum'
             name:
               type: string
             id:
               type: string
               format: uuid
         state:
-          $ref: "#/components/schemas/StatusKindEnum"
+          $ref: '#/components/schemas/StatusKindEnum'
         message:
           type: string
           nullable: true
@@ -18123,11 +18101,11 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/EnvironmentLog"
+            $ref: '#/components/schemas/EnvironmentLog'
     EnvironmentLogsResponseList:
       type: array
       items:
-        $ref: "#/components/schemas/EnvironmentLogs"
+        $ref: '#/components/schemas/EnvironmentLogs'
     EnvironmentLogTypeEnum:
       type: string
       enum:
@@ -18161,11 +18139,11 @@ components:
           type: string
           format: uuid
         mode:
-          $ref: "#/components/schemas/CreateEnvironmentModeEnum"
+          $ref: '#/components/schemas/CreateEnvironmentModeEnum'
     EnvironmentStats:
       allOf:
-        - $ref: "#/components/schemas/ReferenceObject"
-        - $ref: "#/components/schemas/ServiceTotalNumber"
+        - $ref: '#/components/schemas/ReferenceObject'
+        - $ref: '#/components/schemas/ServiceTotalNumber'
     EnvironmentStatus:
       type: object
       required:
@@ -18177,13 +18155,13 @@ components:
           type: string
           format: uuid
         state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         last_deployment_date:
           type: string
           format: date-time
           nullable: true
         last_deployment_state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         last_deployment_id:
           type: string
           nullable: true
@@ -18191,12 +18169,12 @@ components:
           type: integer
           nullable: true
         origin:
-          $ref: "#/components/schemas/EnvironmentStatusEventOriginEnum"
+          $ref: '#/components/schemas/EnvironmentStatusEventOriginEnum'
         triggered_by:
           type: string
           nullable: true
         deployment_status:
-          $ref: "#/components/schemas/EnvironmentDeploymentStatusEnum"
+          $ref: '#/components/schemas/EnvironmentDeploymentStatusEnum'
         deployment_request_id:
           type: string
           format: uuid
@@ -18205,14 +18183,14 @@ components:
           type: array
           nullable: true
           items:
-            $ref: "#/components/schemas/StageStepMetrics"
+            $ref: '#/components/schemas/StageStepMetrics'
     EnvironmentStatsResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/EnvironmentStats"
+            $ref: '#/components/schemas/EnvironmentStats'
     EnvironmentStatuses:
       type: object
       required:
@@ -18225,31 +18203,31 @@ components:
         - terraforms
       properties:
         environment:
-          $ref: "#/components/schemas/EnvironmentStatus"
+          $ref: '#/components/schemas/EnvironmentStatus'
         applications:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         containers:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         jobs:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         databases:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         helms:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         terraforms:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
     EnvironmentStatusEventOriginEnum:
       type: string
       nullable: true
@@ -18266,18 +18244,18 @@ components:
       type: object
       properties:
         environment:
-          $ref: "#/components/schemas/EnvironmentStatus"
+          $ref: '#/components/schemas/EnvironmentStatus'
         stages:
           type: array
           items:
-            $ref: "#/components/schemas/DeploymentStageWithServicesStatuses"
+            $ref: '#/components/schemas/DeploymentStageWithServicesStatuses'
         pre_check_stage:
           type: object
           x-stoplight:
             id: l9y5i1bt4jmsk
           properties:
             status:
-              $ref: "#/components/schemas/StepMetricStatusEnum"
+              $ref: '#/components/schemas/StepMetricStatusEnum'
             total_duration_sec:
               type: integer
               x-stoplight:
@@ -18288,7 +18266,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/EnvironmentStatus"
+            $ref: '#/components/schemas/EnvironmentStatus'
     EnvironmentTotalNumber:
       type: object
       required:
@@ -18298,31 +18276,31 @@ components:
           type: number
     EnvironmentVariable:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/EnvironmentVariableRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/EnvironmentVariableRequest'
         - type: object
           required:
             - scope
             - variable_type
           properties:
             overridden_variable:
-              $ref: "#/components/schemas/EnvironmentVariableOverride"
+              $ref: '#/components/schemas/EnvironmentVariableOverride'
             aliased_variable:
-              $ref: "#/components/schemas/EnvironmentVariableAlias"
+              $ref: '#/components/schemas/EnvironmentVariableAlias'
             scope:
-              $ref: "#/components/schemas/APIVariableScopeEnum"
+              $ref: '#/components/schemas/APIVariableScopeEnum'
             variable_type:
-              $ref: "#/components/schemas/APIVariableTypeEnum"
+              $ref: '#/components/schemas/APIVariableTypeEnum'
             service_id:
               type: string
               format: uuid
             service_name:
               type: string
             service_type:
-              $ref: "#/components/schemas/LinkedServiceTypeEnum"
+              $ref: '#/components/schemas/LinkedServiceTypeEnum'
             owned_by:
               type: string
-              description: "Entity that created/own the variable (i.e: Qovery, Doppler)"
+              description: 'Entity that created/own the variable (i.e: Qovery, Doppler)'
     EnvironmentVariableAlias:
       type: object
       required:
@@ -18344,9 +18322,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_type:
-          $ref: "#/components/schemas/APIVariableTypeEnum"
+          $ref: '#/components/schemas/APIVariableTypeEnum'
     EnvironmentVariableOverride:
       type: object
       required:
@@ -18367,9 +18345,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_type:
-          $ref: "#/components/schemas/APIVariableTypeEnum"
+          $ref: '#/components/schemas/APIVariableTypeEnum'
     EnvironmentVariableEditRequest:
       type: object
       required:
@@ -18432,7 +18410,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/EnvironmentVariable"
+            $ref: '#/components/schemas/EnvironmentVariable'
     EnvironmentServiceIdsAllRequest:
       type: object
       properties:
@@ -18516,7 +18494,7 @@ components:
           type: integer
           example: 3600
         cost:
-          $ref: "#/components/schemas/Cost"
+          $ref: '#/components/schemas/Cost'
     GitAuthProvider:
       type: object
       required:
@@ -18539,7 +18517,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/GitAuthProvider"
+            $ref: '#/components/schemas/GitAuthProvider'
     GitProviderEnum:
       type: string
       enum:
@@ -18560,7 +18538,7 @@ components:
           example: simple-node-app
         url:
           type: string
-          example: "https://github.com/Qovery/simple-node-app"
+          example: 'https://github.com/Qovery/simple-node-app'
         default_branch:
           type: string
           example: master
@@ -18580,14 +18558,14 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/GitRepositoryBranch"
+            $ref: '#/components/schemas/GitRepositoryBranch'
     GitRepositoryResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/GitRepository"
+            $ref: '#/components/schemas/GitRepository'
     GitTokenAssociatedServiceType:
       type: string
       enum:
@@ -18623,14 +18601,14 @@ components:
         service_name:
           type: string
         service_type:
-          $ref: "#/components/schemas/GitTokenAssociatedServiceType"
+          $ref: '#/components/schemas/GitTokenAssociatedServiceType'
     GitTokenAssociatedServicesResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/GitTokenAssociatedServiceResponse"
+            $ref: '#/components/schemas/GitTokenAssociatedServiceResponse'
     GitTokenRequest:
       type: object
       required:
@@ -18643,13 +18621,13 @@ components:
         description:
           type: string
         type:
-          $ref: "#/components/schemas/GitProviderEnum"
+          $ref: '#/components/schemas/GitProviderEnum'
         token:
           type: string
           description: The token from your git provider side
         workspace:
           type: string
-          description: "Mandatory only for BITBUCKET git provider, to allow us to fetch repositories at creation/edition of a service"
+          description: 'Mandatory only for BITBUCKET git provider, to allow us to fetch repositories at creation/edition of a service'
         git_api_url:
           type: string
           x-stoplight:
@@ -18660,7 +18638,7 @@ components:
             I.e: Self-hosted version of Gitlab
     GitTokenResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -18673,7 +18651,7 @@ components:
             description:
               type: string
             type:
-              $ref: "#/components/schemas/GitProviderEnum"
+              $ref: '#/components/schemas/GitProviderEnum'
             expired_at:
               type: string
               format: date
@@ -18694,18 +18672,18 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/GitTokenResponse"
+            $ref: '#/components/schemas/GitTokenResponse'
     Healthcheck:
       type: object
       nullable: false
       properties:
         readiness_probe:
-          $ref: "#/components/schemas/Probe"
+          $ref: '#/components/schemas/Probe'
         liveness_probe:
-          $ref: "#/components/schemas/Probe"
+          $ref: '#/components/schemas/Probe'
     InviteMember:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - email
@@ -18718,12 +18696,12 @@ components:
               type: string
               format: email
             role:
-              $ref: "#/components/schemas/InviteMemberRoleEnum"
+              $ref: '#/components/schemas/InviteMemberRoleEnum'
             invitation_link:
               type: string
               format: uri
             invitation_status:
-              $ref: "#/components/schemas/InviteStatusEnum"
+              $ref: '#/components/schemas/InviteStatusEnum'
             organization_name:
               type: string
             inviter:
@@ -18744,7 +18722,7 @@ components:
         email:
           type: string
         role:
-          $ref: "#/components/schemas/InviteMemberRoleEnum"
+          $ref: '#/components/schemas/InviteMemberRoleEnum'
         role_id:
           type: string
           format: uuid
@@ -18755,7 +18733,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/InviteMember"
+            $ref: '#/components/schemas/InviteMember'
     InviteMemberRoleEnum:
       type: string
       description: deprecated
@@ -18771,7 +18749,7 @@ components:
         - PENDING
     Invoice:
       allOf:
-        - $ref: "#/components/schemas/Cost"
+        - $ref: '#/components/schemas/Cost'
         - type: object
           required:
             - id
@@ -18788,14 +18766,14 @@ components:
               type: string
               format: date-time
             status:
-              $ref: "#/components/schemas/InvoiceStatusEnum"
+              $ref: '#/components/schemas/InvoiceStatusEnum'
     InvoiceResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Invoice"
+            $ref: '#/components/schemas/Invoice'
     InvoiceStatusEnum:
       type: string
       enum:
@@ -18820,13 +18798,13 @@ components:
           description: free test describing this stage
     DeploymentStageResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - environment
           properties:
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             name:
               type: string
               description: name is case insensitive
@@ -18837,21 +18815,21 @@ components:
               description: Position of the deployment stage within the environment
               example: 1
             services:
-              $ref: "#/components/schemas/DeploymentStageServiceResponseList"
+              $ref: '#/components/schemas/DeploymentStageServiceResponseList'
     DeploymentStageResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/DeploymentStageResponse"
+            $ref: '#/components/schemas/DeploymentStageResponse'
     DeploymentStageServiceResponseList:
       type: array
       items:
-        $ref: "#/components/schemas/DeploymentStageServiceResponse"
+        $ref: '#/components/schemas/DeploymentStageServiceResponse'
     DeploymentStageServiceResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             service_id:
@@ -18860,7 +18838,7 @@ components:
               description: id of the service attached to the stage
             service_type:
               type: string
-              description: "type of the service (i.e APPLICATION, JOB, DATABASE, ...)"
+              description: 'type of the service (i.e APPLICATION, JOB, DATABASE, ...)'
             is_skipped:
               type: boolean
               description: whether the service is excluded from environment-level deployments
@@ -18870,29 +18848,29 @@ components:
         applications:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         containers:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         jobs:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         databases:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         helms:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         terraforms:
           type: array
           items:
-            $ref: "#/components/schemas/Status"
+            $ref: '#/components/schemas/Status'
         stage:
-          $ref: "#/components/schemas/Stage"
+          $ref: '#/components/schemas/Stage'
     DockerfileCheckRequest:
       type: object
       required:
@@ -18900,7 +18878,7 @@ components:
         - dockerfile_path
       properties:
         git_repository:
-          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
         dockerfile_path:
           type: string
           description: path of the dockerfile with root_path as base path
@@ -18929,7 +18907,7 @@ components:
         - files
       properties:
         git_repository:
-          $ref: "#/components/schemas/HelmGitRepositoryRequest"
+          $ref: '#/components/schemas/HelmGitRepositoryRequest'
         files:
           type: array
           items:
@@ -18942,7 +18920,7 @@ components:
         - git_repository
       properties:
         git_repository:
-          $ref: "#/components/schemas/HelmGitRepositoryRequest"
+          $ref: '#/components/schemas/HelmGitRepositoryRequest'
     HelmCheckResponse:
       type: object
     ContainerImageCheckRequest:
@@ -19039,7 +19017,7 @@ components:
                   nullable: true
                   properties:
                     git_repository:
-                      $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+                      $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
                     dockerfile_path:
                       type: string
                       description: The path of the associated Dockerfile. Only if you are using build_mode = DOCKER
@@ -19057,7 +19035,7 @@ components:
                       description: The target build stage in the Dockerfile to build
                       nullable: true
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             schedule:
               type: object
               description: |
@@ -19119,7 +19097,7 @@ components:
                         See https://crontab.guru/ to WISIWIG interface.  
                         Timezone is UTC
                 lifecycle_type:
-                  $ref: "#/components/schemas/JobLifecycleTypeEnum"
+                  $ref: '#/components/schemas/JobLifecycleTypeEnum'
             auto_deploy:
               type: boolean
               description: |
@@ -19127,9 +19105,9 @@ components:
                 The new image tag shall be communicated via the "Auto Deploy job" endpoint https://api-doc.qovery.com/#tag/Jobs/operation/autoDeployJobEnvironments
               nullable: true
             annotations_groups:
-              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
+              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
             labels_groups:
-              $ref: "#/components/schemas/ServiceLabelsRequestList"
+              $ref: '#/components/schemas/ServiceLabelsRequestList'
             icon_uri:
               type: string
               format: uri
@@ -19139,20 +19117,20 @@ components:
       type: object
     JobResponse:
       oneOf:
-        - $ref: "#/components/schemas/LifecycleJobResponse"
-        - $ref: "#/components/schemas/CronJobResponse"
+        - $ref: '#/components/schemas/LifecycleJobResponse'
+        - $ref: '#/components/schemas/CronJobResponse'
       discriminator:
         propertyName: job_type
         mapping:
-          LIFECYCLE: "#/components/schemas/LifecycleJobResponse"
-          CRON: "#/components/schemas/CronJobResponse"
+          LIFECYCLE: '#/components/schemas/LifecycleJobResponse'
+          CRON: '#/components/schemas/CronJobResponse'
     JobResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/JobResponse"
+            $ref: '#/components/schemas/JobResponse'
     JobAdvancedSettings:
       type: object
       properties:
@@ -19218,24 +19196,24 @@ components:
         - value
       properties:
         mode:
-          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
         type:
-          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
         value:
           type: string
-          description: "For `PATH` restrictions, the value must not start with `/`"
+          description: 'For `PATH` restrictions, the value must not start with `/`'
           example: job1/src/
     JobDeploymentRestrictionResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/JobDeploymentRestrictionRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/JobDeploymentRestrictionRequest'
     JobDeploymentRestrictionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/JobDeploymentRestrictionResponse"
+            $ref: '#/components/schemas/JobDeploymentRestrictionResponse'
     JobScheduleEvent:
       type: string
       enum:
@@ -19258,25 +19236,25 @@ components:
         - CRON
     DeploymentHistoryJobResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
               description: name of the job
             status:
-              $ref: "#/components/schemas/StateEnum"
+              $ref: '#/components/schemas/StateEnum'
             image_name:
               type: string
             tag:
               type: string
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             schedule:
               type: object
               properties:
                 event:
-                  $ref: "#/components/schemas/JobScheduleEvent"
+                  $ref: '#/components/schemas/JobScheduleEvent'
                 schedule_at:
                   type: string
                   format: cron
@@ -19295,7 +19273,7 @@ components:
               type: string
     HelmRequest:
       allOf:
-        - $ref: "#/components/schemas/HelmPortRequest"
+        - $ref: '#/components/schemas/HelmPortRequest'
         - type: object
           required:
             - name
@@ -19331,7 +19309,7 @@ components:
                 - type: object
                   properties:
                     git_repository:
-                      $ref: "#/components/schemas/HelmGitRepositoryRequest"
+                      $ref: '#/components/schemas/HelmGitRepositoryRequest'
                 - type: object
                   properties:
                     helm_repository:
@@ -19365,11 +19343,11 @@ components:
                 Specify helm values you want to set or override
               properties:
                 set:
-                  $ref: "#/components/schemas/HelmKeyValues"
+                  $ref: '#/components/schemas/HelmKeyValues'
                 set_string:
-                  $ref: "#/components/schemas/HelmKeyValues"
+                  $ref: '#/components/schemas/HelmKeyValues'
                 set_json:
-                  $ref: "#/components/schemas/HelmKeyValues"
+                  $ref: '#/components/schemas/HelmKeyValues'
                 file:
                   type: object
                   nullable: true
@@ -19382,7 +19360,7 @@ components:
                         - paths
                       properties:
                         git_repository:
-                          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+                          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
                         paths:
                           type: array
                           description: List of path inside your git repository to locate values file. Must start by a /
@@ -19411,7 +19389,7 @@ components:
                 id: 117p5u95nwx2p
     HelmResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - environment
@@ -19426,7 +19404,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             name:
               type: string
               description: name is case insensitive
@@ -19452,13 +19430,13 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/HelmPortResponseWithServiceName"
-                  - $ref: "#/components/schemas/HelmPortResponseWithServiceSelectors"
+                  - $ref: '#/components/schemas/HelmPortResponseWithServiceName'
+                  - $ref: '#/components/schemas/HelmPortResponseWithServiceSelectors'
                 discriminator:
                   propertyName: port_type
                   mapping:
-                    SERVICE_NAME: "#/components/schemas/HelmPortResponseWithServiceName"
-                    SERVICE_SELECTORS: "#/components/schemas/HelmPortResponseWithServiceSelectors"
+                    SERVICE_NAME: '#/components/schemas/HelmPortResponseWithServiceName'
+                    SERVICE_SELECTORS: '#/components/schemas/HelmPortResponseWithServiceSelectors'
             source:
               nullable: false
               oneOf:
@@ -19466,7 +19444,7 @@ components:
                     - git
                   properties:
                     git:
-                      $ref: "#/components/schemas/HelmSourceGitResponse"
+                      $ref: '#/components/schemas/HelmSourceGitResponse'
                   type: object
                 - x-stoplight:
                     id: 0prdehm6z8pua
@@ -19474,7 +19452,7 @@ components:
                     - repository
                   properties:
                     repository:
-                      $ref: "#/components/schemas/HelmSourceRepositoryResponse"
+                      $ref: '#/components/schemas/HelmSourceRepositoryResponse'
                   type: object
             arguments:
               type: array
@@ -19493,11 +19471,11 @@ components:
                 Specify helm values you want to set or override
               properties:
                 set:
-                  $ref: "#/components/schemas/HelmKeyValues"
+                  $ref: '#/components/schemas/HelmKeyValues'
                 set_string:
-                  $ref: "#/components/schemas/HelmKeyValues"
+                  $ref: '#/components/schemas/HelmKeyValues'
                 set_json:
-                  $ref: "#/components/schemas/HelmKeyValues"
+                  $ref: '#/components/schemas/HelmKeyValues'
                 file:
                   type: object
                   nullable: true
@@ -19530,7 +19508,7 @@ components:
                         - paths
                       properties:
                         git_repository:
-                          $ref: "#/components/schemas/ApplicationGitRepository"
+                          $ref: '#/components/schemas/ApplicationGitRepository'
                         paths:
                           type: array
                           description: List of path inside your git repository to locate values file. Must start by a /
@@ -19543,7 +19521,7 @@ components:
               x-stoplight:
                 id: i2pvbugqsldhe
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
     HelmPortResponseBase:
       type: object
       required:
@@ -19570,13 +19548,13 @@ components:
         namespace:
           type: string
         protocol:
-          $ref: "#/components/schemas/HelmPortProtocolEnum"
+          $ref: '#/components/schemas/HelmPortProtocolEnum'
         is_default:
           type: boolean
           description: is the default port to use for domain
     HelmPortResponseWithServiceName:
       allOf:
-        - $ref: "#/components/schemas/HelmPortResponseBase"
+        - $ref: '#/components/schemas/HelmPortResponseBase'
         - type: object
           required:
             - service_name
@@ -19585,7 +19563,7 @@ components:
               type: string
     HelmPortResponseWithServiceSelectors:
       allOf:
-        - $ref: "#/components/schemas/HelmPortResponseBase"
+        - $ref: '#/components/schemas/HelmPortResponseBase'
         - type: object
           required:
             - service_selectors
@@ -19593,14 +19571,14 @@ components:
             service_selectors:
               type: array
               items:
-                $ref: "#/components/schemas/KubernetesSelector"
+                $ref: '#/components/schemas/KubernetesSelector'
     HelmResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/HelmResponse"
+            $ref: '#/components/schemas/HelmResponse'
     HelmAdvancedSettings:
       type: object
       properties:
@@ -19613,7 +19591,7 @@ components:
           type: boolean
           x-stoplight:
             id: 6tcwjiqqo99ii
-          description: "When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available"
+          description: 'When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available'
         network.ingress.enable_cors:
           type: boolean
         network.ingress.cors_allow_origin:
@@ -19716,24 +19694,24 @@ components:
         - value
       properties:
         mode:
-          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
         type:
-          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
         value:
           type: string
-          description: "For `PATH` restrictions, the value must not start with `/`"
+          description: 'For `PATH` restrictions, the value must not start with `/`'
           example: helm1/src/
     HelmDeploymentRestrictionResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/HelmDeploymentRestrictionRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/HelmDeploymentRestrictionRequest'
     HelmDeploymentRestrictionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/HelmDeploymentRestrictionResponse"
+            $ref: '#/components/schemas/HelmDeploymentRestrictionResponse'
     HelmPortRequest:
       type: object
       properties:
@@ -19758,7 +19736,7 @@ components:
                   namespace:
                     type: string
                   protocol:
-                    $ref: "#/components/schemas/HelmPortProtocolEnum"
+                    $ref: '#/components/schemas/HelmPortProtocolEnum'
                   is_default:
                     type: boolean
                     description: is the default port to use for domain
@@ -19768,7 +19746,7 @@ components:
                       service_selectors:
                         type: array
                         items:
-                          $ref: "#/components/schemas/KubernetesSelector"
+                          $ref: '#/components/schemas/KubernetesSelector'
                   - type: object
                     properties:
                       service_name:
@@ -19779,20 +19757,20 @@ components:
         - DIFF
     DeploymentHistoryHelmResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
               type: string
               description: name of the helm
             status:
-              $ref: "#/components/schemas/StateEnum"
+              $ref: '#/components/schemas/StateEnum'
             commit:
-              $ref: "#/components/schemas/Commit"
+              $ref: '#/components/schemas/Commit'
             repository:
               type: object
               nullable: true
-              description: "If the chart source if from a repository, the chart name and its version"
+              description: 'If the chart source if from a repository, the chart name and its version'
               properties:
                 chart_name:
                   type: string
@@ -19815,7 +19793,7 @@ components:
                 - type: object
                   properties:
                     git_repository:
-                      $ref: "#/components/schemas/HelmGitRepositoryRequest"
+                      $ref: '#/components/schemas/HelmGitRepositoryRequest'
                 - type: object
                   properties:
                     helm_repository:
@@ -19875,7 +19853,7 @@ components:
           format: uuid
           description: ID of the associated service
         service_type:
-          $ref: "#/components/schemas/ServiceTypeEnum"
+          $ref: '#/components/schemas/ServiceTypeEnum'
         url:
           type: string
           description: URL to access the service
@@ -19884,10 +19862,10 @@ components:
           description: The port from which the service is reachable from within the cluster
         external_port:
           type: integer
-          description: "The port from which the service is reachable from externally (i.e: 443 for HTTPS)"
+          description: 'The port from which the service is reachable from externally (i.e: 443 for HTTPS)'
         is_qovery_domain:
           type: boolean
-          description: "True if the domain is managed by Qovery, false if it belongs to the user"
+          description: 'True if the domain is managed by Qovery, false if it belongs to the user'
         is_default:
           type: boolean
           description: |
@@ -19903,10 +19881,10 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Link"
+            $ref: '#/components/schemas/Link'
     LinkedServiceTypeEnum:
       type: string
-      description: "type of the service (application, database, job, gateway...)"
+      description: 'type of the service (application, database, job, gateway...)'
       enum:
         - APPLICATION
         - CONTAINER
@@ -19928,7 +19906,7 @@ components:
         created_at:
           type: string
           format: date-time
-          example: "2022-04-19T15:36:12.024Z"
+          example: '2022-04-19T15:36:12.024Z'
         message:
           type: string
         pod_name:
@@ -19943,7 +19921,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Log"
+            $ref: '#/components/schemas/Log'
     ManagedDatabaseTypeResponse:
       type: object
       required:
@@ -19958,7 +19936,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ManagedDatabaseTypeResponse"
+            $ref: '#/components/schemas/ManagedDatabaseTypeResponse'
     ManagedDatabaseInstanceTypeResponse:
       type: object
       required:
@@ -19973,10 +19951,10 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ManagedDatabaseInstanceTypeResponse"
+            $ref: '#/components/schemas/ManagedDatabaseInstanceTypeResponse'
     Member:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - email
@@ -19996,7 +19974,7 @@ components:
               format: date-time
               description: last time the user was connected
             role:
-              $ref: "#/components/schemas/InviteMemberRoleEnum"
+              $ref: '#/components/schemas/InviteMemberRoleEnum'
             role_name:
               type: string
               description: the role linked to the user
@@ -20009,7 +19987,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Member"
+            $ref: '#/components/schemas/Member'
     MemberRoleUpdateRequest:
       type: object
       required:
@@ -20024,8 +20002,8 @@ components:
           format: uuid
     Organization:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/OrganizationRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/OrganizationRequest'
         - type: object
           properties:
             owner:
@@ -20048,13 +20026,13 @@ components:
               type: object
               properties:
                 plan:
-                  $ref: "#/components/schemas/PlanEnum"
+                  $ref: '#/components/schemas/PlanEnum'
                 audit_logs_retention_in_days:
                   type: number
                   description: audit logs maximum period available in days
     OrganizationApiToken:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
@@ -20068,7 +20046,7 @@ components:
               format: uuid
     OrganizationApiTokenCreate:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             name:
@@ -20094,7 +20072,7 @@ components:
         description:
           type: string
         scope:
-          $ref: "#/components/schemas/OrganizationApiTokenScope"
+          $ref: '#/components/schemas/OrganizationApiTokenScope'
         role_id:
           type: string
           format: uuid
@@ -20106,7 +20084,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationApiToken"
+            $ref: '#/components/schemas/OrganizationApiToken'
     OrganizationApiTokenScope:
       type: string
       nullable: true
@@ -20130,7 +20108,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationAvailableRole"
+            $ref: '#/components/schemas/OrganizationAvailableRole'
     OrganizationChangePlanRequest:
       type: object
       properties:
@@ -20161,7 +20139,7 @@ components:
           type: string
     OrganizationCurrentCost:
       allOf:
-        - $ref: "#/components/schemas/CurrentCost"
+        - $ref: '#/components/schemas/CurrentCost'
         - type: object
     OrganizationCustomRoleCreateRequest:
       type: object
@@ -20193,7 +20171,7 @@ components:
                 type: string
                 format: uuid
               permission:
-                $ref: "#/components/schemas/OrganizationCustomRoleClusterPermission"
+                $ref: '#/components/schemas/OrganizationCustomRoleClusterPermission'
         project_permissions:
           description: Should contain an entry for every existing project
           type: array
@@ -20226,9 +20204,9 @@ components:
                   type: object
                   properties:
                     environment_type:
-                      $ref: "#/components/schemas/EnvironmentModeEnum"
+                      $ref: '#/components/schemas/EnvironmentModeEnum'
                     permission:
-                      $ref: "#/components/schemas/OrganizationCustomRoleProjectPermission"
+                      $ref: '#/components/schemas/OrganizationCustomRoleProjectPermission'
     OrganizationCustomRole:
       type: object
       properties:
@@ -20249,7 +20227,7 @@ components:
               cluster_name:
                 type: string
               permission:
-                $ref: "#/components/schemas/OrganizationCustomRoleClusterPermission"
+                $ref: '#/components/schemas/OrganizationCustomRoleClusterPermission'
         project_permissions:
           type: array
           items:
@@ -20276,16 +20254,16 @@ components:
                   type: object
                   properties:
                     environment_type:
-                      $ref: "#/components/schemas/EnvironmentModeEnum"
+                      $ref: '#/components/schemas/EnvironmentModeEnum'
                     permission:
-                      $ref: "#/components/schemas/OrganizationCustomRoleProjectPermission"
+                      $ref: '#/components/schemas/OrganizationCustomRoleProjectPermission'
     OrganizationCustomRoleList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationCustomRole"
+            $ref: '#/components/schemas/OrganizationCustomRole'
     OrganizationCustomRoleProjectPermission:
       type: string
       description: |
@@ -20363,7 +20341,7 @@ components:
           type: string
           nullable: true
         plan:
-          $ref: "#/components/schemas/PlanEnum"
+          $ref: '#/components/schemas/PlanEnum'
         website_url:
           type: string
           nullable: true
@@ -20387,7 +20365,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Organization"
+            $ref: '#/components/schemas/Organization'
     OrganizationEventResponse:
       type: object
       properties:
@@ -20398,7 +20376,7 @@ components:
           type: string
           format: date-time
         event_type:
-          $ref: "#/components/schemas/OrganizationEventType"
+          $ref: '#/components/schemas/OrganizationEventType'
         target_id:
           type: string
           format: uuid
@@ -20406,13 +20384,13 @@ components:
         target_name:
           type: string
         target_type:
-          $ref: "#/components/schemas/OrganizationEventTargetType"
+          $ref: '#/components/schemas/OrganizationEventTargetType'
         sub_target_type:
-          $ref: "#/components/schemas/OrganizationEventSubTargetType"
+          $ref: '#/components/schemas/OrganizationEventSubTargetType'
         change:
           type: string
         origin:
-          $ref: "#/components/schemas/OrganizationEventOrigin"
+          $ref: '#/components/schemas/OrganizationEventOrigin'
         triggered_by:
           type: string
         project_id:
@@ -20433,8 +20411,8 @@ components:
         original_change:
           type: string
           nullable: true
-      description: ""
-      title: ""
+      description: ''
+      title: ''
     OrganizationEventResponseList:
       type: object
       properties:
@@ -20453,7 +20431,7 @@ components:
         events:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationEventResponse"
+            $ref: '#/components/schemas/OrganizationEventResponse'
     OrganizationEventTargetResponseList:
       type: object
       properties:
@@ -20541,7 +20519,7 @@ components:
         - WEBHOOK
         - TERRAFORM
       example: APPLICATION
-      title: ""
+      title: ''
     OrganizationEventType:
       type: string
       description: Type of the organization event
@@ -20619,9 +20597,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_type:
-          $ref: "#/components/schemas/APIVariableTypeEnum"
+          $ref: '#/components/schemas/APIVariableTypeEnum'
         description:
           type: string
           x-stoplight:
@@ -20642,7 +20620,7 @@ components:
         - events
       properties:
         kind:
-          $ref: "#/components/schemas/OrganizationWebhookKindEnum"
+          $ref: '#/components/schemas/OrganizationWebhookKindEnum'
         target_url:
           type: string
           description: |
@@ -20661,7 +20639,7 @@ components:
         events:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationWebhookEventEnum"
+            $ref: '#/components/schemas/OrganizationWebhookEventEnum'
         project_names_filter:
           type: array
           description: |
@@ -20676,14 +20654,14 @@ components:
             Specify the environment modes you want to filter to.
             This webhook will be triggered only if the event is coming from an environment with the specified mode.
           items:
-            $ref: "#/components/schemas/EnvironmentModeEnum"
+            $ref: '#/components/schemas/EnvironmentModeEnum'
     OrganizationWebhookCreateResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             kind:
-              $ref: "#/components/schemas/OrganizationWebhookKindEnum"
+              $ref: '#/components/schemas/OrganizationWebhookKindEnum'
             target_url:
               type: string
               description: |
@@ -20699,7 +20677,7 @@ components:
             events:
               type: array
               items:
-                $ref: "#/components/schemas/OrganizationWebhookEventEnum"
+                $ref: '#/components/schemas/OrganizationWebhookEventEnum'
             project_names_filter:
               type: array
               description: |
@@ -20714,7 +20692,7 @@ components:
                 Specify the environment modes you want to filter to.
                 This webhook will be triggered only if the event is coming from an environment with the specified mode.
               items:
-                $ref: "#/components/schemas/EnvironmentModeEnum"
+                $ref: '#/components/schemas/EnvironmentModeEnum'
     OrganizationWebhookEventEnum:
       type: string
       description: |
@@ -20755,9 +20733,9 @@ components:
           format: date-time
           description: Timestamp when the webhook event was created
         kind:
-          $ref: "#/components/schemas/OrganizationWebhookKindEnum"
+          $ref: '#/components/schemas/OrganizationWebhookKindEnum'
         matched_event:
-          $ref: "#/components/schemas/OrganizationWebhookEventEnum"
+          $ref: '#/components/schemas/OrganizationWebhookEventEnum'
         target_url_used:
           type: string
           format: uri
@@ -20776,11 +20754,11 @@ components:
           description: Response body from the webhook target
     OrganizationWebhookResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           properties:
             kind:
-              $ref: "#/components/schemas/OrganizationWebhookKindEnum"
+              $ref: '#/components/schemas/OrganizationWebhookKindEnum'
             target_url:
               type: string
               description: |
@@ -20796,7 +20774,7 @@ components:
             events:
               type: array
               items:
-                $ref: "#/components/schemas/OrganizationWebhookEventEnum"
+                $ref: '#/components/schemas/OrganizationWebhookEventEnum'
             project_names_filter:
               type: array
               description: |
@@ -20811,21 +20789,21 @@ components:
                 Specify the environment modes you want to filter to.
                 This webhook will be triggered only if the event is coming from an environment with the specified mode.
               items:
-                $ref: "#/components/schemas/EnvironmentModeEnum"
+                $ref: '#/components/schemas/EnvironmentModeEnum'
     OrganizationWebhookResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationWebhookResponse"
+            $ref: '#/components/schemas/OrganizationWebhookResponse'
     WebhookEventResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/WebhookEventResponse"
+            $ref: '#/components/schemas/WebhookEventResponse'
     GitWebhookStatusResponse:
       type: object
       required:
@@ -20870,18 +20848,18 @@ components:
         annotations:
           type: array
           items:
-            $ref: "#/components/schemas/Annotation"
+            $ref: '#/components/schemas/Annotation'
         scopes:
           type: array
           items:
-            $ref: "#/components/schemas/OrganizationAnnotationsGroupScopeEnum"
+            $ref: '#/components/schemas/OrganizationAnnotationsGroupScopeEnum'
     OrganizationAnnotationsGroupResponseList:
       type: array
       items:
-        $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
+        $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
     OrganizationAnnotationsGroupResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -20893,11 +20871,11 @@ components:
             annotations:
               type: array
               items:
-                $ref: "#/components/schemas/Annotation"
+                $ref: '#/components/schemas/Annotation'
             scopes:
               type: array
               items:
-                $ref: "#/components/schemas/OrganizationAnnotationsGroupScopeEnum"
+                $ref: '#/components/schemas/OrganizationAnnotationsGroupScopeEnum'
     OrganizationAnnotationsGroupScopeEnum:
       type: string
       description: Annotations Group Scope
@@ -20944,7 +20922,7 @@ components:
               item_name:
                 type: string
               item_type:
-                $ref: "#/components/schemas/AnnotationsGroupAssociatedItemType"
+                $ref: '#/components/schemas/AnnotationsGroupAssociatedItemType'
     AnnotationsGroupAssociatedItemType:
       type: string
       description: Annotations Group Associated Item Type
@@ -20978,15 +20956,15 @@ components:
         labels:
           type: array
           items:
-            $ref: "#/components/schemas/Label"
+            $ref: '#/components/schemas/Label'
     OrganizationLabelsGroupResponseList:
       type: array
       items:
-        $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
-      title: ""
+        $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
+      title: ''
     OrganizationLabelsGroupResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -20997,8 +20975,8 @@ components:
             labels:
               type: array
               items:
-                $ref: "#/components/schemas/Label"
-      title: ""
+                $ref: '#/components/schemas/Label'
+      title: ''
     OrganizationLabelsGroupAssociatedItemsResponseList:
       type: object
       properties:
@@ -21032,7 +21010,7 @@ components:
               item_name:
                 type: string
               item_type:
-                $ref: "#/components/schemas/LabelsGroupAssociatedItemType"
+                $ref: '#/components/schemas/LabelsGroupAssociatedItemType'
     LabelsGroupAssociatedItemType:
       type: string
       description: Labels Group Associated Item Type
@@ -21071,7 +21049,7 @@ components:
           example: 20
     PlanEnum:
       type: string
-      description: "FREE, BUSINESS & PROFESSIONAL are deprecated. 2025 plans are the new plans available."
+      description: 'FREE, BUSINESS & PROFESSIONAL are deprecated. 2025 plans are the new plans available.'
       enum:
         - FREE
         - TEAM
@@ -21128,7 +21106,7 @@ components:
               properties:
                 command:
                   type: array
-                  description: 'Command to execute inside the container, specified as an array of strings. The first element is the executable, followed by its arguments. Example: ["sh", "-c", "test -f /tmp/healthy"]'
+                  description: "Command to execute inside the container, specified as an array of strings. The first element is the executable, followed by its arguments. Example: [\"sh\", \"-c\", \"test -f /tmp/healthy\"]"
                   example: ["sh", "-c", "test -f /tmp/healthy"]
                   items:
                     type: string
@@ -21160,7 +21138,7 @@ components:
           default: 9
     Project:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -21174,27 +21152,27 @@ components:
             associated_environments_count:
               type: integer
             organization:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
     ProjectCurrentCost:
       allOf:
-        - $ref: "#/components/schemas/GenericObjectCurrentCost"
+        - $ref: '#/components/schemas/GenericObjectCurrentCost'
         - type: object
           properties:
             environments:
               type: array
               items:
-                $ref: "#/components/schemas/GenericObjectCurrentCost"
+                $ref: '#/components/schemas/GenericObjectCurrentCost'
     ProjectCurrentCostResponseList:
       type: object
       properties:
         projects:
           type: array
           items:
-            $ref: "#/components/schemas/ProjectCurrentCost"
+            $ref: '#/components/schemas/ProjectCurrentCost'
     ProjectDeploymentRule:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/ProjectDeploymentRuleRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/ProjectDeploymentRuleRequest'
         - type: object
           properties:
             priority_index:
@@ -21222,7 +21200,7 @@ components:
           nullable: true
           example: description project rule
         mode:
-          $ref: "#/components/schemas/EnvironmentModeEnum"
+          $ref: '#/components/schemas/EnvironmentModeEnum'
         cluster_id:
           type: string
           format: uuid
@@ -21235,18 +21213,18 @@ components:
         start_time:
           type: string
           format: date-time
-          example: "1970-01-01T08:00:00.000Z"
+          example: '1970-01-01T08:00:00.000Z'
         stop_time:
           type: string
           format: date-time
-          example: "1970-01-01T19:00:00.000Z"
+          example: '1970-01-01T19:00:00.000Z'
         weekdays:
           type: array
           items:
-            $ref: "#/components/schemas/WeekdayEnum"
+            $ref: '#/components/schemas/WeekdayEnum'
         wildcard:
           type: string
-          default: ""
+          default: ''
           description: wildcard pattern composed of '?' and/or '*' used to target new created environments
     ProjectDeploymentRuleResponseList:
       type: object
@@ -21254,7 +21232,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ProjectDeploymentRule"
+            $ref: '#/components/schemas/ProjectDeploymentRule'
     ProjectDeploymentRulesPriorityOrderRequest:
       type: object
       properties:
@@ -21280,19 +21258,19 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Project"
+            $ref: '#/components/schemas/Project'
     ProjectStats:
       allOf:
-        - $ref: "#/components/schemas/ReferenceObject"
-        - $ref: "#/components/schemas/ServiceTotalNumber"
-        - $ref: "#/components/schemas/EnvironmentTotalNumber"
+        - $ref: '#/components/schemas/ReferenceObject'
+        - $ref: '#/components/schemas/ServiceTotalNumber'
+        - $ref: '#/components/schemas/EnvironmentTotalNumber'
     ProjectStatsResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ProjectStats"
+            $ref: '#/components/schemas/ProjectStats'
     RebootServicesRequest:
       type: object
       properties:
@@ -21322,15 +21300,15 @@ components:
           readOnly: true
     ReferenceObjectStatus:
       allOf:
-        - $ref: "#/components/schemas/ReferenceObject"
-        - $ref: "#/components/schemas/Status"
+        - $ref: '#/components/schemas/ReferenceObject'
+        - $ref: '#/components/schemas/Status'
     ReferenceObjectStatusResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ReferenceObjectStatus"
+            $ref: '#/components/schemas/ReferenceObjectStatus'
     Referral:
       type: object
       properties:
@@ -21339,7 +21317,7 @@ components:
           example: 2
         invitation_link:
           type: string
-          example: "https://join.qovery.com/xDowkWEl"
+          example: 'https://join.qovery.com/xDowkWEl'
     RewardClaim:
       type: object
       properties:
@@ -21371,7 +21349,7 @@ components:
           type: string
     Secret:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - key
@@ -21381,23 +21359,23 @@ components:
               type: string
               description: key is case sensitive
             overridden_secret:
-              $ref: "#/components/schemas/SecretOverride"
+              $ref: '#/components/schemas/SecretOverride'
             aliased_secret:
-              $ref: "#/components/schemas/SecretAlias"
+              $ref: '#/components/schemas/SecretAlias'
             scope:
-              $ref: "#/components/schemas/APIVariableScopeEnum"
+              $ref: '#/components/schemas/APIVariableScopeEnum'
             variable_type:
-              $ref: "#/components/schemas/APIVariableTypeEnum"
+              $ref: '#/components/schemas/APIVariableTypeEnum'
             service_id:
               type: string
               format: uuid
             service_name:
               type: string
             service_type:
-              $ref: "#/components/schemas/LinkedServiceTypeEnum"
+              $ref: '#/components/schemas/LinkedServiceTypeEnum'
             owned_by:
               type: string
-              description: "Entity that created/own the variable (i.e: Qovery, Doppler)"
+              description: 'Entity that created/own the variable (i.e: Qovery, Doppler)'
             description:
               type: string
               x-stoplight:
@@ -21465,22 +21443,22 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Secret"
+            $ref: '#/components/schemas/Secret'
     Service:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - id
           properties:
             type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
             name:
               type: string
               description: name of the service
             id:
               type: string
-              description: "uuid of the associated service (application, database, job, gateway...)"
+              description: 'uuid of the associated service (application, database, job, gateway...)'
               format: uuid
             deployed_commit_id:
               type: string
@@ -21495,7 +21473,7 @@ components:
             service_typology:
               type: string
               example: container
-              description: "describes the typology of service (container, postgresl, redis...)"
+              description: 'describes the typology of service (container, postgresl, redis...)'
             service_version:
               type: string
               description: for databases this field exposes the database version
@@ -21519,7 +21497,7 @@ components:
       type: string
       x-stoplight:
         id: d66063cd29913
-      description: "type of the service (application, database, job, ...)"
+      description: 'type of the service (application, database, job, ...)'
       enum:
         - APPLICATION
         - DATABASE
@@ -21529,8 +21507,8 @@ components:
         - TERRAFORM
     SignUp:
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/SignUpRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/SignUpRequest'
     SignUpRequest:
       type: object
       required:
@@ -21547,14 +21525,14 @@ components:
         user_email:
           type: string
         type_of_use:
-          $ref: "#/components/schemas/TypeOfUseEnum"
+          $ref: '#/components/schemas/TypeOfUseEnum'
         qovery_usage:
           type: string
         company_name:
           type: string
           nullable: true
         company_size:
-          $ref: "#/components/schemas/CompanySizeEnum"
+          $ref: '#/components/schemas/CompanySizeEnum'
         user_role:
           type: string
           nullable: true
@@ -21687,22 +21665,22 @@ components:
           type: string
           format: uuid
         state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         service_deployment_status:
-          $ref: "#/components/schemas/ServiceDeploymentStatusEnum"
+          $ref: '#/components/schemas/ServiceDeploymentStatusEnum'
         last_deployment_date:
           type: string
           format: date-time
         is_part_last_deployment:
           type: boolean
         steps:
-          $ref: "#/components/schemas/ServiceStepMetrics"
+          $ref: '#/components/schemas/ServiceStepMetrics'
         execution_id:
           type: string
           x-stoplight:
             id: 3o9tz4272s2ct
         status_details:
-          $ref: "#/components/schemas/StatusDetails"
+          $ref: '#/components/schemas/StatusDetails'
         deployment_request_id:
           type: string
           x-stoplight:
@@ -21721,11 +21699,11 @@ components:
         - sub_action
       properties:
         action:
-          $ref: "#/components/schemas/ServiceActionEnum"
+          $ref: '#/components/schemas/ServiceActionEnum'
         status:
-          $ref: "#/components/schemas/ServiceActionStatusEnum"
+          $ref: '#/components/schemas/ServiceActionStatusEnum'
         sub_action:
-          $ref: "#/components/schemas/ServiceSubActionEnum"
+          $ref: '#/components/schemas/ServiceSubActionEnum'
     Stage:
       type: object
       required:
@@ -21740,13 +21718,13 @@ components:
           type: string
           description: stage name
         steps:
-          $ref: "#/components/schemas/StageStepMetrics"
+          $ref: '#/components/schemas/StageStepMetrics'
         description:
           type: string
           x-stoplight:
             id: gwpra9face692
         status:
-          $ref: "#/components/schemas/StageStatusEnum"
+          $ref: '#/components/schemas/StageStatusEnum'
     StatusKindEnum:
       type: string
       enum:
@@ -21812,7 +21790,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/User"
+            $ref: '#/components/schemas/User'
     Value:
       type: object
       title: EnvironmentVariableOverrideRequest
@@ -21854,7 +21832,7 @@ components:
                 type: string
                 description: Optional if the variable is secret
               scope:
-                $ref: "#/components/schemas/APIVariableScopeEnum"
+                $ref: '#/components/schemas/APIVariableScopeEnum'
               is_secret:
                 type: boolean
     VariableImportRequest:
@@ -21881,7 +21859,7 @@ components:
               value:
                 type: string
               scope:
-                $ref: "#/components/schemas/APIVariableScopeEnum"
+                $ref: '#/components/schemas/APIVariableScopeEnum'
               is_secret:
                 type: boolean
     Version:
@@ -21891,14 +21869,14 @@ components:
       properties:
         name:
           type: string
-          example: "10.1"
+          example: '10.1'
     VersionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Version"
+            $ref: '#/components/schemas/Version'
     WeekdayEnum:
       type: string
       enum:
@@ -21921,7 +21899,7 @@ components:
           type: string
           description: the value to be used as Alias of the targeted environment variable.
         alias_scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         alias_parent_id:
           type: string
           format: uuid
@@ -21949,7 +21927,7 @@ components:
           type: string
           description: the value to be used as Override of the targeted environment variable.
         override_scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         override_parent_id:
           type: string
           format: uuid
@@ -21987,13 +21965,13 @@ components:
           nullable: true
         is_secret:
           type: boolean
-          description: "if true, the variable will be considered as a secret and will not be accessible after its creation. Only your applications will be able to access its value at build and run time."
+          description: 'if true, the variable will be considered as a secret and will not be accessible after its creation. Only your applications will be able to access its value at build and run time.'
         variable_scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_parent_id:
           type: string
           format: uuid
-          description: "based on the selected scope, it contains the ID of the service, environment or project where the variable is attached"
+          description: 'based on the selected scope, it contains the ID of the service, environment or project where the variable is attached'
         description:
           type: string
           x-stoplight:
@@ -22030,7 +22008,7 @@ components:
           nullable: true
     VariableResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - key
@@ -22048,13 +22026,13 @@ components:
               type: string
               nullable: true
             overridden_variable:
-              $ref: "#/components/schemas/VariableOverride"
+              $ref: '#/components/schemas/VariableOverride'
             aliased_variable:
-              $ref: "#/components/schemas/VariableAlias"
+              $ref: '#/components/schemas/VariableAlias'
             scope:
-              $ref: "#/components/schemas/APIVariableScopeEnum"
+              $ref: '#/components/schemas/APIVariableScopeEnum'
             variable_type:
-              $ref: "#/components/schemas/APIVariableTypeEnum"
+              $ref: '#/components/schemas/APIVariableTypeEnum'
             service_id:
               type: string
               format: uuid
@@ -22063,10 +22041,10 @@ components:
               type: string
               description: The name of the service referenced by this variable.
             service_type:
-              $ref: "#/components/schemas/LinkedServiceTypeEnum"
+              $ref: '#/components/schemas/LinkedServiceTypeEnum'
             owned_by:
               type: string
-              description: "Entity that created/own the variable (i.e: Qovery, Doppler)"
+              description: 'Entity that created/own the variable (i.e: Qovery, Doppler)'
             is_secret:
               type: boolean
             description:
@@ -22083,7 +22061,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/VariableResponse"
+            $ref: '#/components/schemas/VariableResponse'
     VariableAlias:
       type: object
       required:
@@ -22105,9 +22083,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_type:
-          $ref: "#/components/schemas/APIVariableTypeEnum"
+          $ref: '#/components/schemas/APIVariableTypeEnum'
     VariableOverride:
       type: object
       required:
@@ -22132,9 +22110,9 @@ components:
           type: string
           description: The mounth path of the overriden variable (only if environment variable type is 'file')
         scope:
-          $ref: "#/components/schemas/APIVariableScopeEnum"
+          $ref: '#/components/schemas/APIVariableScopeEnum'
         variable_type:
-          $ref: "#/components/schemas/APIVariableTypeEnum"
+          $ref: '#/components/schemas/APIVariableTypeEnum'
     ClusterDeploymentStatusEnum:
       type: string
       enum:
@@ -22145,9 +22123,9 @@ components:
       type: object
       properties:
         step_name:
-          $ref: "#/components/schemas/ServiceStepMetricNameEnum"
+          $ref: '#/components/schemas/ServiceStepMetricNameEnum'
         status:
-          $ref: "#/components/schemas/StepMetricStatusEnum"
+          $ref: '#/components/schemas/StepMetricStatusEnum'
         duration_sec:
           description: The duration of the step in seconds.
           type: integer
@@ -22165,7 +22143,7 @@ components:
           description: A list of metrics for deployment steps of the stage.
           type: array
           items:
-            $ref: "#/components/schemas/StageStepMetric"
+            $ref: '#/components/schemas/StageStepMetric'
     ServiceStepMetrics:
       type: object
       required:
@@ -22184,7 +22162,7 @@ components:
           description: A list of metrics for deployment steps of the service.
           type: array
           items:
-            $ref: "#/components/schemas/ServiceStepMetric"
+            $ref: '#/components/schemas/ServiceStepMetric'
     StageStepMetric:
       type: object
       properties:
@@ -22192,9 +22170,9 @@ components:
           type: string
           format: uuid
         step_name:
-          $ref: "#/components/schemas/StageStepMetricNameEnum"
+          $ref: '#/components/schemas/StageStepMetricNameEnum'
         status:
-          $ref: "#/components/schemas/StepMetricStatusEnum"
+          $ref: '#/components/schemas/StepMetricStatusEnum'
         duration_sec:
           description: The duration of the step in seconds.
           type: integer
@@ -22281,14 +22259,14 @@ components:
         - CRON
     LifecycleJobResponse:
       allOf:
-        - $ref: "#/components/schemas/BaseJobResponse"
+        - $ref: '#/components/schemas/BaseJobResponse'
         - type: object
           required:
             - job_type
             - schedule
           properties:
             job_type:
-              $ref: "#/components/schemas/JobTypeEnum"
+              $ref: '#/components/schemas/JobTypeEnum'
             schedule:
               type: object
               properties:
@@ -22323,22 +22301,22 @@ components:
                       type: string
                       description: optional entrypoint when launching container
                 lifecycle_type:
-                  $ref: "#/components/schemas/JobLifecycleTypeEnum"
+                  $ref: '#/components/schemas/JobLifecycleTypeEnum'
             annotations_groups:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
             labels_groups:
-              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
-      title: ""
+              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
+      title: ''
     CronJobResponse:
       allOf:
-        - $ref: "#/components/schemas/BaseJobResponse"
+        - $ref: '#/components/schemas/BaseJobResponse'
         - type: object
           required:
             - job_type
             - schedule
           properties:
             job_type:
-              $ref: "#/components/schemas/JobTypeEnum"
+              $ref: '#/components/schemas/JobTypeEnum'
             schedule:
               type: object
               required:
@@ -22370,12 +22348,12 @@ components:
                         See https://crontab.guru/ to WISIWIG interface.  
                         Timezone is UT
             annotations_groups:
-              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
             labels_groups:
-              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
+              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
     BaseJobResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - environment
@@ -22393,7 +22371,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             maximum_cpu:
               type: integer
               description: Maximum cpu that can be allocated to the job based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu
@@ -22460,16 +22438,16 @@ components:
                     - image
                   properties:
                     image:
-                      $ref: "#/components/schemas/ContainerSource"
+                      $ref: '#/components/schemas/ContainerSource'
                   type: object
                 - required:
                     - docker
                   properties:
                     docker:
-                      $ref: "#/components/schemas/JobSourceDockerResponse"
+                      $ref: '#/components/schemas/JobSourceDockerResponse'
                   type: object
             healthchecks:
-              $ref: "#/components/schemas/Healthcheck"
+              $ref: '#/components/schemas/Healthcheck'
             auto_deploy:
               type: boolean
               description: |
@@ -22482,7 +22460,7 @@ components:
               x-stoplight:
                 id: p1secr7kxozsd
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
     HelmGitRepositoryRequest:
       type: object
       required:
@@ -22494,7 +22472,7 @@ components:
         url:
           type: string
           description: application git repository URL
-          example: "https://github.com/Qovery/simple-node-app"
+          example: 'https://github.com/Qovery/simple-node-app'
         branch:
           type: string
           description: |
@@ -22510,10 +22488,10 @@ components:
           format: uuid
           description: The git token id on Qovery side
           nullable: true
-      title: ""
+      title: ''
     HelmKeyValues:
       type: array
-      description: "The input is in json array format: [ [$KEY,$VALUE], [...] ]"
+      description: 'The input is in json array format: [ [$KEY,$VALUE], [...] ]'
       items:
         type: array
         items:
@@ -22529,12 +22507,12 @@ components:
           description: The start date of the report
           type: string
           format: date-time
-          example: "2020-01-01T00:00:00.000Z"
+          example: '2020-01-01T00:00:00.000Z'
         to:
           description: The end date of the report
           type: string
           format: date-time
-          example: "2020-01-31T23:59:59.000Z"
+          example: '2020-01-31T23:59:59.000Z'
         report_expiration_in_seconds:
           description: The number of seconds the report will be publicly available
           type: integer
@@ -22588,13 +22566,13 @@ components:
         id: 2tbiuqncqaqaw
       type: array
       items:
-        $ref: "#/components/schemas/OrganizationAnnotationsGroupEnrichedResponse"
+        $ref: '#/components/schemas/OrganizationAnnotationsGroupEnrichedResponse'
     OrganizationAnnotationsGroupEnrichedResponse:
       title: OrganizationAnnotationsGroupEnrichedResponse
       x-stoplight:
         id: edjpmiyq8n5nt
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           x-stoplight:
             id: 2auhw8xgz67rj
@@ -22612,13 +22590,13 @@ components:
               x-stoplight:
                 id: 4yn29zdqeb0og
               items:
-                $ref: "#/components/schemas/Annotation"
+                $ref: '#/components/schemas/Annotation'
             scopes:
               x-stoplight:
                 id: h8qu8e8yp5dh3
               type: array
               items:
-                $ref: "#/components/schemas/OrganizationAnnotationsGroupScopeEnum"
+                $ref: '#/components/schemas/OrganizationAnnotationsGroupScopeEnum'
             associated_items_count:
               type: integer
               x-stoplight:
@@ -22627,11 +22605,11 @@ components:
       title: OrganizationLabelsGroupEnrichedResponseList
       type: array
       items:
-        $ref: "#/components/schemas/OrganizationLabelsGroupEnrichedResponse"
+        $ref: '#/components/schemas/OrganizationLabelsGroupEnrichedResponse'
     OrganizationLabelsGroupEnrichedResponse:
       title: OrganizationLabelsGroupEnrichedResponse
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -22642,7 +22620,7 @@ components:
             labels:
               type: array
               items:
-                $ref: "#/components/schemas/Label"
+                $ref: '#/components/schemas/Label'
             associated_items_count:
               type: integer
     JobSourceDockerResponse:
@@ -22652,7 +22630,7 @@ components:
       type: object
       properties:
         git_repository:
-          $ref: "#/components/schemas/ApplicationGitRepository"
+          $ref: '#/components/schemas/ApplicationGitRepository'
         dockerfile_path:
           type: string
           x-stoplight:
@@ -22721,7 +22699,7 @@ components:
         - git_repository
       properties:
         git_repository:
-          $ref: "#/components/schemas/ApplicationGitRepository"
+          $ref: '#/components/schemas/ApplicationGitRepository'
     CpuArchitectureEnum:
       title: CpuArchitectureEnum
       x-stoplight:
@@ -22739,9 +22717,9 @@ components:
         - value
       properties:
         type:
-          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
+          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
         value:
-          $ref: "#/components/schemas/ClusterFeatureKarpenterParameters"
+          $ref: '#/components/schemas/ClusterFeatureKarpenterParameters'
     ClusterFeatureKarpenterParameters:
       title: ClusterFeatureKarpenterParameters
       x-stoplight:
@@ -22774,9 +22752,9 @@ components:
           example: 255
           description: Unit is in MB/s. The disk throughput to be used for the node configuration
         default_service_architecture:
-          $ref: "#/components/schemas/CpuArchitectureEnum"
+          $ref: '#/components/schemas/CpuArchitectureEnum'
         qovery_node_pools:
-          $ref: "#/components/schemas/KarpenterNodePool"
+          $ref: '#/components/schemas/KarpenterNodePool'
     JobLifecycleTypeEnum:
       title: JobLifecycleTypeEnum
       x-stoplight:
@@ -22857,7 +22835,7 @@ components:
           format: uri
           description: location of the template
         cloud_provider:
-          $ref: "#/components/schemas/CloudProviderEnum"
+          $ref: '#/components/schemas/CloudProviderEnum'
         events:
           type: array
           x-stoplight:
@@ -22948,7 +22926,7 @@ components:
                 type: object
                 x-stoplight:
                   id: 71mpuvnx5g4gm
-                description: "If present, the variable should be a file instead of a raw value"
+                description: 'If present, the variable should be a file instead of a raw value'
                 required:
                   - path
                 properties:
@@ -22976,7 +22954,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/ContainerRegistryAssociatedServicesResponse"
+            $ref: '#/components/schemas/ContainerRegistryAssociatedServicesResponse'
     CheckedCustomDomainsResponse:
       title: CheckedCustomDomainsResponse
       type: object
@@ -22986,7 +22964,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/CheckedCustomDomainResponse"
+            $ref: '#/components/schemas/CheckedCustomDomainResponse'
     CheckedCustomDomainStatus:
       type: string
       enum:
@@ -23015,7 +22993,7 @@ components:
           description: domain name checked
           example: my.domain.tld
         status:
-          $ref: "#/components/schemas/CheckedCustomDomainStatus"
+          $ref: '#/components/schemas/CheckedCustomDomainStatus'
         error_details:
           type: string
           nullable: true
@@ -23062,7 +23040,7 @@ components:
           x-stoplight:
             id: ga0yqhtmi4nl6
         service_type:
-          $ref: "#/components/schemas/ContainerRegistryAssociatedServiceType"
+          $ref: '#/components/schemas/ContainerRegistryAssociatedServiceType'
     ContainerRegistryAssociatedServiceType:
       title: ContainerRegistryAssociatedServiceType
       x-stoplight:
@@ -23119,7 +23097,7 @@ components:
           x-stoplight:
             id: rb0g9ev15frmu
         service_type:
-          $ref: "#/components/schemas/HelmRepositoryAssociatedServiceType"
+          $ref: '#/components/schemas/HelmRepositoryAssociatedServiceType'
     HelmRepositoryAssociatedServicesResponseList:
       title: HelmRepositoryAssociatedServicesResponseList
       x-stoplight:
@@ -23131,7 +23109,7 @@ components:
           x-stoplight:
             id: 00sn35cw5lnb4
           items:
-            $ref: "#/components/schemas/HelmRepositoryAssociatedServicesResponse"
+            $ref: '#/components/schemas/HelmRepositoryAssociatedServicesResponse'
     KubernetesServiceResponseList:
       title: KubernetesServiceResponseList
       x-stoplight:
@@ -23141,7 +23119,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/KubernetesService"
+            $ref: '#/components/schemas/KubernetesService'
     KubernetesService:
       title: KubernetesService
       x-stoplight:
@@ -23152,9 +23130,9 @@ components:
         - service_spec
       properties:
         metadata:
-          $ref: "#/components/schemas/KubernetesMetadata"
+          $ref: '#/components/schemas/KubernetesMetadata'
         service_spec:
-          $ref: "#/components/schemas/KubernetesServiceSpec"
+          $ref: '#/components/schemas/KubernetesServiceSpec'
     KubernetesMetadata:
       title: KubernetesMetadata
       x-stoplight:
@@ -23180,13 +23158,13 @@ components:
           x-stoplight:
             id: xaa6ow6ugihju
           items:
-            $ref: "#/components/schemas/KubernetesServicePort"
+            $ref: '#/components/schemas/KubernetesServicePort'
         selectors:
           type: array
           x-stoplight:
             id: snld7nhiy088w
           items:
-            $ref: "#/components/schemas/KubernetesSelector"
+            $ref: '#/components/schemas/KubernetesSelector'
     KubernetesServicePort:
       title: KubernetesServicePort
       x-stoplight:
@@ -23290,13 +23268,13 @@ components:
             id: pkowctfxv7q77
           type: array
           items:
-            $ref: "#/components/schemas/KarpenterNodePoolRequirement"
+            $ref: '#/components/schemas/KarpenterNodePoolRequirement'
         stable_override:
-          $ref: "#/components/schemas/KarpenterStableNodePoolOverride"
+          $ref: '#/components/schemas/KarpenterStableNodePoolOverride'
         default_override:
-          $ref: "#/components/schemas/KarpenterDefaultNodePoolOverride"
+          $ref: '#/components/schemas/KarpenterDefaultNodePoolOverride'
         gpu_override:
-          $ref: "#/components/schemas/KarpenterGpuNodePoolOverride"
+          $ref: '#/components/schemas/KarpenterGpuNodePoolOverride'
     KarpenterNodePoolRequirementKey:
       title: KarpenterNodePoolRequirementKey
       x-stoplight:
@@ -23324,9 +23302,9 @@ components:
         - values
       properties:
         key:
-          $ref: "#/components/schemas/KarpenterNodePoolRequirementKey"
+          $ref: '#/components/schemas/KarpenterNodePoolRequirementKey'
         operator:
-          $ref: "#/components/schemas/KarpenterNodePoolRequirementOperator"
+          $ref: '#/components/schemas/KarpenterNodePoolRequirementOperator'
         values:
           type: array
           x-stoplight:
@@ -23340,13 +23318,13 @@ components:
       type: object
       properties:
         consolidation:
-          $ref: "#/components/schemas/KarpenterNodePoolConsolidation"
+          $ref: '#/components/schemas/KarpenterNodePoolConsolidation'
         limits:
-          $ref: "#/components/schemas/KarpenterNodePoolLimits"
+          $ref: '#/components/schemas/KarpenterNodePoolLimits'
         consolidate_after:
           type: string
-          description: "Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h"
-          example: "30s"
+          description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
+          example: '30s'
           pattern: '^\d+(s|m|h)$'
     KarpenterGpuNodePoolOverride:
       title: KarpenterGpuNodePoolOverride
@@ -23355,15 +23333,15 @@ components:
       type: object
       properties:
         consolidation:
-          $ref: "#/components/schemas/KarpenterNodePoolConsolidation"
+          $ref: '#/components/schemas/KarpenterNodePoolConsolidation'
         limits:
-          $ref: "#/components/schemas/KarpenterNodePoolLimits"
+          $ref: '#/components/schemas/KarpenterNodePoolLimits'
         requirements:
           type: array
           x-stoplight:
             id: 38pdri17ozql9
           items:
-            $ref: "#/components/schemas/KarpenterNodePoolRequirement"
+            $ref: '#/components/schemas/KarpenterNodePoolRequirement'
         disk_size_in_gib:
           type: integer
           x-stoplight:
@@ -23394,19 +23372,19 @@ components:
           default: false
         consolidate_after:
           type: string
-          description: "Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h"
-          example: "30s"
+          description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
+          example: '30s'
           pattern: '^\d+(s|m|h)$'
     KarpenterDefaultNodePoolOverride:
       title: KarpenterDefaultNodePoolOverride
       type: object
       properties:
         limits:
-          $ref: "#/components/schemas/KarpenterNodePoolLimits"
+          $ref: '#/components/schemas/KarpenterNodePoolLimits'
         consolidate_after:
           type: string
-          description: "Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h"
-          example: "1m"
+          description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
+          example: '1m'
           pattern: '^\d+(s|m|h)$'
     KarpenterNodePoolConsolidation:
       title: KarpenterNodePoolConsolidation
@@ -23425,13 +23403,13 @@ components:
           type: array
           nullable: false
           items:
-            $ref: "#/components/schemas/WeekdayEnum"
+            $ref: '#/components/schemas/WeekdayEnum'
         start_time:
           description: |
             The start date of the consolidation.
             The format should follow ISO-8601 convention: "PThh:mm"
           type: string
-          example: "PT22:30"
+          example: 'PT22:30'
           nullable: false
         duration:
           description: |
@@ -23463,10 +23441,10 @@ components:
           nullable: false
         max_cpu_in_vcpu:
           type: integer
-          description: "CPU limit that will be applied for the node pool (in vCPU unit: 1 vCPU = 1000 millicores)"
+          description: 'CPU limit that will be applied for the node pool (in vCPU unit: 1 vCPU = 1000 millicores)'
         max_memory_in_gibibytes:
           type: integer
-          description: "Memory limit that will be applied for the node pool (in Gibibytes unit: 1Gi = 1024 mebibytes)"
+          description: 'Memory limit that will be applied for the node pool (in Gibibytes unit: 1Gi = 1024 mebibytes)'
         max_gpu:
           type: integer
           x-stoplight:
@@ -23535,7 +23513,7 @@ components:
           x-stoplight:
             id: xpi2ooy1zclay
           items:
-            $ref: "#/components/schemas/ClusterLock"
+            $ref: '#/components/schemas/ClusterLock'
     EnvDeploymentStatus:
       title: EnvDeploymentStatus
       x-stoplight:
@@ -23553,7 +23531,7 @@ components:
             id: t6sa9u90dayva
           format: uuid
         status:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
     DeploymentHistoryActionStatus:
       title: DeploymentHistoryActionStatus
       x-stoplight:
@@ -23607,9 +23585,9 @@ components:
               x-stoplight:
                 id: hfi1kibghpsc3
             origin:
-              $ref: "#/components/schemas/OrganizationEventOrigin"
+              $ref: '#/components/schemas/OrganizationEventOrigin'
         trigger_action:
-          $ref: "#/components/schemas/DeploymentHistoryTriggerAction"
+          $ref: '#/components/schemas/DeploymentHistoryTriggerAction'
         stages:
           type: array
           x-stoplight:
@@ -23628,7 +23606,7 @@ components:
                 x-stoplight:
                   id: 7p40i9fzfddii
               status:
-                $ref: "#/components/schemas/StageStatusEnum"
+                $ref: '#/components/schemas/StageStatusEnum'
               services:
                 type: array
                 x-stoplight:
@@ -23656,13 +23634,13 @@ components:
                             id: ixyztl7bo1e7r
                           format: uuid
                         service_type:
-                          $ref: "#/components/schemas/ServiceTypeEnum"
+                          $ref: '#/components/schemas/ServiceTypeEnum'
                         name:
                           type: string
                           x-stoplight:
                             id: rqj252xn7e17p
                     status:
-                      $ref: "#/components/schemas/StageStatusEnum"
+                      $ref: '#/components/schemas/StageStatusEnum'
                     icon_uri:
                       type: string
                       x-stoplight:
@@ -23713,7 +23691,7 @@ components:
                 id: 0l33zc2pd2ie0
               format: uuid
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
             name:
               type: string
               x-stoplight:
@@ -23726,9 +23704,9 @@ components:
             triggered_by:
               type: string
             origin:
-              $ref: "#/components/schemas/OrganizationEventOrigin"
+              $ref: '#/components/schemas/OrganizationEventOrigin'
         status_details:
-          $ref: "#/components/schemas/StatusDetails"
+          $ref: '#/components/schemas/StatusDetails'
         icon_uri:
           type: string
           x-stoplight:
@@ -23769,7 +23747,7 @@ components:
           x-stoplight:
             id: k6zs0jdg7k95f
         service_type:
-          $ref: "#/components/schemas/ServiceTypeEnum"
+          $ref: '#/components/schemas/ServiceTypeEnum'
         project_id:
           type: string
           x-stoplight:
@@ -23801,7 +23779,7 @@ components:
             - LIFECYCLE
     OrganizationEnvironmentResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -23813,11 +23791,11 @@ components:
               type: string
               description: name is case insensitive
             organization:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             project:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             mode:
-              $ref: "#/components/schemas/EnvironmentModeEnum"
+              $ref: '#/components/schemas/EnvironmentModeEnum'
     ClusterMetricsResponse:
       title: ClusterMetricsResponse
       x-stoplight:
@@ -23842,11 +23820,11 @@ components:
           x-stoplight:
             id: 1e9r2at0nxziv
           oneOf:
-            - $ref: "#/components/schemas/MetricsConfigurationManagedByQovery"
+            - $ref: '#/components/schemas/MetricsConfigurationManagedByQovery'
           discriminator:
             propertyName: kind
             mapping:
-              MANAGED_BY_QOVERY: "#/components/schemas/MetricsConfigurationManagedByQovery"
+              MANAGED_BY_QOVERY: '#/components/schemas/MetricsConfigurationManagedByQovery'
     MetricsConfigurationManagedByQovery:
       title: MetricsConfigurationManagedByQovery
       x-stoplight:
@@ -23859,17 +23837,17 @@ components:
           enum:
             - MANAGED_BY_QOVERY
         resource_profile:
-          $ref: "#/components/schemas/ObservabilityResourceProfile"
+          $ref: '#/components/schemas/ObservabilityResourceProfile'
         cloud_watch_export_config:
-          $ref: "#/components/schemas/CloudWatchExportConfig"
+          $ref: '#/components/schemas/CloudWatchExportConfig'
         high_availability:
           type: boolean
           x-stoplight:
             id: zs2zhdd1p5e6q
         internal_network_monitoring:
-          $ref: "#/components/schemas/InternalNetworkMonitoring"
+          $ref: '#/components/schemas/InternalNetworkMonitoring'
         alerting:
-          $ref: "#/components/schemas/AlertingConfig"
+          $ref: '#/components/schemas/AlertingConfig'
     InfrastructureOutputs:
       type: object
       required:
@@ -23877,15 +23855,15 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          AKS: "#/components/schemas/AksInfrastructureOutputs"
-          EKS: "#/components/schemas/EksInfrastructureOutputs"
-          GKE: "#/components/schemas/GkeInfrastructureOutputs"
-          SCW_KAPSULE: "#/components/schemas/KapsuleInfrastructureOutputs"
+          AKS: '#/components/schemas/AksInfrastructureOutputs'
+          EKS: '#/components/schemas/EksInfrastructureOutputs'
+          GKE: '#/components/schemas/GkeInfrastructureOutputs'
+          SCW_KAPSULE: '#/components/schemas/KapsuleInfrastructureOutputs'
       oneOf:
-        - $ref: "#/components/schemas/AksInfrastructureOutputs"
-        - $ref: "#/components/schemas/EksInfrastructureOutputs"
-        - $ref: "#/components/schemas/GkeInfrastructureOutputs"
-        - $ref: "#/components/schemas/KapsuleInfrastructureOutputs"
+        - $ref: '#/components/schemas/AksInfrastructureOutputs'
+        - $ref: '#/components/schemas/EksInfrastructureOutputs'
+        - $ref: '#/components/schemas/GkeInfrastructureOutputs'
+        - $ref: '#/components/schemas/KapsuleInfrastructureOutputs'
     AksInfrastructureOutputs:
       type: object
       required:
@@ -23957,7 +23935,7 @@ components:
             id: e507c0na5om2i
           format: uuid
         status:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
     GcpStaticClusterCredentials:
       title: GcpStaticClusterCredentials
       x-stoplight:
@@ -24077,15 +24055,15 @@ components:
             - type: object
               properties:
                 git_repository:
-                  $ref: "#/components/schemas/TerraformGitRepositoryRequest"
+                  $ref: '#/components/schemas/TerraformGitRepositoryRequest'
         terraform_variables_source:
-          $ref: "#/components/schemas/TerraformVariablesSourceRequest"
+          $ref: '#/components/schemas/TerraformVariablesSourceRequest'
         backend:
-          $ref: "#/components/schemas/TerraformBackend"
+          $ref: '#/components/schemas/TerraformBackend'
         engine:
-          $ref: "#/components/schemas/TerraformEngineEnum"
+          $ref: '#/components/schemas/TerraformEngineEnum'
         provider_version:
-          $ref: "#/components/schemas/TerraformProviderVersion"
+          $ref: '#/components/schemas/TerraformProviderVersion'
         timeout_sec:
           type: integer
           x-stoplight:
@@ -24096,7 +24074,7 @@ components:
             id: nem7zoh97kyzc
           format: uri
         job_resources:
-          $ref: "#/components/schemas/TerraformRequestJobResources"
+          $ref: '#/components/schemas/TerraformRequestJobResources'
         use_cluster_credentials:
           type: boolean
           x-stoplight:
@@ -24124,13 +24102,13 @@ components:
             Custom Dockerfile fragment to inject during build. Optional field.
             When null, no custom fragment is injected.
           oneOf:
-            - $ref: "#/components/schemas/DockerfileFragmentFile"
-            - $ref: "#/components/schemas/DockerfileFragmentInline"
+            - $ref: '#/components/schemas/DockerfileFragmentFile'
+            - $ref: '#/components/schemas/DockerfileFragmentInline'
           discriminator:
             propertyName: type
             mapping:
-              file: "#/components/schemas/DockerfileFragmentFile"
-              inline: "#/components/schemas/DockerfileFragmentInline"
+              file: '#/components/schemas/DockerfileFragmentFile'
+              inline: '#/components/schemas/DockerfileFragmentInline'
     TerraformResourceResponse:
       type: object
       title: Terraform Resource Response
@@ -24152,7 +24130,7 @@ components:
           example: 550e8400-e29b-41d4-a716-446655440000
         resource_type:
           type: string
-          description: "Type of the Terraform resource (e.g., aws_instance, aws_s3_bucket)"
+          description: 'Type of the Terraform resource (e.g., aws_instance, aws_s3_bucket)'
           example: aws_instance
         name:
           type: string
@@ -24160,11 +24138,11 @@ components:
           example: web_server
         address:
           type: string
-          description: "Full address of the resource (e.g., aws_instance.web_server)"
+          description: 'Full address of the resource (e.g., aws_instance.web_server)'
           example: aws_instance.web_server
         provider:
           type: string
-          description: "Terraform provider name (e.g., aws, google, azurerm)"
+          description: 'Terraform provider name (e.g., aws, google, azurerm)'
           example: aws
         mode:
           type: string
@@ -24186,7 +24164,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the resource was extracted from Terraform state
-          example: "2023-01-15T10:30:00Z"
+          example: '2023-01-15T10:30:00Z'
     TerraformResourcesResponse:
       type: object
       title: Terraform Resources List Response
@@ -24198,7 +24176,7 @@ components:
           type: array
           description: Array of Terraform resources
           items:
-            $ref: "#/components/schemas/TerraformResourceResponse"
+            $ref: '#/components/schemas/TerraformResourceResponse'
     TerraformResourcesRequest:
       type: object
       title: Terraform Resources Request
@@ -24227,7 +24205,7 @@ components:
           example: '[{"resource_type":"aws_instance","name":"web_server","provider":"aws","address":"aws_instance.web_server","mode":"managed","attributes":{"instance_id":"i-1234567890abcdef0","instance_type":"t2.micro"}}]'
     TerraformResponse:
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -24262,7 +24240,7 @@ components:
               x-stoplight:
                 id: abfhjb6q74upq
               oneOf:
-                - $ref: "#/components/schemas/TerraformFilesSource"
+                - $ref: '#/components/schemas/TerraformFilesSource'
             icon_uri:
               type: string
               format: uri
@@ -24270,19 +24248,19 @@ components:
               x-stoplight:
                 id: i2pvbugqsldhe
             service_type:
-              $ref: "#/components/schemas/ServiceTypeEnum"
+              $ref: '#/components/schemas/ServiceTypeEnum'
             terraform_variables_source:
-              $ref: "#/components/schemas/TerraformVariablesSourceResponse"
+              $ref: '#/components/schemas/TerraformVariablesSourceResponse'
             engine:
-              $ref: "#/components/schemas/TerraformEngineEnum"
+              $ref: '#/components/schemas/TerraformEngineEnum'
             backend:
-              $ref: "#/components/schemas/TerraformBackend"
+              $ref: '#/components/schemas/TerraformBackend'
             provider_version:
-              $ref: "#/components/schemas/TerraformProviderVersion"
+              $ref: '#/components/schemas/TerraformProviderVersion'
             job_resources:
-              $ref: "#/components/schemas/TerraformJobResourcesResponse"
+              $ref: '#/components/schemas/TerraformJobResourcesResponse'
             environment:
-              $ref: "#/components/schemas/ReferenceObject"
+              $ref: '#/components/schemas/ReferenceObject'
             use_cluster_credentials:
               type: boolean
               x-stoplight:
@@ -24310,13 +24288,13 @@ components:
                 Custom Dockerfile fragment to inject during build.
                 When null, no custom fragment is injected.
               oneOf:
-                - $ref: "#/components/schemas/DockerfileFragmentFile"
-                - $ref: "#/components/schemas/DockerfileFragmentInline"
+                - $ref: '#/components/schemas/DockerfileFragmentFile'
+                - $ref: '#/components/schemas/DockerfileFragmentInline'
               discriminator:
                 propertyName: type
                 mapping:
-                  file: "#/components/schemas/DockerfileFragmentFile"
-                  inline: "#/components/schemas/DockerfileFragmentInline"
+                  file: '#/components/schemas/DockerfileFragmentFile'
+                  inline: '#/components/schemas/DockerfileFragmentInline'
       description: A Terraform service
     TerraformRequestJobResources:
       title: TerraformRequestJobResources
@@ -24370,7 +24348,7 @@ components:
         - git_repository
       properties:
         git_repository:
-          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
     TerraformVariablesSourceRequest:
       title: TerraformVariablesSourceRequest
       x-stoplight:
@@ -24391,7 +24369,7 @@ components:
         tf_vars:
           type: array
           items:
-            $ref: "#/components/schemas/TerraformVarKeyValue"
+            $ref: '#/components/schemas/TerraformVarKeyValue'
     TerraformVarKeyValue:
       title: TerraformVarKeyValue
       type: object
@@ -24427,18 +24405,18 @@ components:
         nullable:
           type: boolean
           default: true
-          description: "Whether the variable accepts null values. If false, the variable is required."
+          description: 'Whether the variable accepts null values. If false, the variable is required.'
         default:
           type: string
           nullable: true
-          description: "The default value of the variable, or null if no default is provided"
+          description: 'The default value of the variable, or null if no default is provided'
         source:
           type: string
           description: The path inside your git repository where the variable is defined
         description:
           type: string
           nullable: true
-          description: "The description of the variable, or null if no description is provided"
+          description: 'The description of the variable, or null if no description is provided'
     TerraformFilesSourceRequest:
       title: TerraformFilesSourceRequest
       x-stoplight:
@@ -24450,26 +24428,26 @@ components:
           x-stoplight:
             id: vtpiblf7t37xq
     TerraformAutoDeployConfig:
-      title: TerraformAutoDeployConfig
-      type: object
-      required:
-        - auto_deploy
-        - terraform_action
-      properties:
-        auto_deploy:
-          type: boolean
-        terraform_action:
-          type: string
-          description: |
-            Action to force a specific Terraform behavior on autodeploy.
-            `DEFAULT`: The action is resolved based on the deployment type:
-              - Start/Restart -> PLAN_AND_APPLY
-              - Delete -> DESTROY
-              - Pause -> PLAN_ONLY
-          enum:
-            - DEFAULT
-            - PLAN
-            - NOOP
+          title: TerraformAutoDeployConfig
+          type: object
+          required:
+            - auto_deploy
+            - terraform_action
+          properties:
+            auto_deploy:
+              type: boolean
+            terraform_action:
+              type: string
+              description: |
+                Action to force a specific Terraform behavior on autodeploy.
+                `DEFAULT`: The action is resolved based on the deployment type:
+                  - Start/Restart -> PLAN_AND_APPLY
+                  - Delete -> DESTROY
+                  - Pause -> PLAN_ONLY
+              enum:
+                - DEFAULT
+                - PLAN
+                - NOOP
     TerraformGitRepositoryRequest:
       title: TerraformGitRepositoryRequest
       x-stoplight:
@@ -24514,7 +24492,7 @@ components:
         tf_vars:
           type: array
           items:
-            $ref: "#/components/schemas/TerraformVarKeyValue"
+            $ref: '#/components/schemas/TerraformVarKeyValue'
     TfVarsListRequest:
       title: TfVarsListRequest
       type: object
@@ -24524,20 +24502,20 @@ components:
         - mode
       properties:
         git_repository:
-          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
+          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
         mode:
-          $ref: "#/components/schemas/TfVarsDiscoveryMode"
+          $ref: '#/components/schemas/TfVarsDiscoveryMode'
     TfVarsDiscoveryMode:
       title: TfVarsDiscoveryMode
       description: Discovery mode for Terraform tfvars files - either auto-discover or specify paths
       oneOf:
-        - $ref: "#/components/schemas/TfVarsDiscoveryModeAutoDiscover"
-        - $ref: "#/components/schemas/TfVarsDiscoveryModeSpecificPaths"
+        - $ref: '#/components/schemas/TfVarsDiscoveryModeAutoDiscover'
+        - $ref: '#/components/schemas/TfVarsDiscoveryModeSpecificPaths'
       discriminator:
         propertyName: type
         mapping:
-          AutoDiscover: "#/components/schemas/TfVarsDiscoveryModeAutoDiscover"
-          SpecificPaths: "#/components/schemas/TfVarsDiscoveryModeSpecificPaths"
+          AutoDiscover: '#/components/schemas/TfVarsDiscoveryModeAutoDiscover'
+          SpecificPaths: '#/components/schemas/TfVarsDiscoveryModeSpecificPaths'
     TfVarsDiscoveryModeAutoDiscover:
       title: TfVarsDiscoveryModeAutoDiscover
       type: object
@@ -24666,7 +24644,7 @@ components:
           x-stoplight:
             id: mkzx2zfzysbnp
           items:
-            $ref: "#/components/schemas/TerraformResponse"
+            $ref: '#/components/schemas/TerraformResponse'
     TerraformVersionResponse:
       type: object
       required:
@@ -24674,7 +24652,7 @@ components:
         - version
       properties:
         engine:
-          $ref: "#/components/schemas/TerraformEngineEnum"
+          $ref: '#/components/schemas/TerraformEngineEnum'
         version:
           type: string
           description: Terraform version string
@@ -24684,7 +24662,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/TerraformVersionResponse"
+            $ref: '#/components/schemas/TerraformVersionResponse'
     TerraformAdvancedSettings:
       title: TerraformAdvancedSettings
       x-stoplight:
@@ -24748,21 +24726,21 @@ components:
         - value
       properties:
         mode:
-          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
         type:
-          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
+          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
         value:
           type: string
           x-stoplight:
             id: hsk8w0ydpuwm4
-          description: "‘For `PATH` restrictions, the value must not start with `/`’"
+          description: '‘For `PATH` restrictions, the value must not start with `/`’'
     TerraformDeploymentRestrictionResponse:
       title: TerraformDeploymentRestrictionResponse
       x-stoplight:
         id: 9t9zdouc9tao0
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/TerraformDeploymentRestrictionRequest"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/TerraformDeploymentRestrictionRequest'
     TerraformDeploymentRestrictionResponseList:
       title: TerraformDeploymentRestrictionResponseList
       x-stoplight:
@@ -24774,7 +24752,7 @@ components:
             id: iu0k7b7tkayre
           type: array
           items:
-            $ref: "#/components/schemas/TerraformDeploymentRestrictionResponse"
+            $ref: '#/components/schemas/TerraformDeploymentRestrictionResponse'
     OrganizationCrendentialsResponseList:
       title: OrganizationCrendentialsResponseList
       x-stoplight:
@@ -24791,13 +24769,13 @@ components:
             type: object
             properties:
               credential:
-                $ref: "#/components/schemas/ClusterCredentials"
+                $ref: '#/components/schemas/ClusterCredentials'
               clusters:
                 type: array
                 x-stoplight:
                   id: 7o7dzkbyt78bu
                 items:
-                  $ref: "#/components/schemas/CredentialCluster"
+                  $ref: '#/components/schemas/CredentialCluster'
     CredentialCluster:
       title: CredentialCluster
       x-stoplight:
@@ -24814,7 +24792,7 @@ components:
           x-stoplight:
             id: skztj7io7an31
         cloud_provider:
-          $ref: "#/components/schemas/CloudProviderEnum"
+          $ref: '#/components/schemas/CloudProviderEnum'
     TerraformFilesSource:
       title: TerraformFilesSource
       x-stoplight:
@@ -24827,7 +24805,7 @@ components:
           type: object
           properties:
             git_repository:
-              $ref: "#/components/schemas/ApplicationGitRepository"
+              $ref: '#/components/schemas/ApplicationGitRepository'
     ClusterLogsResponse:
       title: ClusterLogsResponse
       x-stoplight:
@@ -24842,13 +24820,13 @@ components:
       type: object
       properties:
         nginx_parameters:
-          $ref: "#/components/schemas/ClusterInfrastructureNginxChartParameters"
+          $ref: '#/components/schemas/ClusterInfrastructureNginxChartParameters'
         cert_manager_parameters:
-          $ref: "#/components/schemas/ClusterInfrastructureCertManagerChartParameters"
+          $ref: '#/components/schemas/ClusterInfrastructureCertManagerChartParameters'
         metal_lb_parameters:
-          $ref: "#/components/schemas/ClusterInfrastructureMetalLbChartParameters"
+          $ref: '#/components/schemas/ClusterInfrastructureMetalLbChartParameters'
         eks_anywhere_parameters:
-          $ref: "#/components/schemas/ClusterInfrastructureEksAnywhereParameters"
+          $ref: '#/components/schemas/ClusterInfrastructureEksAnywhereParameters'
     ClusterInfrastructureEksAnywhereParameters:
       type: object
       required:
@@ -24856,7 +24834,7 @@ components:
         - yaml_file_path
       properties:
         git_repository:
-          $ref: "#/components/schemas/ClusterEksAnywhereGitRepository"
+          $ref: '#/components/schemas/ClusterEksAnywhereGitRepository'
         yaml_file_path:
           type: string
           description: Path to the EKS Anywhere cluster YAML file in the git repository
@@ -24871,7 +24849,7 @@ components:
           type: string
           format: uri
           description: EKS Anywhere git repository URL
-          example: "https://github.com/Qovery/eks-anywhere-config.git"
+          example: 'https://github.com/Qovery/eks-anywhere-config.git'
         branch:
           type: string
           description: |
@@ -24883,7 +24861,7 @@ components:
           format: uuid
           description: Qovery git token id used to access the repository
         provider:
-          $ref: "#/components/schemas/GitProviderEnum"
+          $ref: '#/components/schemas/GitProviderEnum'
     ClusterInfrastructureNginxChartParameters:
       title: ClusterInfrastructureNginxChartParameters
       x-stoplight:
@@ -24942,7 +24920,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/EnterpriseConnectionDto"
+            $ref: '#/components/schemas/EnterpriseConnectionDto'
     EnterpriseConnectionDto:
       title: EnterpriseConnectionDto
       type: object
@@ -24988,13 +24966,13 @@ components:
         id: q1oj36zhkhmvp
       x-internal: false
       oneOf:
-        - $ref: "#/components/schemas/SlackAlertReceiverCreationRequest"
-        - $ref: "#/components/schemas/EmailAlertReceiverCreationRequest"
+        - $ref: '#/components/schemas/SlackAlertReceiverCreationRequest'
+        - $ref: '#/components/schemas/EmailAlertReceiverCreationRequest'
       discriminator:
         propertyName: type
         mapping:
-          SLACK: "#/components/schemas/SlackAlertReceiverCreationRequest"
-          EMAIL: "#/components/schemas/EmailAlertReceiverCreationRequest"
+          SLACK: '#/components/schemas/SlackAlertReceiverCreationRequest'
+          EMAIL: '#/components/schemas/EmailAlertReceiverCreationRequest'
     AlertReceiverCreationRequestBase:
       title: AlertReceiverCreationRequestBase
       type: object
@@ -25019,7 +24997,7 @@ components:
           x-stoplight:
             id: lrlxf8a34veta
         type:
-          $ref: "#/components/schemas/AlertReceiverType"
+          $ref: '#/components/schemas/AlertReceiverType'
         send_resolved:
           type: boolean
           x-stoplight:
@@ -25035,7 +25013,7 @@ components:
       x-stoplight:
         id: awuv9zidg4qxx
       allOf:
-        - $ref: "#/components/schemas/AlertReceiverCreationRequestBase"
+        - $ref: '#/components/schemas/AlertReceiverCreationRequestBase'
         - type: object
           required:
             - webhook_url
@@ -25048,7 +25026,7 @@ components:
     EmailAlertReceiverCreationRequest:
       title: EmailAlertReceiverCreationRequest
       allOf:
-        - $ref: "#/components/schemas/AlertReceiverCreationRequestBase"
+        - $ref: '#/components/schemas/AlertReceiverCreationRequestBase'
         - type: object
           required:
             - to
@@ -25067,8 +25045,8 @@ components:
               description: Sender email address
             smarthost:
               type: string
-              description: "SMTP server in format 'host:port'"
-              example: "smtp.example.com:587"
+              description: 'SMTP server in format ''host:port'''
+              example: 'smtp.example.com:587'
             auth_username:
               type: string
               nullable: true
@@ -25092,13 +25070,13 @@ components:
       x-stoplight:
         id: y2od6vkbmt7yr
       oneOf:
-        - $ref: "#/components/schemas/SlackAlertReceiverEditRequest"
-        - $ref: "#/components/schemas/EmailAlertReceiverEditRequest"
+        - $ref: '#/components/schemas/SlackAlertReceiverEditRequest'
+        - $ref: '#/components/schemas/EmailAlertReceiverEditRequest'
       discriminator:
         propertyName: type
         mapping:
-          SLACK: "#/components/schemas/SlackAlertReceiverEditRequest"
-          EMAIL: "#/components/schemas/EmailAlertReceiverEditRequest"
+          SLACK: '#/components/schemas/SlackAlertReceiverEditRequest'
+          EMAIL: '#/components/schemas/EmailAlertReceiverEditRequest'
     AlertReceiverEditRequestBase:
       title: AlertReceiverEditRequestBase
       type: object
@@ -25117,7 +25095,7 @@ components:
           x-stoplight:
             id: 0l6xifjl3s4e2
         type:
-          $ref: "#/components/schemas/AlertReceiverType"
+          $ref: '#/components/schemas/AlertReceiverType'
         send_resolved:
           type: boolean
           x-stoplight:
@@ -25133,20 +25111,20 @@ components:
       x-stoplight:
         id: hcxf6sxx1jrv9
       allOf:
-        - $ref: "#/components/schemas/AlertReceiverEditRequestBase"
+        - $ref: '#/components/schemas/AlertReceiverEditRequestBase'
         - type: object
           properties:
             webhook_url:
               type: string
               format: uri
               nullable: true
-              description: "Update webhook URL. If null, keeps existing value."
+              description: 'Update webhook URL. If null, keeps existing value.'
               x-stoplight:
                 id: 8c5ze7hwv90q2
     EmailAlertReceiverEditRequest:
       title: EmailAlertReceiverEditRequest
       allOf:
-        - $ref: "#/components/schemas/AlertReceiverEditRequestBase"
+        - $ref: '#/components/schemas/AlertReceiverEditRequestBase'
         - type: object
           required:
             - to
@@ -25162,7 +25140,7 @@ components:
               format: email
             smarthost:
               type: string
-              description: "SMTP server in format 'host:port'"
+              description: 'SMTP server in format ''host:port'''
             auth_username:
               type: string
               nullable: true
@@ -25170,7 +25148,7 @@ components:
               type: string
               format: password
               nullable: true
-              description: "SMTP password. If null, keeps existing password."
+              description: 'SMTP password. If null, keeps existing password.'
             require_tls:
               type: boolean
     AlertReceiverResponse:
@@ -25178,17 +25156,17 @@ components:
       x-stoplight:
         id: qyrx61cvx84cz
       oneOf:
-        - $ref: "#/components/schemas/SlackAlertReceiverResponse"
-        - $ref: "#/components/schemas/EmailAlertReceiverResponse"
+        - $ref: '#/components/schemas/SlackAlertReceiverResponse'
+        - $ref: '#/components/schemas/EmailAlertReceiverResponse'
       discriminator:
         propertyName: type
         mapping:
-          SLACK: "#/components/schemas/SlackAlertReceiverResponse"
-          EMAIL: "#/components/schemas/EmailAlertReceiverResponse"
+          SLACK: '#/components/schemas/SlackAlertReceiverResponse'
+          EMAIL: '#/components/schemas/EmailAlertReceiverResponse'
     SlackAlertReceiverResponse:
       title: SlackAlertReceiverResponse
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -25205,7 +25183,7 @@ components:
               x-stoplight:
                 id: aja5apvg882lo
             type:
-              $ref: "#/components/schemas/AlertReceiverType"
+              $ref: '#/components/schemas/AlertReceiverType'
             send_resolved:
               type: boolean
               x-stoplight:
@@ -25219,7 +25197,7 @@ components:
     EmailAlertReceiverResponse:
       title: EmailAlertReceiverResponse
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           required:
             - name
@@ -25237,7 +25215,7 @@ components:
             description:
               type: string
             type:
-              $ref: "#/components/schemas/AlertReceiverType"
+              $ref: '#/components/schemas/AlertReceiverType'
             send_resolved:
               type: boolean
             to:
@@ -25272,7 +25250,7 @@ components:
             id: e8a6xqrax75d5
           type: array
           items:
-            $ref: "#/components/schemas/AlertReceiverResponse"
+            $ref: '#/components/schemas/AlertReceiverResponse'
     AlertPresentation:
       title: AlertPresentation
       x-stoplight:
@@ -25321,7 +25299,7 @@ components:
           x-stoplight:
             id: luojx47y8mgl1
           format: uuid
-          description: " Cluster identifier where the rule will be deployed"
+          description: ' Cluster identifier where the rule will be deployed'
         name:
           type: string
           x-stoplight:
@@ -25338,7 +25316,7 @@ components:
           x-stoplight:
             id: eaisshdmo1xgi
         condition:
-          $ref: "#/components/schemas/AlertRuleCondition"
+          $ref: '#/components/schemas/AlertRuleCondition'
         for_duration:
           type: string
           x-stoplight:
@@ -25346,9 +25324,9 @@ components:
           description: Duration the condition must be true before firing (ISO-8601 duration format)
           format: duration
         severity:
-          $ref: "#/components/schemas/AlertSeverity"
+          $ref: '#/components/schemas/AlertSeverity'
         presentation:
-          $ref: "#/components/schemas/AlertPresentation"
+          $ref: '#/components/schemas/AlertPresentation'
         enabled:
           type: boolean
           x-stoplight:
@@ -25366,7 +25344,7 @@ components:
             type: string
             format: uuid
         target:
-          $ref: "#/components/schemas/AlertTarget"
+          $ref: '#/components/schemas/AlertTarget'
     AlertSeverity:
       title: AlertSeverity
       x-stoplight:
@@ -25413,7 +25391,7 @@ components:
           x-stoplight:
             id: p754eq1nh7gqp
         condition:
-          $ref: "#/components/schemas/AlertRuleCondition"
+          $ref: '#/components/schemas/AlertRuleCondition'
         for_duration:
           type: string
           x-stoplight:
@@ -25421,7 +25399,7 @@ components:
           format: duration
           description: Duration the condition must be true before firing (ISO-8601 duration format)
         severity:
-          $ref: "#/components/schemas/AlertSeverity"
+          $ref: '#/components/schemas/AlertSeverity'
         enabled:
           type: boolean
           x-stoplight:
@@ -25439,7 +25417,7 @@ components:
             type: string
             format: uuid
         presentation:
-          $ref: "#/components/schemas/AlertPresentation"
+          $ref: '#/components/schemas/AlertPresentation'
     AlertPresentationResponse:
       title: AlertPresentationResponse
       x-stoplight:
@@ -25450,7 +25428,7 @@ components:
           type: string
           x-stoplight:
             id: z5t89ub093022
-          description: " Alert summary template"
+          description: ' Alert summary template'
           nullable: true
         runbook_url:
           type: string
@@ -25482,26 +25460,26 @@ components:
         - state
       properties:
         source:
-          $ref: "#/components/schemas/AlertRuleSource"
+          $ref: '#/components/schemas/AlertRuleSource'
         name:
           type: string
           x-stoplight:
             id: base_name_prop
           description: Name of the alert rule
         state:
-          $ref: "#/components/schemas/AlertRuleState"
+          $ref: '#/components/schemas/AlertRuleState'
       discriminator:
         propertyName: source
         mapping:
-          MANAGED: "#/components/schemas/AlertRuleResponse"
-          GHOST: "#/components/schemas/GhostAlertRuleResponse"
+          MANAGED: '#/components/schemas/AlertRuleResponse'
+          GHOST: '#/components/schemas/GhostAlertRuleResponse'
     AlertRuleResponse:
       title: AlertRuleResponse
       x-stoplight:
         id: jsi9jy70651hv
       allOf:
-        - $ref: "#/components/schemas/Base"
-        - $ref: "#/components/schemas/AlertRuleResponseBase"
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/AlertRuleResponseBase'
         - type: object
           required:
             - organization_id
@@ -25527,7 +25505,7 @@ components:
               type: string
               x-stoplight:
                 id: nd3oz9h1qpa6w
-              description: " Cluster identifier"
+              description: ' Cluster identifier'
               format: uuid
             description:
               type: string
@@ -25539,7 +25517,7 @@ components:
               x-stoplight:
                 id: kloew25gqdxqt
             condition:
-              $ref: "#/components/schemas/AlertRuleCondition"
+              $ref: '#/components/schemas/AlertRuleCondition'
             for_duration:
               type: string
               x-stoplight:
@@ -25547,7 +25525,7 @@ components:
               format: duration
               description: Duration the condition must be true before firing (ISO-8601 duration format)
             severity:
-              $ref: "#/components/schemas/AlertSeverity"
+              $ref: '#/components/schemas/AlertSeverity'
             enabled:
               type: boolean
               x-stoplight:
@@ -25564,9 +25542,9 @@ components:
                 type: string
                 format: uuid
             presentation:
-              $ref: "#/components/schemas/AlertPresentationResponse"
+              $ref: '#/components/schemas/AlertPresentationResponse'
             target:
-              $ref: "#/components/schemas/AlertTarget"
+              $ref: '#/components/schemas/AlertTarget'
             is_up_to_date:
               type: boolean
               x-stoplight:
@@ -25586,12 +25564,12 @@ components:
         id: ghost_alert_rule_response
       description: Response for ghost alerts that exist in Prometheus but have been deleted from the database
       allOf:
-        - $ref: "#/components/schemas/AlertRuleResponseBase"
+        - $ref: '#/components/schemas/AlertRuleResponseBase'
         - type: object
           properties:
             target:
               allOf:
-                - $ref: "#/components/schemas/AlertTarget"
+                - $ref: '#/components/schemas/AlertTarget'
                 - nullable: true
               description: May be null if target info couldn't be extracted from Prometheus
             starts_at:
@@ -25606,7 +25584,7 @@ components:
       x-stoplight:
         id: y45ivkwhr7wb4
       enum:
-        - " CLUSTER"
+        - ' CLUSTER'
         - ENVIRONMENT
         - APPLICATION
         - CONTAINER
@@ -25625,15 +25603,15 @@ components:
         - target_id
       properties:
         target_type:
-          $ref: "#/components/schemas/AlertTargetType"
+          $ref: '#/components/schemas/AlertTargetType'
         target_id:
           type: string
           x-stoplight:
             id: 8begp36fsknxq
           format: uuid
         service:
-          $ref: "#/components/schemas/ServiceLightResponse"
-          description: "Service details when target_type is APPLICATION, CONTAINER, JOB, CRONJOB, HELM or TERRAFORM"
+          $ref: '#/components/schemas/ServiceLightResponse'
+          description: 'Service details when target_type is APPLICATION, CONTAINER, JOB, CRONJOB, HELM or TERRAFORM'
     AlertRuleState:
       title: AlertRuleState
       x-stoplight:
@@ -25660,13 +25638,13 @@ components:
             id: nsk4tfkil7yuf
           items:
             oneOf:
-              - $ref: "#/components/schemas/AlertRuleResponse"
-              - $ref: "#/components/schemas/GhostAlertRuleResponse"
+              - $ref: '#/components/schemas/AlertRuleResponse'
+              - $ref: '#/components/schemas/GhostAlertRuleResponse'
             discriminator:
               propertyName: source
               mapping:
-                MANAGED: "#/components/schemas/AlertRuleResponse"
-                GHOST: "#/components/schemas/GhostAlertRuleResponse"
+                MANAGED: '#/components/schemas/AlertRuleResponse'
+                GHOST: '#/components/schemas/GhostAlertRuleResponse'
     ObservabilityResourceProfile:
       title: ObservabilityResourceProfile
       x-stoplight:
@@ -25742,15 +25720,15 @@ components:
         - promql
       properties:
         kind:
-          $ref: "#/components/schemas/AlertRuleConditionKind"
+          $ref: '#/components/schemas/AlertRuleConditionKind'
         operator:
-          $ref: "#/components/schemas/AlertRuleConditionOperator"
+          $ref: '#/components/schemas/AlertRuleConditionOperator'
         threshold:
           type: number
           x-stoplight:
             id: ua0w1t89vrl0b
         function:
-          $ref: "#/components/schemas/AlertRuleConditionFunction"
+          $ref: '#/components/schemas/AlertRuleConditionFunction'
         promql:
           type: string
           x-stoplight:
@@ -25803,7 +25781,7 @@ components:
         - alert_receiver
       properties:
         alert_receiver:
-          $ref: "#/components/schemas/AlertReceiverCreationRequest"
+          $ref: '#/components/schemas/AlertReceiverCreationRequest'
         message:
           type: string
           x-stoplight:
@@ -25825,11 +25803,11 @@ components:
       x-stoplight:
         id: ylgyx3ozik2hf
       oneOf:
-        - $ref: "#/components/schemas/KedaAutoscalingRequest"
+        - $ref: '#/components/schemas/KedaAutoscalingRequest'
       discriminator:
         propertyName: mode
         mapping:
-          KEDA: "#/components/schemas/KedaAutoscalingRequest"
+          KEDA: '#/components/schemas/KedaAutoscalingRequest'
     AutoscalingMode:
       title: AutoscalingMode
       x-stoplight:
@@ -25847,7 +25825,7 @@ components:
         - scalers
       properties:
         mode:
-          $ref: "#/components/schemas/AutoscalingMode"
+          $ref: '#/components/schemas/AutoscalingMode'
         polling_interval_seconds:
           type: integer
           x-stoplight:
@@ -25864,7 +25842,7 @@ components:
             id: 6oh134v1tqb28
           minItems: 1
           items:
-            $ref: "#/components/schemas/KedaScalerRequest"
+            $ref: '#/components/schemas/KedaScalerRequest'
     KedaScalerRole:
       title: KedaScalerRole
       x-stoplight:
@@ -25878,7 +25856,7 @@ components:
       x-stoplight:
         id: dgcb902szizvv
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           x-stoplight:
             id: zjlwqohiiyuwf
@@ -25895,7 +25873,7 @@ components:
                 id: j9bxhtiyyl0iv
               format: uuid
             mode:
-              $ref: "#/components/schemas/AutoscalingMode"
+              $ref: '#/components/schemas/AutoscalingMode'
             polling_interval_seconds:
               type: integer
               x-stoplight:
@@ -25912,8 +25890,8 @@ components:
                 id: oyhxgvwg36ixz
               minItems: 1
               items:
-                $ref: "#/components/schemas/KedaScalerResponse"
-      description: ""
+                $ref: '#/components/schemas/KedaScalerResponse'
+      description: ''
     KedaTriggerAuthenticationRequest:
       title: KedaTriggerAuthenticationRequest
       x-stoplight:
@@ -25936,7 +25914,7 @@ components:
       x-stoplight:
         id: 7mm4a4sk9jhz3
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           x-stoplight:
             id: ssejnexbsra11
@@ -25956,7 +25934,7 @@ components:
               type: string
               x-stoplight:
                 id: r5lmrzakyk9o6
-              description: " Optional raw KEDA TriggerAuthentication YAML configuration."
+              description: ' Optional raw KEDA TriggerAuthentication YAML configuration.'
     KedaTriggerAuthenticationResponseList:
       title: KedaTriggerAuthenticationResponseList
       x-stoplight:
@@ -25968,7 +25946,7 @@ components:
           x-stoplight:
             id: md92njfinutyy
           items:
-            $ref: "#/components/schemas/KedaTriggerAuthenticationResponse"
+            $ref: '#/components/schemas/KedaTriggerAuthenticationResponse'
     KedaScalerRequest:
       title: KedaScalerRequest
       x-stoplight:
@@ -25987,7 +25965,7 @@ components:
           x-stoplight:
             id: 9m67trg9m0ioz
         role:
-          $ref: "#/components/schemas/KedaScalerRole"
+          $ref: '#/components/schemas/KedaScalerRole'
         config_json:
           type: object
           x-stoplight:
@@ -25997,13 +25975,13 @@ components:
           x-stoplight:
             id: 8c7vktd7svl30
         trigger_authentication:
-          $ref: "#/components/schemas/KedaTriggerAuthenticationRequest"
+          $ref: '#/components/schemas/KedaTriggerAuthenticationRequest'
     KedaScalerResponse:
       title: KedaScalerResponse
       x-stoplight:
         id: gaaqg32ivl48h
       allOf:
-        - $ref: "#/components/schemas/Base"
+        - $ref: '#/components/schemas/Base'
         - type: object
           x-stoplight:
             id: 74tt3hgf95nfe
@@ -26021,7 +25999,7 @@ components:
               x-stoplight:
                 id: 0dnjwnlkuj3kp
             role:
-              $ref: "#/components/schemas/KedaScalerRole"
+              $ref: '#/components/schemas/KedaScalerRole'
             config_json:
               type: object
               nullable: true
@@ -26029,17 +26007,17 @@ components:
               type: string
               nullable: true
             trigger_authentication:
-              $ref: "#/components/schemas/KedaTriggerAuthenticationResponse"
+              $ref: '#/components/schemas/KedaTriggerAuthenticationResponse'
     AutoscalingPolicyResponse:
       title: AutoscalingPolicyResponse
       x-stoplight:
         id: mjawsx6obi237
       oneOf:
-        - $ref: "#/components/schemas/KedaAutoscalingResponse"
+        - $ref: '#/components/schemas/KedaAutoscalingResponse'
       discriminator:
         propertyName: mode
         mapping:
-          KEDA: "#/components/schemas/KedaAutoscalingResponse"
+          KEDA: '#/components/schemas/KedaAutoscalingResponse'
     ClusterLabelsGroup:
       title: ClusterLabelsGroup
       x-stoplight:
@@ -26057,17 +26035,17 @@ components:
         id: imn8c9l4fab56
       type: array
       items:
-        $ref: "#/components/schemas/ClusterLabelsGroup"
+        $ref: '#/components/schemas/ClusterLabelsGroup'
   responses:
-    "204":
+    '204':
       description: no content
-    "400":
+    '400':
       description: Bad request
-    "401":
+    '401':
       description: Access token is missing or invalid
-    "403":
+    '403':
       description: Access forbidden
-    "404":
+    '404':
       description: Resource not found
     204-deletion:
       description: The resource was deleted successfully

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -7,10 +7,10 @@ info:
     - ℹ️ The API is stable and still in development.
   contact:
     name: Qovery Product Team
-    url: 'https://www.qovery.com'
+    url: "https://www.qovery.com"
     email: support+api+documentation@qovery.com
   x-logo:
-    url: 'https://console.qovery.com/assets/logos/logo-white.svg'
+    url: "https://console.qovery.com/assets/logos/logo-white.svg"
     altText: Qovery
 tags:
   - name: Account
@@ -258,7 +258,7 @@ x-tagGroups:
       - Alert Receivers
       - Alert Rules
 servers:
-  - url: 'https://api.qovery.com'
+  - url: "https://api.qovery.com"
 paths:
   /organization:
     get:
@@ -267,18 +267,18 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: List organizations
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an organization
       operationId: createOrganization
@@ -288,151 +288,151 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationRequest'
+              $ref: "#/components/schemas/OrganizationRequest"
       responses:
-        '201':
+        "201":
           description: Create organization
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Organization name is already taken
-  '/organization/{organizationId}':
+  "/organization/{organizationId}":
     get:
       summary: Get organization by ID
       operationId: getOrganization
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Get organization by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/Organization"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an organization
       description: To edit an organization you must have the admin permission.
       operationId: editOrganization
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationEditRequest'
+              $ref: "#/components/schemas/OrganizationEditRequest"
       responses:
-        '200':
+        "200":
           description: Edit an organization
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Organization name is already taken
     delete:
       summary: Delete an organization
       description: To delete an organization you must have the admin permission
       operationId: deleteOrganization
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/apiToken':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/apiToken":
     get:
       summary: List organization api tokens
       description: List organization api tokens
       operationId: listOrganizationApiTokens
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Api Token
       responses:
-        '200':
+        "200":
           description: List organization api tokens
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationApiTokenResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationApiTokenResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an organization api token
       description: Create an organization api token. You can use the generated token to interact in a programmatic way with our API.
       operationId: createOrganizationApiToken
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Api Token
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationApiTokenCreateRequest'
+              $ref: "#/components/schemas/OrganizationApiTokenCreateRequest"
       responses:
-        '201':
+        "201":
           description: Organization api token created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationApiTokenCreate'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/OrganizationApiTokenCreate"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Organization Api Token name is already taken
-  '/organization/{organizationId}/apiToken/{apiTokenId}':
+  "/organization/{organizationId}/apiToken/{apiTokenId}":
     delete:
       summary: Delete organization api token
       description: Delete organization api token
       operationId: deleteOrganizationApiToken
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - name: apiTokenId
           in: path
           description: Organization Api Token ID
@@ -443,176 +443,176 @@ paths:
       tags:
         - Organization Api Token
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/availableRole':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/availableRole":
     get:
       summary: List organization available roles
       description: List organization available roles
       operationId: listOrganizationAvailableRoles
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: List organization available roles
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationAvailableRoleList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/gitToken':
+                $ref: "#/components/schemas/OrganizationAvailableRoleList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/gitToken":
     get:
       summary: List organization git tokens
       description: List organization git tokens
       operationId: listOrganizationGitTokens
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: List organization git tokens
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitTokenResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/GitTokenResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a git token
       description: Create a new git token to be used as a git provider by a service
       operationId: createGitToken
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GitTokenRequest'
+              $ref: "#/components/schemas/GitTokenRequest"
       responses:
-        '201':
+        "201":
           description: Git token created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitTokenResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/gitToken/{gitTokenId}':
+                $ref: "#/components/schemas/GitTokenResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/gitToken/{gitTokenId}":
     get:
       summary: Get organization git token
       description: Get organization git token
       operationId: getOrganizationGitToken
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/gitTokenId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/gitTokenId"
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Get organization git token
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitTokenResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/GitTokenResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a git token
       operationId: editGitToken
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/gitTokenId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/gitTokenId"
       tags:
         - Organization Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GitTokenRequest'
+              $ref: "#/components/schemas/GitTokenRequest"
       responses:
-        '200':
+        "200":
           description: Git token edited
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitTokenResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/GitTokenResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a git token
       operationId: deleteGitToken
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/gitTokenId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/gitTokenId"
       tags:
         - Organization Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/gitToken/{gitTokenId}/associatedServices':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/gitToken/{gitTokenId}/associatedServices":
     get:
       summary: Get organization git token associated services
       description: Get organization git tokens associated services
       operationId: getGitTokenAssociatedServices
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/gitTokenId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/gitTokenId"
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Get organization git token associated services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitTokenAssociatedServicesResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/listDirectoriesFromGitRepository':
+                $ref: "#/components/schemas/GitTokenAssociatedServicesResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/listDirectoriesFromGitRepository":
     post:
       summary: List directories from a git repository
       description: |
@@ -621,16 +621,16 @@ paths:
         and select the appropriate root path.
       operationId: listDirectoriesFromGitRepository
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Git repositories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+              $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
       responses:
-        '200':
+        "200":
           description: List of directories at the specified path
           content:
             application/json:
@@ -645,64 +645,64 @@ paths:
                       - infra
                       - terraform
                       - .github
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/member':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/member":
     get:
       summary: Get organization members
       operationId: getOrganizationMembers
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Members
       responses:
-        '200':
+        "200":
           description: Get members
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MemberResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/MemberResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an organization member role
       description: Edit an organization member role
       operationId: editOrganizationMemberRole
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Members
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MemberRoleUpdateRequest'
+              $ref: "#/components/schemas/MemberRoleUpdateRequest"
       responses:
-        '200':
+        "200":
           description: Edit an organization member role
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Remove a member
       operationId: deleteMember
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       requestBody:
         content:
           application/json:
@@ -717,226 +717,226 @@ paths:
       tags:
         - Members
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/inviteMember':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/inviteMember":
     get:
       summary: Get invited members
       operationId: getOrganizationInvitedMembers
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Members
       responses:
-        '200':
+        "200":
           description: Get invited members
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InviteMemberResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/InviteMemberResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Invite someone in the organization
       operationId: postInviteMember
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Members
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InviteMemberRequest'
+              $ref: "#/components/schemas/InviteMemberRequest"
       responses:
-        '201':
+        "201":
           description: User invited
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InviteMember'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/InviteMember"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: User already invited
-  '/organization/{organizationId}/inviteMember/{inviteId}':
+  "/organization/{organizationId}/inviteMember/{inviteId}":
     get:
       summary: Get member invitation
       operationId: getMemberInvitation
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/inviteId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/inviteId"
       tags:
         - Members
       responses:
-        '200':
+        "200":
           description: Get member invitation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InviteMember'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/InviteMember"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Accept Invite in the organization
       operationId: postAcceptInviteMember
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/inviteId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/inviteId"
       tags:
         - Members
       responses:
-        '201':
+        "201":
           description: User invited
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InviteMember'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/InviteMember"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: User already invited
     delete:
       summary: Remove an invited member
       operationId: deleteInviteMember
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/inviteId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/inviteId"
       tags:
         - Members
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/transferOwnership':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/transferOwnership":
     post:
       summary: Transfer organization ownership to another user
       operationId: postOrganizationTransferOwnership
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Members
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransferOwnershipRequest'
+              $ref: "#/components/schemas/TransferOwnershipRequest"
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/currentCost':
+        "204":
+          $ref: "#/components/responses/204"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/currentCost":
     get:
       summary: Get organization current cost
       operationId: getOrganizationCurrentCost
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get Cost
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationCurrentCost'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/creditCode':
+                $ref: "#/components/schemas/OrganizationCurrentCost"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/creditCode":
     post:
       summary: Add credit code
       operationId: addCreditCode
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationCreditCodeRequest'
+              $ref: "#/components/schemas/OrganizationCreditCodeRequest"
       responses:
-        '200':
+        "200":
           description: add credit code
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/changePlan':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/changePlan":
     post:
       summary: Change organization plan
       operationId: changePlan
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationChangePlanRequest'
+              $ref: "#/components/schemas/OrganizationChangePlanRequest"
       responses:
-        '200':
+        "200":
           description: plan has been successfully changed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/currentCost':
+                $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/currentCost":
     get:
       summary: Get cluster current cost
       operationId: getClusterCurrentCost
@@ -944,72 +944,72 @@ paths:
         Get your cluster cost range. We are unable to give a precise cost of your infrastructure at the moment.
         But Qovery guarantees that the cost of your cluster will not exceed the max range.
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get cluster cost
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CostRange'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/billingInfo':
+                $ref: "#/components/schemas/CostRange"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/billingInfo":
     get:
       summary: Get organization billing info
       operationId: getOrganizationBillingInfo
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get Billing Info
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BillingInfo'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/BillingInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit Organization Billing Info
       operationId: editOrganizationBillingInfo
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BillingInfoRequest'
+              $ref: "#/components/schemas/BillingInfoRequest"
       responses:
-        '200':
+        "200":
           description: Edit billing info
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BillingInfo'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/billingStatus':
+                $ref: "#/components/schemas/BillingInfo"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/billingStatus":
     get:
       summary: Get organization billing status
       description: |
@@ -1019,491 +1019,491 @@ paths:
         - For Community organization, it returns false if there is no credit left
       operationId: getOrganizationBillingStatus
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get Billing Status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BillingStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/billingUsageReport':
+                $ref: "#/components/schemas/BillingStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/billingUsageReport":
     post:
       summary: Generate organization billing usage report
       operationId: generateBillingUsageReport
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationBillingUsageReportRequest'
+              $ref: "#/components/schemas/OrganizationBillingUsageReportRequest"
       responses:
-        '200':
+        "200":
           description: billing usage report has been successfully generated
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationBillingUsageReportResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/billingExternalId':
+                $ref: "#/components/schemas/OrganizationBillingUsageReportResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/billingExternalId":
     get:
       summary: Get organization billing external ID
       description: |
         This endpoint returns the external ID of the organization's billing account
       operationId: getOrganizationBillingExternalId
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get Billing External ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BillingExternalId'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/invoice':
+                $ref: "#/components/schemas/BillingExternalId"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/invoice":
     get:
       summary: List organization invoices
       operationId: listOrganizationInvoice
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: List Invoices
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvoiceResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/invoice/{invoiceId}':
+                $ref: "#/components/schemas/InvoiceResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/invoice/{invoiceId}":
     get:
       summary: Get organization invoice
       operationId: getOrganizationInvoice
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/invoiceId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/invoiceId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get Invoice
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Invoice'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/invoice/{invoiceId}/download':
+                $ref: "#/components/schemas/Invoice"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/invoice/{invoiceId}/download":
     get:
       summary: Get invoice link
       description: This will return URL of the invoice PDF
       operationId: getOrganizationInvoicePDF
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/invoiceId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/invoiceId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: Get invoice PDF
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Link'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/downloadInvoices':
+                $ref: "#/components/schemas/Link"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/downloadInvoices":
     post:
       summary: Download all invoices
       operationId: organizationDownloadAllInvoices
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '202':
+        "202":
           description: You will receive an email containing your invoices
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/creditCard':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/creditCard":
     get:
       summary: List organization credit cards
       operationId: listOrganizationCreditCards
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       responses:
-        '200':
+        "200":
           description: List cfredit cards
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreditCardResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CreditCardResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add credit card
       operationId: addCreditCard
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Billing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreditCardRequest'
+              $ref: "#/components/schemas/CreditCardRequest"
       responses:
-        '201':
+        "201":
           description: Add credit card
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreditCard'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/creditCard/{creditCardId}':
+                $ref: "#/components/schemas/CreditCard"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/creditCard/{creditCardId}":
     delete:
       summary: Delete credit card
       operationId: deleteCreditCard
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/creditCardId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/creditCardId"
       tags:
         - Billing
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/project':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/project":
     get:
       summary: List projects
       operationId: listProject
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Projects
       responses:
-        '200':
+        "200":
           description: List projects
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ProjectResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a project
       operationId: createProject
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Projects
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectRequest'
+              $ref: "#/components/schemas/ProjectRequest"
       responses:
-        '200':
+        "200":
           description: Create project
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Project'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Project name within the organization is already taken
-  '/organization/{organizationId}/project/stats':
+  "/organization/{organizationId}/project/stats":
     get:
       summary: List total number of services and environments for each project of the organization
-      description: 'Returns a list of project ids, and for each its total numberof services and environments'
+      description: "Returns a list of project ids, and for each its total numberof services and environments"
       operationId: getOrganizationProjectStats
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Projects
       responses:
-        '200':
+        "200":
           description: Get number of services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectStatsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster':
+                $ref: "#/components/schemas/ProjectStatsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster":
     get:
       summary: List organization clusters
       operationId: listOrganizationCluster
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: List clusters
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a cluster
       operationId: createCluster
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterRequest'
+              $ref: "#/components/schemas/ClusterRequest"
       responses:
-        '201':
+        "201":
           description: Create cluster
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Cluster'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/status':
+                $ref: "#/components/schemas/Cluster"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/status":
     get:
       summary: List all clusters statuses
       description: Returns a list of clusters with only their id and status.
       operationId: getOrganizationClusterStatus
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Get statuses
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}':
+                $ref: "#/components/schemas/ClusterStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}":
     delete:
       summary: Delete a cluster
       operationId: deleteCluster
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
         - in: query
           name: deleteMode
           schema:
-            $ref: '#/components/schemas/ClusterDeleteMode'
+            $ref: "#/components/schemas/ClusterDeleteMode"
       tags:
         - Clusters
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a cluster
       operationId: editCluster
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterRequest'
+              $ref: "#/components/schemas/ClusterRequest"
       responses:
-        '200':
+        "200":
           description: Edited the cluster
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Cluster'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/status':
+                $ref: "#/components/schemas/Cluster"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/status":
     get:
       summary: Get cluster status
       operationId: getClusterStatus
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/installationHelmValues':
+                $ref: "#/components/schemas/ClusterStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/installationHelmValues":
     get:
       summary: Get cluster helm values for self managed installation
       operationId: getInstallationHelmValues
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Helm values
           content:
             application/x-yaml:
               schema:
                 type: string
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/kubeconfig':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/kubeconfig":
     get:
       summary: Get cluster kubeconfig
       operationId: getClusterKubeconfig
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
         - schema:
             type: boolean
           in: query
           name: with_token_from_cli
-          description: 'If true, the user auth part will have an exec command with qovery cli'
+          description: "If true, the user auth part will have an exec command with qovery cli"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Get kubeconfig of the cluster
           content:
             application/x-yaml:
               schema:
                 type: string
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit cluster kubeconfig
       operationId: editClusterKubeconfig
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       requestBody:
@@ -1512,15 +1512,15 @@ paths:
             schema:
               type: string
       responses:
-        '204':
+        "204":
           description: edit kubeconfig of the cluster
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/advancedSettings':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/advancedSettings":
     get:
       summary: Get advanced settings
       description: |
@@ -1528,625 +1528,625 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/cluster-advanced-settings/)
       operationId: getClusterAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editClusterAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterAdvancedSettings'
+              $ref: "#/components/schemas/ClusterAdvancedSettings"
       responses:
-        '201':
+        "201":
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterAdvancedSettings'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/routingTable':
+                $ref: "#/components/schemas/ClusterAdvancedSettings"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/routingTable":
     get:
       summary: Get routing table
       description: Retrieve network routing table where each line corresponds to a route between a destination and a target.
       operationId: getRoutingTable
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Routing table
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterRoutingTable'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterRoutingTable"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit routing table
       description: Edit routing table by returning updated table.
       operationId: editRoutingTable
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterRoutingTableRequest'
+              $ref: "#/components/schemas/ClusterRoutingTableRequest"
       responses:
-        '201':
+        "201":
           description: Updated routing table
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterRoutingTable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/logs':
+                $ref: "#/components/schemas/ClusterRoutingTable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/logs":
     get:
       summary: List Cluster Logs
       description: List Cluster Logs
       operationId: listClusterLogs
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: list cluster logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterLogsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/aws/credentials':
+                $ref: "#/components/schemas/ClusterLogsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/aws/credentials":
     get:
       summary: List AWS credentials
       operationId: listAWSCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentialsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentialsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create AWS credentials set
       operationId: createAWSCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AwsCredentialsRequest'
+              $ref: "#/components/schemas/AwsCredentialsRequest"
       responses:
-        '201':
+        "201":
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/aws/credentials/{credentialsId}':
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/aws/credentials/{credentialsId}":
     get:
       summary: Get a set of AWS credentials
       operationId: getAWSCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: Get a set of AWS credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a set of AWS credentials
       operationId: editAWSCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AwsCredentialsRequest'
+              $ref: "#/components/schemas/AwsCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Edit a set of AWS credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a set of AWS credentials
       operationId: deleteAWSCredentials
       parameters:
-        - $ref: '#/components/parameters/credentialsId'
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/credentialsId"
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/onPremise/credentials':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/onPremise/credentials":
     get:
       summary: List OnPremise credentials
       operationId: listOnPremiseCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentialsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentialsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create OnPremise credentials set
       operationId: createOnPremiseCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OnPremiseCredentialsRequest'
+              $ref: "#/components/schemas/OnPremiseCredentialsRequest"
       responses:
-        '201':
+        "201":
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/onPremise/credentials/{credentialsId}':
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/onPremise/credentials/{credentialsId}":
     get:
       summary: Get a set of OnPremise credentials
       operationId: getOnPremiseCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: Get a set of OnPremise credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a set of OnPremise credentials
       operationId: editOnPremiseCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OnPremiseCredentialsRequest'
+              $ref: "#/components/schemas/OnPremiseCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Edit a set of OnPremise credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a set of OnPremise credentials
       operationId: deleteOnPremiseCredentials
       parameters:
-        - $ref: '#/components/parameters/credentialsId'
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/credentialsId"
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/scaleway/credentials':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/scaleway/credentials":
     get:
       summary: List Scaleway credentials
       operationId: listScalewayCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentialsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentialsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create Scaleway credentials set
       operationId: createScalewayCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ScalewayCredentialsRequest'
+              $ref: "#/components/schemas/ScalewayCredentialsRequest"
       responses:
-        '201':
+        "201":
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/scaleway/credentials/{credentialsId}':
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/scaleway/credentials/{credentialsId}":
     get:
       summary: Get a set of Scaleway credentials
       operationId: getScalewayCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: Get a set of Scaleway credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a set of Scaleway credentials
       operationId: editScalewayCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ScalewayCredentialsRequest'
+              $ref: "#/components/schemas/ScalewayCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Edit a set of Scaleway credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a set of Scaleway credentials
       operationId: deleteScalewayCredentials
       parameters:
-        - $ref: '#/components/parameters/credentialsId'
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/credentialsId"
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/gcp/credentials':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/gcp/credentials":
     get:
       summary: List GCP credentials
       operationId: listGcpCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentialsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentialsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create GCP credentials set
       operationId: createGcpCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GcpCredentialsRequest'
+              $ref: "#/components/schemas/GcpCredentialsRequest"
       responses:
-        '201':
+        "201":
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/gcp/credentials/{credentialsId}':
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/gcp/credentials/{credentialsId}":
     get:
       summary: Get a set of GCP credentials
       operationId: getGcpCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: Get a set of GCP credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a set of GCP credentials
       operationId: editGcpCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/credentialsId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/credentialsId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GcpCredentialsRequest'
+              $ref: "#/components/schemas/GcpCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Edit a set of GCP credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a set of GCP credentials
       operationId: deleteGcpCredentials
       parameters:
-        - $ref: '#/components/parameters/credentialsId'
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/credentialsId"
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/github/connect':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/github/connect":
     post:
       summary: Connect a github account to an organization
       operationId: organizationGithubAppConnect
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Github App
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationGithubAppConnectRequest'
+              $ref: "#/components/schemas/OrganizationGithubAppConnectRequest"
       responses:
-        '200':
+        "200":
           description: Github App connected
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/github/disconnect':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/github/disconnect":
     delete:
       summary: Disconnect a github account from an organization
       operationId: organizationGithubAppDisconnect
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: force
           schema:
@@ -2155,37 +2155,37 @@ paths:
       tags:
         - Github App
       responses:
-        '204':
+        "204":
           description: Github App disconnected
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/account/gitAuthProvider':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/account/gitAuthProvider":
     get:
       summary: Get git provider accounts
       operationId: getOrganizationGitProviderAccount
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Account Git Repositories
       responses:
-        '200':
+        "200":
           description: Get account
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitAuthProviderResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/account/github/repository':
+                $ref: "#/components/schemas/GitAuthProviderResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/account/github/repository":
     get:
       summary: Get github repositories of the connected user
       operationId: getOrganizationGithubRepositories
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: gitTokenId
           schema:
@@ -2195,22 +2195,22 @@ paths:
       tags:
         - Organization Account Git Repositories
       responses:
-        '200':
+        "200":
           description: Get github repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/account/github/repository/branch':
+                $ref: "#/components/schemas/GitRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/account/github/repository/branch":
     get:
       summary: Get github branches of the specified repository
       operationId: getOrganizationGithubRepositoryBranches
       tags:
         - Organization Account Git Repositories
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: name
           schema:
@@ -2223,20 +2223,20 @@ paths:
             format: uuid
           description: The git token id that must be used for the application
       responses:
-        '200':
+        "200":
           description: Get github repository branches
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/account/gitlab/repository':
+                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/account/gitlab/repository":
     get:
       summary: Get gitlab repositories of the connected user
       operationId: getOrganizationGitlabRepositories
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: gitTokenId
           schema:
@@ -2246,22 +2246,22 @@ paths:
       tags:
         - Organization Account Git Repositories
       responses:
-        '200':
+        "200":
           description: Get gitlab repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/account/gitlab/repository/branch':
+                $ref: "#/components/schemas/GitRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/account/gitlab/repository/branch":
     get:
       summary: Get gitlab branches of the specified repository
       operationId: getOrganizationGitlabRepositoryBranches
       tags:
         - Organization Account Git Repositories
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: name
           schema:
@@ -2274,20 +2274,20 @@ paths:
             format: uuid
           description: The git token id that must be used for the application
       responses:
-        '200':
+        "200":
           description: Get gitlab repository branches
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/account/bitbucket/repository':
+                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/account/bitbucket/repository":
     get:
       summary: Get bitbucket repositories of the connected user
       operationId: getOrganizationBitbucketRepositories
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: gitTokenId
           schema:
@@ -2297,22 +2297,22 @@ paths:
       tags:
         - Organization Account Git Repositories
       responses:
-        '200':
+        "200":
           description: Get bitbucket repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/account/bitbucket/repository/branch':
+                $ref: "#/components/schemas/GitRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/account/bitbucket/repository/branch":
     get:
       summary: Get bitbucket branches of the specified repository
       operationId: getOrganizationBitbucketRepositoryBranches
       tags:
         - Organization Account Git Repositories
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: name
           schema:
@@ -2325,282 +2325,282 @@ paths:
             format: uuid
           description: The git token id that must be used for the application
       responses:
-        '200':
+        "200":
           description: Get bitbucket repository branches
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-  '/organization/{organizationId}/webhook':
+                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+  "/organization/{organizationId}/webhook":
     get:
       summary: List organization webhooks
       description: List organization webhooks
       operationId: listOrganizationWebHooks
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Webhook
       responses:
-        '200':
+        "200":
           description: List organization webhooks
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationWebhookResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationWebhookResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an organization webhook
       description: Create an organization webhook.
       operationId: createOrganizationWebhook
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Webhook
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationWebhookCreateRequest'
+              $ref: "#/components/schemas/OrganizationWebhookCreateRequest"
       responses:
-        '201':
+        "201":
           description: Organization webhook created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationWebhookCreateResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/OrganizationWebhookCreateResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
       x-stoplight:
         id: ihun7iwf9rffw
-  '/organization/{organizationId}/webhook/{webhookId}/event':
+  "/organization/{organizationId}/webhook/{webhookId}/event":
     get:
       summary: List events of a webhook
       description: List events of a webhooks
       operationId: listWebhookEvent
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/webhookId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/webhookId"
       tags:
         - Organization Webhook
       responses:
-        '200':
+        "200":
           description: List of event for the webhook
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookEventResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/webhook/{webhookId}':
+                $ref: "#/components/schemas/WebhookEventResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/webhook/{webhookId}":
     get:
       summary: Get an Organization webhook
       description: Get an Organization webhook
       operationId: getOrganizationWebhook
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/webhookId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/webhookId"
       tags:
         - Organization Webhook
       responses:
-        '200':
+        "200":
           description: Get organization webhook
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationWebhookResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationWebhookResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an organization webhook
       description: Edit an organization webhook
       operationId: editOrganizationWebhook
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/webhookId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/webhookId"
       tags:
         - Organization Webhook
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationWebhookCreateRequest'
+              $ref: "#/components/schemas/OrganizationWebhookCreateRequest"
       responses:
-        '200':
+        "200":
           description: Edit an organization webhook
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationWebhookCreateResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationWebhookCreateResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete organization webhook
       description: Delete organization webhook
       operationId: deleteOrganizationWebhook
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/webhookId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/webhookId"
       tags:
         - Organization Webhook
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/customRole':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/customRole":
     get:
       summary: List organization custom roles
       description: List organization custom roles
       operationId: listOrganizationCustomRoles
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Custom Role
       responses:
-        '200':
+        "200":
           description: List organization custom roles
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationCustomRoleList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationCustomRoleList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an organization custom role
       description: Create an organization custom role
       operationId: createOrganizationCustomRole
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Custom Role
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationCustomRoleCreateRequest'
+              $ref: "#/components/schemas/OrganizationCustomRoleCreateRequest"
       responses:
-        '201':
+        "201":
           description: Organization custom role created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationCustomRole'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-  '/organization/{organizationId}/customRole/{customRoleId}':
+                $ref: "#/components/schemas/OrganizationCustomRole"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+  "/organization/{organizationId}/customRole/{customRoleId}":
     get:
-      summary: 'Get an organization custom role '
-      description: 'Get an organization custom role '
+      summary: "Get an organization custom role "
+      description: "Get an organization custom role "
       operationId: getOrganizationCustomRole
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/customRoleId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/customRoleId"
       tags:
         - Organization Custom Role
       responses:
-        '200':
-          description: 'Get an organization custom role '
+        "200":
+          description: "Get an organization custom role "
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationCustomRole'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationCustomRole"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an organization custom role
       description: Edit an organization custom role
       operationId: editOrganizationCustomRole
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/customRoleId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/customRoleId"
       tags:
         - Organization Custom Role
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationCustomRoleUpdateRequest'
+              $ref: "#/components/schemas/OrganizationCustomRoleUpdateRequest"
       responses:
-        '200':
+        "200":
           description: Edit an organization custom role
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationCustomRole'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationCustomRole"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete organization custom role
       description: Delete organization custom role
       operationId: deleteOrganizationCustomRole
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/customRoleId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/customRoleId"
       tags:
         - Organization Custom Role
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/events':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/events":
     get:
       summary: Get all events inside the organization
       description: Get all events inside the organization
       operationId: getOrganizationEvents
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: pageSize
           description: The number of events to display in the current page
@@ -2643,11 +2643,11 @@ paths:
         - in: query
           name: eventType
           schema:
-            $ref: '#/components/schemas/OrganizationEventType'
+            $ref: "#/components/schemas/OrganizationEventType"
         - in: query
           name: targetType
           schema:
-            $ref: '#/components/schemas/OrganizationEventTargetType'
+            $ref: "#/components/schemas/OrganizationEventTargetType"
         - in: query
           name: targetId
           description: |
@@ -2660,7 +2660,7 @@ paths:
         - in: query
           name: subTargetType
           schema:
-            $ref: '#/components/schemas/OrganizationEventSubTargetType'
+            $ref: "#/components/schemas/OrganizationEventSubTargetType"
         - in: query
           name: triggeredBy
           description: Information about the owner of the event (user name / apitoken / automatic action)
@@ -2669,7 +2669,7 @@ paths:
         - in: query
           name: origin
           schema:
-            $ref: '#/components/schemas/OrganizationEventOrigin'
+            $ref: "#/components/schemas/OrganizationEventOrigin"
         - in: query
           name: serviceProjectId
           description: The project chosen when filtering on a service type
@@ -2683,25 +2683,25 @@ paths:
       tags:
         - Organization Event
       responses:
-        '200':
+        "200":
           description: Get organization events
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationEventResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/targets':
+                $ref: "#/components/schemas/OrganizationEventResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/targets":
     get:
       summary: Get available event targets to filter events
       description: Get available event targets to filter events
       operationId: getOrganizationEventTargets
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
         - in: query
           name: fromTimestamp
           description: |
@@ -2723,11 +2723,11 @@ paths:
         - in: query
           name: eventType
           schema:
-            $ref: '#/components/schemas/OrganizationEventType'
+            $ref: "#/components/schemas/OrganizationEventType"
         - in: query
           name: targetType
           schema:
-            $ref: '#/components/schemas/OrganizationEventTargetType'
+            $ref: "#/components/schemas/OrganizationEventTargetType"
         - in: query
           name: triggeredBy
           description: Information about the owner of the event (user name / apitoken / automatic action)
@@ -2736,7 +2736,7 @@ paths:
         - in: query
           name: origin
           schema:
-            $ref: '#/components/schemas/OrganizationEventOrigin'
+            $ref: "#/components/schemas/OrganizationEventOrigin"
         - in: query
           name: projectId
           description: Mandatory when requesting an environment or a service
@@ -2753,33 +2753,33 @@ paths:
           name: targetLevelToFetch
           description: Used only to retrieve projects or environments linked to service typed events
           schema:
-            $ref: '#/components/schemas/OrganizationEventTargetLevel'
+            $ref: "#/components/schemas/OrganizationEventTargetLevel"
       tags:
         - Organization Event
       responses:
-        '200':
+        "200":
           description: Get organization event targets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationEventTargetResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/annotationsGroups':
+                $ref: "#/components/schemas/OrganizationEventTargetResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/annotationsGroups":
     get:
       summary: List organization annotations group
       description: List organization annotations group
       operationId: listOrganizationAnnotationsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Annotations Group
       responses:
-        '200':
+        "200":
           description: List organization annotations groups
           content:
             application/json:
@@ -2787,141 +2787,141 @@ paths:
                 type: object
                 properties:
                   results:
-                    $ref: '#/components/schemas/OrganizationAnnotationsGroupEnrichedResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                    $ref: "#/components/schemas/OrganizationAnnotationsGroupEnrichedResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an organization annotations group
       description: Create an organization annotations group
       operationId: createOrganizationAnnotationsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Annotations Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupCreateRequest'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupCreateRequest"
       responses:
-        '201':
+        "201":
           description: Organization annotations group created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-  '/organization/{organizationId}/annotationsGroups/{annotationsGroupId}':
+                $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+  "/organization/{organizationId}/annotationsGroups/{annotationsGroupId}":
     get:
       summary: Get organization annotations group
       description: Get organization annotations group
       operationId: getOrganizationAnnotationsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/annotationsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/annotationsGroupId"
       tags:
         - Organization Annotations Group
       responses:
-        '200':
+        "200":
           description: List organization annotations groups
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit organization annotations group
       description: Edit organization annotations group
       operationId: editOrganizationAnnotationsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/annotationsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/annotationsGroupId"
       tags:
         - Organization Annotations Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupCreateRequest'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupCreateRequest"
       responses:
-        '200':
+        "200":
           description: Edit organization annotations groups
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete organization annotations group
       description: Delete organization annotations group
       operationId: deleteOrganizationAnnotationsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/annotationsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/annotationsGroupId"
       tags:
         - Organization Annotations Group
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/annotationsGroups/{annotationsGroupId}/associatedItems':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/annotationsGroups/{annotationsGroupId}/associatedItems":
     get:
       summary: Get organization annotations group associated items
       description: Get organization annotations group associated items
       operationId: getOrganizationAnnotationsGroupAssociatedItems
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/annotationsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/annotationsGroupId"
       tags:
         - Organization Annotations Group
       responses:
-        '200':
+        "200":
           description: Get organization annotations group token associated items
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationAnnotationsGroupAssociatedItemsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/labelsGroups':
+                $ref: "#/components/schemas/OrganizationAnnotationsGroupAssociatedItemsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/labelsGroups":
     get:
       summary: List organization labels group
       description: List organization labels group
       operationId: listOrganizationLabelsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Labels Group
       responses:
-        '200':
+        "200":
           description: List organization labels groups
           content:
             application/json:
@@ -2929,130 +2929,130 @@ paths:
                 type: object
                 properties:
                   results:
-                    $ref: '#/components/schemas/OrganizationLabelsGroupEnrichedResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                    $ref: "#/components/schemas/OrganizationLabelsGroupEnrichedResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an organization labels group
       description: Create an organization labels group
       operationId: createOrganizationLabelsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Labels Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationLabelsGroupCreateRequest'
+              $ref: "#/components/schemas/OrganizationLabelsGroupCreateRequest"
       responses:
-        '201':
+        "201":
           description: Organization labels group created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-  '/organization/{organizationId}/labelsGroups/{labelsGroupId}':
+                $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+  "/organization/{organizationId}/labelsGroups/{labelsGroupId}":
     get:
       summary: Get organization labels group
       description: Get organization labels group
       operationId: getOrganizationLabelssGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/labelsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/labelsGroupId"
       tags:
         - Organization Labels Group
       responses:
-        '200':
+        "200":
           description: List organization labels groups
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit organization labels group
       description: Edit organization labels group
       operationId: editOrganizationLabelsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/labelsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/labelsGroupId"
       tags:
         - Organization Labels Group
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationLabelsGroupCreateRequest'
+              $ref: "#/components/schemas/OrganizationLabelsGroupCreateRequest"
       responses:
-        '200':
+        "200":
           description: Edit organization labels groups
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete organization labels group
       description: Delete organization labels group
       operationId: deleteOrganizationLabelsGroup
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/labelsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/labelsGroupId"
       tags:
         - Organization Labels Group
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/labelsGroups/{labelsGroupId}/associatedItems':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/labelsGroups/{labelsGroupId}/associatedItems":
     get:
       summary: Get organization labels group associated items
       description: Get organization labels group associated items
       operationId: getOrganizationLabelsGroupAssociatedItems
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/labelsGroupId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/labelsGroupId"
       tags:
         - Organization Labels Group
       responses:
-        '200':
+        "200":
           description: Get organization labels group token associated items
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationLabelsGroupAssociatedItemsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/OrganizationLabelsGroupAssociatedItemsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /cloudProvider:
     get:
       summary: List Cloud providers available
@@ -3060,18 +3060,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list cloud providers
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CloudProviderResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CloudProviderResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /aws/region:
     get:
       summary: List AWS regions
@@ -3079,18 +3079,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list regions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterRegionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterRegionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /aws/clusterFeature:
     get:
       summary: List AWS features available
@@ -3098,18 +3098,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list features available for AWS cloud provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterFeatureResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterFeatureResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /aws/instanceType:
     get:
       summary: List AWS available instance types
@@ -3117,18 +3117,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list the instance types available for AWS cloud provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /aws/managedDatabase/type:
     get:
       summary: List AWS available managed database types
@@ -3136,46 +3136,46 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list AWS available managed database types
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagedDatabaseTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/aws/managedDatabase/instanceType/{region}/{databaseType}':
+                $ref: "#/components/schemas/ManagedDatabaseTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/aws/managedDatabase/instanceType/{region}/{databaseType}":
     get:
       summary: List AWS available managed database instance types
       operationId: listAWSManagedDatabaseInstanceType
       parameters:
-        - $ref: '#/components/parameters/region'
-        - $ref: '#/components/parameters/databaseType'
+        - $ref: "#/components/parameters/region"
+        - $ref: "#/components/parameters/databaseType"
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list AWS available managed database instance types
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagedDatabaseInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/azure/aks/instanceType/{region}':
+                $ref: "#/components/schemas/ManagedDatabaseInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/azure/aks/instanceType/{region}":
     get:
       summary: List Azure AKS available instance types
       operationId: listAzureAKSInstanceType
       parameters:
-        - $ref: '#/components/parameters/region'
+        - $ref: "#/components/parameters/region"
         - schema:
             type: boolean
           in: query
@@ -3184,7 +3184,7 @@ paths:
             type: boolean
           in: query
           name: with_gpu
-          description: 'deprecated field, use `gpu` instead'
+          description: "deprecated field, use `gpu` instead"
           deprecated: true
         - schema:
             type: string
@@ -3198,24 +3198,24 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list the instance types available for Azure AKS by region
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/aws/eks/instanceType/{region}':
+                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/aws/eks/instanceType/{region}":
     get:
       summary: List AWS EKS available instance types
       operationId: listAWSEKSInstanceType
       parameters:
-        - $ref: '#/components/parameters/region'
+        - $ref: "#/components/parameters/region"
         - schema:
             type: boolean
           in: query
@@ -3224,7 +3224,7 @@ paths:
             type: boolean
           in: query
           name: with_gpu
-          description: 'deprecated field, use `gpu` instead'
+          description: "deprecated field, use `gpu` instead"
           deprecated: true
         - schema:
             type: string
@@ -3239,18 +3239,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list the instance types available for AWS EKS by region
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /scaleway/region:
     get:
       summary: List Scaleway regions
@@ -3258,18 +3258,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list regions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterRegionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterRegionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /scaleway/clusterFeature:
     get:
       summary: List Scaleway features available
@@ -3277,18 +3277,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list features available for Scaleway cloud provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterFeatureResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterFeatureResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /scaleway/instanceType:
     get:
       summary: List Scaleway available instance types
@@ -3296,18 +3296,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list the instance types available for Scaleway cloud provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /scaleway/managedDatabase/type:
     get:
       summary: List Scaleway available managed database types
@@ -3315,19 +3315,19 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list Scaleway available managed database types
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagedDatabaseTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/scaleway/instanceType/{zone}':
+                $ref: "#/components/schemas/ManagedDatabaseTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/scaleway/instanceType/{zone}":
     get:
       summary: List Scaleway Kapsule available instance types
       operationId: listScalewayKapsuleInstanceType
@@ -3342,18 +3342,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list the instance types available for Scaleway Kapsule by region
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /gcp/region:
     get:
       summary: List GCP regions
@@ -3361,18 +3361,18 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list regions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterRegionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterRegionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /gcp/clusterFeature:
     get:
       summary: List GCP features available
@@ -3380,148 +3380,148 @@ paths:
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list features available for GCP cloud provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterFeatureResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/gcp/instanceType/{region}':
+                $ref: "#/components/schemas/ClusterFeatureResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/gcp/instanceType/{region}":
     get:
       summary: List GCP GKE available instance types
       operationId: listGcpGkeInstanceType
       parameters:
-        - $ref: '#/components/parameters/region'
+        - $ref: "#/components/parameters/region"
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list the instance types available for GCP GKE by region
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterInstanceTypeResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/cloudProviderInfo':
+                $ref: "#/components/schemas/ClusterInstanceTypeResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/cloudProviderInfo":
     get:
       summary: Get cluster cloud provider info and credentials
       operationId: getOrganizationCloudProviderInfo
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: get cloud provider info and credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCloudProviderInfo'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCloudProviderInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Specify cluster cloud provider info and credentials
       operationId: specifyClusterCloudProviderInfo
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterCloudProviderInfoRequest'
+              $ref: "#/components/schemas/ClusterCloudProviderInfoRequest"
       responses:
-        '201':
+        "201":
           description: Create cluster
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCloudProviderInfo'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/isReady':
+                $ref: "#/components/schemas/ClusterCloudProviderInfo"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/isReady":
     get:
       summary: Know if a cluster is ready to be deployed or not
       operationId: getClusterReadinessStatus
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Get Cluster Readiness Status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterReadinessStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/deploy':
+                $ref: "#/components/schemas/ClusterReadinessStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/deploy":
     post:
       summary: Deploy a cluster
       description: allows to deploy a cluster
       operationId: deployCluster
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
         - schema:
             type: boolean
           in: query
           name: dry_run
-          description: 'default: false. Decide if the deployment of the cluster should be done in dry_run mode. Avoiding any changes'
+          description: "default: false. Decide if the deployment of the cluster should be done in dry_run mode. Avoiding any changes"
       tags:
         - Clusters
       responses:
-        '201':
+        "201":
           description: Deploy cluster
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterStatus'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/cluster/{clusterId}/argoCdConfig':
+                $ref: "#/components/schemas/ClusterStatus"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/cluster/{clusterId}/argoCdConfig":
     post:
       summary: Save ArgoCD credentials for a cluster
       description: Save or update the ArgoCD URL and authentication token for a cluster. Requires ADMIN role.
       operationId: saveArgoCdCredentials
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - ArgoCD
       requestBody:
@@ -3529,61 +3529,61 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ArgoCdCredentialsRequest'
+              $ref: "#/components/schemas/ArgoCdCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: ArgoCD credentials saved
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArgoCdCredentialsResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ArgoCdCredentialsResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     get:
       summary: Get ArgoCD credentials for a cluster
       description: Retrieve the stored ArgoCD configuration for a cluster. The token is always returned as REDACTED. Requires VIEWER role.
       operationId: getArgoCdCredentials
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - ArgoCD
       responses:
-        '200':
+        "200":
           description: ArgoCD credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArgoCdCredentialsResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ArgoCdCredentialsResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete ArgoCD credentials for a cluster
       description: Remove the stored ArgoCD configuration for a cluster. Requires ADMIN role.
       operationId: deleteArgoCdCredentials
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - ArgoCD
       responses:
-        '204':
+        "204":
           description: ArgoCD credentials deleted
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/cluster/{clusterId}/argoCdConfig/check':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/cluster/{clusterId}/argoCdConfig/check":
     post:
       summary: Check ArgoCD connection
       description: |
@@ -3591,7 +3591,7 @@ paths:
         Always returns HTTP 200 — check the `status` field for the connection outcome. Requires ADMIN role.
       operationId: checkArgoCdConnection
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - ArgoCD
       requestBody:
@@ -3599,259 +3599,259 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ArgoCdCredentialsRequest'
+              $ref: "#/components/schemas/ArgoCdCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Connection check result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArgoCdConnectionCheckResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/cluster/{clusterId}/upgrade':
+                $ref: "#/components/schemas/ArgoCdConnectionCheckResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/cluster/{clusterId}/upgrade":
     post:
       summary: Upgrade a cluster
       description: allows to upgrade a cluster to next available kubernetes version
       operationId: upgradeCluster
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '201':
+        "201":
           description: Upgrade cluster
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterStatus'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/karpenterPrivateSubnetIds':
+                $ref: "#/components/schemas/ClusterStatus"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/karpenterPrivateSubnetIds":
     put:
       summary: Update karpenter private fargate subnet ids
       description: Update karpenter private fargate subnet ids
       operationId: updateKarpenterPrivateFargateSubnetIds
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterKarpenterPrivateSubnetIdsPutRequest'
+              $ref: "#/components/schemas/ClusterKarpenterPrivateSubnetIdsPutRequest"
       responses:
-        '200':
+        "200":
           description: Updated
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/cluster/{clusterId}/stop':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/cluster/{clusterId}/stop":
     post:
       summary: Stop cluster
       description: Cluster stop has been requester.
       operationId: StopCluster
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/clusterId"
       tags:
         - Clusters
       responses:
-        '202':
+        "202":
           description: Update cluster
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/ClusterStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Cluster is already stopped or an operation is in progress
-  '/organization/{organizationId}/containerRegistry':
+  "/organization/{organizationId}/containerRegistry":
     get:
       summary: List organization container registries
       operationId: listContainerRegistry
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Container Registries
       responses:
-        '200':
+        "200":
           description: List container registries
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerRegistryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ContainerRegistryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a container registry
       operationId: createContainerRegistry
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Container Registries
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerRegistryRequest'
+              $ref: "#/components/schemas/ContainerRegistryRequest"
       responses:
-        '201':
+        "201":
           description: Create a Container Registry
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerRegistryResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/containerRegistry/{containerRegistryId}':
+                $ref: "#/components/schemas/ContainerRegistryResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/containerRegistry/{containerRegistryId}":
     get:
       summary: Get a container registry
       operationId: getContainerRegistry
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/containerRegistryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/containerRegistryId"
       tags:
         - Container Registries
       responses:
-        '200':
+        "200":
           description: The container registry
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerRegistryResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ContainerRegistryResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a container registry
       operationId: deleteContainerRegistry
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/containerRegistryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/containerRegistryId"
       tags:
         - Container Registries
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a container registry
       operationId: editContainerRegistry
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/containerRegistryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/containerRegistryId"
       tags:
         - Container Registries
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerRegistryRequest'
+              $ref: "#/components/schemas/ContainerRegistryRequest"
       responses:
-        '200':
+        "200":
           description: Edited the container registry
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerRegistryResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/containerRegistry/{containerRegistryId}/images':
+                $ref: "#/components/schemas/ContainerRegistryResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/containerRegistry/{containerRegistryId}/images":
     get:
       summary: List image version for a container registry
       operationId: getContainerVersions
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/containerRegistryId'
-        - $ref: '#/components/parameters/imageName'
-        - $ref: '#/components/parameters/searchImageName'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/containerRegistryId"
+        - $ref: "#/components/parameters/imageName"
+        - $ref: "#/components/parameters/searchImageName"
       tags:
         - Container Registries
       responses:
-        '200':
+        "200":
           description: The container registry versions list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerVersionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/containerRegistry/{containerRegistryId}/container/status':
+                $ref: "#/components/schemas/ContainerVersionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/containerRegistry/{containerRegistryId}/container/status":
     get:
       summary: List all container registry container statuses
       description: Returns a list of containers with only their id and status.
       operationId: getContainerRegistryContainerStatus
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/containerRegistryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/containerRegistryId"
       tags:
         - Containers
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /availableContainerRegistry:
     get:
       summary: List supported container registries
@@ -3860,18 +3860,18 @@ paths:
       tags:
         - Container Registries
       responses:
-        '200':
+        "200":
           description: supported container registries
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AvailableContainerRegistryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AvailableContainerRegistryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /availableHelmRepository:
     get:
       summary: List supported helm repository
@@ -3880,420 +3880,420 @@ paths:
       tags:
         - Helm Repositories
       responses:
-        '200':
+        "200":
           description: supported helm repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AvailableHelmRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/helmRepository':
+                $ref: "#/components/schemas/AvailableHelmRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/helmRepository":
     get:
       summary: List organization helm repositories
       operationId: listHelmRepository
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Helm Repositories
       responses:
-        '200':
+        "200":
           description: List helm repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a helm repository
       operationId: createHelmRepository
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Helm Repositories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmRepositoryRequest'
+              $ref: "#/components/schemas/HelmRepositoryRequest"
       responses:
-        '201':
+        "201":
           description: Create a helm repository
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmRepositoryResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/helmRepository/{helmRepositoryId}':
+                $ref: "#/components/schemas/HelmRepositoryResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/helmRepository/{helmRepositoryId}":
     get:
       summary: Get a helm repository
       operationId: getHelmRepository
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/helmRepositoryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/helmRepositoryId"
       tags:
         - Helm Repositories
       responses:
-        '200':
+        "200":
           description: The helm repository
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmRepositoryResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmRepositoryResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a helm repository
       operationId: deleteHelmRepository
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/helmRepositoryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/helmRepositoryId"
       tags:
         - Helm Repositories
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a helm repository
       operationId: editHelmRepository
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/helmRepositoryId'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/helmRepositoryId"
       tags:
         - Helm Repositories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmRepositoryRequest'
+              $ref: "#/components/schemas/HelmRepositoryRequest"
       responses:
-        '200':
+        "200":
           description: Edited the helm repository
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmRepositoryResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/helmRepository/{helmRepositoryId}/charts':
+                $ref: "#/components/schemas/HelmRepositoryResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/helmRepository/{helmRepositoryId}/charts":
     get:
       summary: List helm charts contained inside the repository
       operationId: getHelmCharts
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/helmRepositoryId'
-        - $ref: '#/components/parameters/chartName'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/helmRepositoryId"
+        - $ref: "#/components/parameters/chartName"
       tags:
         - Helm Repositories
       responses:
-        '200':
+        "200":
           description: The helm repository versions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmVersionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}':
+                $ref: "#/components/schemas/HelmVersionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}":
     get:
       summary: Get project by ID
       operationId: getProject
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Main Calls
       responses:
-        '200':
+        "200":
           description: Get project by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Project'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a project
       description: To edit a project you must have the admin permission
       operationId: editProject
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectRequest'
+              $ref: "#/components/schemas/ProjectRequest"
       responses:
-        '200':
+        "200":
           description: Edit a project
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Project'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Project name within the organization is already taken
     delete:
       summary: Delete a project
       description: To delete a project you must have the admin permission
       operationId: deleteProject
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/deploymentRule':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/deploymentRule":
     get:
       summary: List project deployment rules
       description: List project deployment rules
       operationId: listProjectDeploymentRules
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Deployment Rule
       responses:
-        '200':
+        "200":
           description: Get project deployment rules
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectDeploymentRuleResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ProjectDeploymentRuleResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a deployment rule
       description: Create a deployment rule
       operationId: createDeploymentRule
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectDeploymentRuleRequest'
+              $ref: "#/components/schemas/ProjectDeploymentRuleRequest"
       responses:
-        '201':
+        "201":
           description: Create deployment rule
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectDeploymentRule'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/deploymentRule/{deploymentRuleId}':
+                $ref: "#/components/schemas/ProjectDeploymentRule"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/deploymentRule/{deploymentRuleId}":
     get:
       summary: Get a project deployment rule
       description: Get a project deployment rule
       operationId: getProjectDeploymentRule
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/deploymentRuleId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/deploymentRuleId"
       tags:
         - Project Deployment Rule
       responses:
-        '200':
+        "200":
           description: Get project deployment rule
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectDeploymentRule'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ProjectDeploymentRule"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a project deployment rule
       description: Edit a project deployment rule
       operationId: editProjectDeployemtnRule
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/deploymentRuleId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/deploymentRuleId"
       tags:
         - Project Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectDeploymentRuleRequest'
+              $ref: "#/components/schemas/ProjectDeploymentRuleRequest"
       responses:
-        '200':
+        "200":
           description: Edit a project deployment rule
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectDeploymentRule'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ProjectDeploymentRule"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a project deployment rule
       description: Delete a project deployment rule
       operationId: deleteProjectDeploymentRule
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/deploymentRuleId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/deploymentRuleId"
       tags:
         - Project Deployment Rule
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/deploymentRule/order':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/deploymentRule/order":
     put:
       summary: Update deployment rules priority order
       description: Update deployment rules priority order
       operationId: updateDeploymentRulesPriorityOrder
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectDeploymentRulesPriorityOrderRequest'
+              $ref: "#/components/schemas/ProjectDeploymentRulesPriorityOrderRequest"
       responses:
-        '200':
+        "200":
           description: Update deployment rules priority order
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environment':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environment":
     get:
       summary: List environments
       operationId: listEnvironment
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Environments
       responses:
-        '200':
+        "200":
           description: List environments
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnvironmentResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an environment
       operationId: createEnvironment
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Environments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateEnvironmentRequest'
+              $ref: "#/components/schemas/CreateEnvironmentRequest"
       responses:
-        '201':
+        "201":
           description: Create environment
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Environment'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Environment"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Environment name within the project is already taken
-  '/project/{projectId}/environmentVariable':
+  "/project/{projectId}/environmentVariable":
     post:
       summary: Add an environment variable to the project
       description: |
@@ -4302,50 +4302,50 @@ paths:
           - If the environment variable value points toward an existing environment variable key, it will be considered as an alias.
       operationId: createProjectEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableRequest'
+              $ref: "#/components/schemas/EnvironmentVariableRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     get:
       summary: List project environment variables
       operationId: listProjectEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Environment Variable
       responses:
-        '200':
+        "200":
           description: List project environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariableResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environmentVariable/{environmentVariableId}':
+                $ref: "#/components/schemas/EnvironmentVariableResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environmentVariable/{environmentVariableId}":
     delete:
       summary: Delete an environment variable from a project
       description: |
@@ -4354,19 +4354,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteProjectEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Project Environment Variable
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an environment variable belonging to the project
       description: |
@@ -4376,8 +4376,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editProjectEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Project Environment Variable
       requestBody:
@@ -4385,23 +4385,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
+              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environmentVariable/{environmentVariableId}/override':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environmentVariable/{environmentVariableId}/override":
     post:
       summary: Create an environment variable override at the project level
       description: |
@@ -4412,31 +4412,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createProjectEnvironmentVariableOverride
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Project Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environmentVariable/{environmentVariableId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environmentVariable/{environmentVariableId}/alias":
     post:
       summary: Create an environment variable alias at the project level
       description: |
@@ -4448,51 +4448,51 @@ paths:
         - You can't create an alias on an alias
       operationId: createProjectEnvironmentVariableAlias
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Project Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/secret':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/secret":
     get:
       summary: List project secrets
       operationId: listProjectSecrets
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Secret
       responses:
-        '200':
+        "200":
           description: List project secrets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/SecretResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add a secret to the project
       description: |
@@ -4501,30 +4501,30 @@ paths:
           - If the secret value points toward an existing secret key, it will be considered as an alias.
       operationId: createProjectSecret
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Project Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretRequest'
+              $ref: "#/components/schemas/SecretRequest"
       responses:
-        '201':
+        "201":
           description: Added a secret
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/secret/{secretId}':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/secret/{secretId}":
     delete:
       summary: Delete a secret from a project
       description: |
@@ -4533,19 +4533,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well  operationId: deleteProjectSecret
       operationId: deleteProjectSecret
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Project Secret
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a secret belonging to the project
       description: |
@@ -4555,8 +4555,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editProjectSecret
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Project Secret
       requestBody:
@@ -4564,23 +4564,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretEditRequest'
+              $ref: "#/components/schemas/SecretEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/secret/{secretId}/override':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/secret/{secretId}/override":
     post:
       summary: Create a secret override at the project level
       description: |
@@ -4591,31 +4591,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createProjectSecretOverride
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Project Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/secret/{secretId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/secret/{secretId}/alias":
     post:
       summary: Create a secret alias at the project level
       description: |
@@ -4627,343 +4627,343 @@ paths:
         - You can't create an alias on an alias
       operationId: createProjectSecretAlias
       parameters:
-        - $ref: '#/components/parameters/projectId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/projectId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Project Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environment/status':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environment/status":
     get:
       summary: List environments statuses
       description: Returns a list of environments with only their id and status.
       operationId: getProjectEnvironmentsStatus
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Environments
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatusList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environment/stats':
+                $ref: "#/components/schemas/EnvironmentStatusList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environment/stats":
     get:
       summary: List total number of services for each environment of the project
-      description: 'Returns a list of environment ids, and for each its total numberof services'
+      description: "Returns a list of environment ids, and for each its total numberof services"
       operationId: getProjectEnvironmentServiceNumber
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Environments
       responses:
-        '200':
+        "200":
           description: Get number of services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/project/{projectId}/environmentOverview':
+                $ref: "#/components/schemas/EnvironmentStatsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/project/{projectId}/environmentOverview":
     get:
       summary: List environments overview
-      description: 'Returns a list of environments with their overview information including deployment status, service count, and cluster details.'
+      description: "Returns a list of environments with their overview information including deployment status, service count, and cluster details."
       operationId: getProjectEnvironmentsOverview
       parameters:
-        - $ref: '#/components/parameters/projectId'
+        - $ref: "#/components/parameters/projectId"
       tags:
         - Environments
       responses:
-        '200':
+        "200":
           description: List environments overview
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentOverviewResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}':
+                $ref: "#/components/schemas/EnvironmentOverviewResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}":
     get:
       summary: Get environment by ID
       operationId: getEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: Get environment by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Environment'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/Environment"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an environment
       description: To edit an environment you must have the admin permission
       operationId: editEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentEditRequest'
+              $ref: "#/components/schemas/EnvironmentEditRequest"
       responses:
-        '200':
+        "200":
           description: Edit an environment
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Environment'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Environment"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Environment name within the project is already taken
     delete:
       summary: Delete an environment
       description: To delete an environment you must have the admin permission
       operationId: deleteEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/status':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/status":
     get:
       summary: Get environment status
       operationId: getEnvironmentStatus
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/statuses':
+                $ref: "#/components/schemas/EnvironmentStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/statuses":
     get:
       summary: Get environment statuses with services status
       operationId: getEnvironmentStatuses
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: Get statuses
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatuses'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/statusesWithStages':
+                $ref: "#/components/schemas/EnvironmentStatuses"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/statusesWithStages":
     get:
       summary: Get environment statuses with stages
       operationId: getEnvironmentStatusesWithStages
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: Get statuses with stages
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatusesWithStages'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploymentStage':
+                $ref: "#/components/schemas/EnvironmentStatusesWithStages"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploymentStage":
     get:
       summary: List environment deployment stage
       operationId: ListEnvironmentDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Deployment Stage Main Calls
       responses:
-        '200':
+        "200":
           description: List deployment stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentStageResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create environment deployment stage
       operationId: CreateEnvironmentDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Deployment Stage Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeploymentStageRequest'
+              $ref: "#/components/schemas/DeploymentStageRequest"
       responses:
-        '200':
+        "200":
           description: created deployment stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/deploymentStage/{deploymentStageId}':
+                $ref: "#/components/schemas/DeploymentStageResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/deploymentStage/{deploymentStageId}":
     get:
       summary: Get Deployment Stage
       operationId: getDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/deploymentStageId'
+        - $ref: "#/components/parameters/deploymentStageId"
       tags:
         - Deployment Stage Main Calls
       responses:
-        '200':
+        "200":
           description: Get Deployment Stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentStageResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete deployment stage
       operationId: DeleteDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/deploymentStageId'
+        - $ref: "#/components/parameters/deploymentStageId"
       tags:
         - Deployment Stage Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit deployment stage
       operationId: EditDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/deploymentStageId'
+        - $ref: "#/components/parameters/deploymentStageId"
       tags:
         - Deployment Stage Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeploymentStageRequest'
+              $ref: "#/components/schemas/DeploymentStageRequest"
       responses:
-        '200':
+        "200":
           description: created deployment stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/deploymentStage/{deploymentStageId}/service/{serviceId}':
+                $ref: "#/components/schemas/DeploymentStageResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/deploymentStage/{deploymentStageId}/service/{serviceId}":
     put:
       summary: Attach service to deployment stage
-      description: 'Moves the service to the specified deployment stage. To skip a service from environment-level deployments while keeping it in its current stage, set `is_skipped: true` in the request body. Moving the service to a different stage automatically un-skips it (sets `is_skipped: false`).'
+      description: "Moves the service to the specified deployment stage. To skip a service from environment-level deployments while keeping it in its current stage, set `is_skipped: true` in the request body. Moving the service to a different stage automatically un-skips it (sets `is_skipped: false`)."
       operationId: AttachServiceToDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/deploymentStageId'
-        - $ref: '#/components/parameters/serviceId'
+        - $ref: "#/components/parameters/deploymentStageId"
+        - $ref: "#/components/parameters/serviceId"
       requestBody:
         content:
           application/json:
@@ -4972,164 +4972,164 @@ paths:
               properties:
                 is_skipped:
                   type: boolean
-                  description: 'When true, marks the service as skipped (excluded from environment-level bulk deployments) while keeping it in the specified stage. When false or omitted, the service is moved to the specified stage and un-skipped.'
+                  description: "When true, marks the service as skipped (excluded from environment-level bulk deployments) while keeping it in the specified stage. When false or omitted, the service is moved to the specified stage and un-skipped."
       tags:
         - Deployment Stage Main Calls
       responses:
-        '200':
+        "200":
           description: List of deployment stages for the env
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/deploymentStage/{deploymentStageId}/moveBefore/{stageId}':
+                $ref: "#/components/schemas/DeploymentStageResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/deploymentStage/{deploymentStageId}/moveBefore/{stageId}":
     put:
       summary: Move deployment stage before requested stage
       operationId: MoveBeforeDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/deploymentStageId'
-        - $ref: '#/components/parameters/stageId'
+        - $ref: "#/components/parameters/deploymentStageId"
+        - $ref: "#/components/parameters/stageId"
       tags:
         - Deployment Stage Main Calls
       responses:
-        '200':
+        "200":
           description: List deployment stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/deploymentStage/{deploymentStageId}/moveAfter/{stageId}':
+                $ref: "#/components/schemas/DeploymentStageResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/deploymentStage/{deploymentStageId}/moveAfter/{stageId}":
     put:
       summary: Move deployment stage after requested stage
       operationId: MoveAfterDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/deploymentStageId'
-        - $ref: '#/components/parameters/stageId'
+        - $ref: "#/components/parameters/deploymentStageId"
+        - $ref: "#/components/parameters/stageId"
       tags:
         - Deployment Stage Main Calls
       responses:
-        '200':
+        "200":
           description: List deployment stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploymentRule':
+                $ref: "#/components/schemas/DeploymentStageResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploymentRule":
     get:
       summary: Get environment deployment rule
       operationId: getEnvironmentDeploymentRule
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Deployment Rule
       responses:
-        '200':
+        "200":
           description: Get deployment rule
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentDeploymentRule'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploymentRule/{deploymentRuleId}':
+                $ref: "#/components/schemas/EnvironmentDeploymentRule"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploymentRule/{deploymentRuleId}":
     put:
       summary: Edit an environment deployment rule
       operationId: editEnvironmentDeploymentRule
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/deploymentRuleId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/deploymentRuleId"
       tags:
         - Environment Deployment Rule
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentDeploymentRuleEditRequest'
+              $ref: "#/components/schemas/EnvironmentDeploymentRuleEditRequest"
       responses:
-        '200':
+        "200":
           description: Edit environment deployment rule
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentDeploymentRule'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploy':
+                $ref: "#/components/schemas/EnvironmentDeploymentRule"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploy":
     post:
       summary: Deploy environment
       description: This will deploy all the services of this environment to their latest version.
       operationId: deployEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       responses:
-        '202':
+        "202":
           description: Deploy environment
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/uninstall':
+  "/environment/{environmentId}/uninstall":
     post:
       summary: Uninstall environment
       description: This will uninstall all the services of this environment.
       operationId: uninstallEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       responses:
-        '202':
+        "202":
           description: uninstall environment
           content:
             application/json:
               schema:
                 type: object
                 properties: {}
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: g57d57j59zihv
@@ -5139,75 +5139,75 @@ paths:
         name: environmentId
         in: path
         required: true
-  '/environment/{environmentId}/stop':
+  "/environment/{environmentId}/stop":
     post:
       summary: Stop environment
       operationId: stopEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       responses:
-        '202':
+        "202":
           description: Environment stop has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/EnvironmentStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Environment is already stopped or an operation is in progress
-  '/environment/{environmentId}/redeploy':
+  "/environment/{environmentId}/redeploy":
     post:
       summary: Redeploy environment
       operationId: redeployEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       responses:
-        '202':
+        "202":
           description: Environment redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/EnvironmentStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/cancelDeployment':
+  "/environment/{environmentId}/cancelDeployment":
     post:
       summary: Cancel environment deployment
       description: Cancel the current deployment of your environment.
       operationId: cancelEnvironmentDeployment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       responses:
-        '202':
+        "202":
           description: environment deployment cancelling has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatus'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/EnvironmentStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Environment deployment is already cancelled or an operation is in progress
       requestBody:
         content:
@@ -5221,7 +5221,7 @@ paths:
                     id: c5k0n6yafpsig
                   default: false
                   description: Force cancel everything running in this environment if set to true (e.q lifecycle jobs triggered during the deployment).
-  '/deploymentQueue/{deploymentRequestId}/cancelDeployment':
+  "/deploymentQueue/{deploymentRequestId}/cancelDeployment":
     post:
       summary: Cancel deployment request
       description: Cancel the a deployment request.
@@ -5229,16 +5229,16 @@ paths:
       tags:
         - Deployment Queue Actions
       responses:
-        '202':
+        "202":
           description: deployment request cancelling has been requested
           content: {}
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Deployment request is already cancelled or an operation is in progress
       requestBody:
         content:
@@ -5255,322 +5255,322 @@ paths:
         name: deploymentRequestId
         in: path
         required: true
-  '/environment/{environmentId}/clone':
+  "/environment/{environmentId}/clone":
     post:
       summary: Clone environment
-      description: 'You must provide a name. This will create a new environment, with the same configuration, and same applications and databases. Database data is not cloned.'
+      description: "You must provide a name. This will create a new environment, with the same configuration, and same applications and databases. Database data is not cloned."
       operationId: cloneEnvironment
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneEnvironmentRequest'
+              $ref: "#/components/schemas/CloneEnvironmentRequest"
       responses:
-        '202':
+        "202":
           description: Environment clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Environment'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Environment"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/application':
+  "/environment/{environmentId}/application":
     get:
       summary: List applications
       operationId: listApplication
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1"
       tags:
         - Applications
       responses:
-        '200':
+        "200":
           description: List applications
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ApplicationResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an application
       operationId: createApplication
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Applications
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationRequest'
+              $ref: "#/components/schemas/ApplicationRequest"
       responses:
-        '201':
+        "201":
           description: Create application
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Application"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Application name within the environment is already taken
-  '/environment/{environmentId}/application/status':
+  "/environment/{environmentId}/application/status":
     get:
       summary: List all environment applications statuses
       description: Returns a list of applications with only their id and status.
       operationId: getEnvironmentApplicationStatus
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Applications
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/container':
+                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/container":
     get:
       summary: List containers
       operationId: listContainer
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Containers
       responses:
-        '200':
+        "200":
           description: List containers
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ContainerResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a container
       operationId: createContainer
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerRequest'
+              $ref: "#/components/schemas/ContainerRequest"
       responses:
-        '201':
+        "201":
           description: Create container
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/ContainerResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Container name within the environment is already taken
-  '/environment/{environmentId}/container/status':
+  "/environment/{environmentId}/container/status":
     get:
       summary: List all environment container statuses
       description: Returns a list of containers with only their id and status.
       operationId: getEnvironmentContainerStatus
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Containers
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/service/deploy':
+                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/service/deploy":
     post:
       summary: Deploy services
       description: Update and deploy the selected services
       operationId: deployAllServices
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeployAllRequest'
+              $ref: "#/components/schemas/DeployAllRequest"
       responses:
-        '202':
+        "202":
           description: Deployed services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentStatus'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/EnvironmentStatus"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/service/restart-service':
+  "/environment/{environmentId}/service/restart-service":
     post:
       summary: Reboot services
       description: Update and reboot the selected services
       operationId: rebootServices
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RebootServicesRequest'
+              $ref: "#/components/schemas/RebootServicesRequest"
       responses:
-        '202':
+        "202":
           description: Reboot services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/service/stop':
+  "/environment/{environmentId}/service/stop":
     post:
       summary: Stop services
       description: Stop selected services
       operationId: stopSelectedServices
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentServiceIdsAllRequest'
+              $ref: "#/components/schemas/EnvironmentServiceIdsAllRequest"
       responses:
-        '200':
+        "200":
           description: Services have been triggered to be deleted
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/service/delete':
+  "/environment/{environmentId}/service/delete":
     post:
       summary: Delete services
       description: Delete selected services
       operationId: deleteSelectedServices
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentServiceIdsAllRequest'
+              $ref: "#/components/schemas/EnvironmentServiceIdsAllRequest"
       responses:
-        '200':
+        "200":
           description: Services have been triggered to be deleted
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/service/uninstall':
+  "/environment/{environmentId}/service/uninstall":
     post:
       summary: Uninstall services
       description: uninstall selected services
       operationId: uninstallSelectedServices
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentServiceIdsAllRequest'
+              $ref: "#/components/schemas/EnvironmentServiceIdsAllRequest"
       responses:
-        '200':
+        "200":
           description: Services have been triggered to be uninstalled
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: m4lfkqr1n8s97
@@ -5580,7 +5580,7 @@ paths:
         name: environmentId
         in: path
         required: true
-  '/organization/{organizationId}/container/deploy':
+  "/organization/{organizationId}/container/deploy":
     post:
       summary: Auto deploy containers
       description: |
@@ -5589,32 +5589,32 @@ paths:
         - the container should have the same image name and a different tag
       operationId: autoDeployContainerEnvironments
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationContainerAutoDeployRequest'
+              $ref: "#/components/schemas/OrganizationContainerAutoDeployRequest"
       responses:
-        '202':
+        "202":
           description: Deployed containers
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/organization/{organizationId}/container/preview':
+  "/organization/{organizationId}/container/preview":
     post:
       summary: Preview container environments
       description: |
@@ -5623,32 +5623,32 @@ paths:
         - the container should have the same image name and a different tag
       operationId: previewContainerEnvironments
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationContainerPreviewRequest'
+              $ref: "#/components/schemas/OrganizationContainerPreviewRequest"
       responses:
-        '202':
+        "202":
           description: Preview environments processing
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/organization/{organizationId}/job/deploy':
+  "/organization/{organizationId}/job/deploy":
     post:
       summary: Auto deploy jobs
       description: |
@@ -5657,60 +5657,60 @@ paths:
         - the job should have the same image name and a different tag
       operationId: autoDeployJobEnvironments
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Jobs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationJobAutoDeployRequest'
+              $ref: "#/components/schemas/OrganizationJobAutoDeployRequest"
       responses:
-        '202':
+        "202":
           description: Deployed jobs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/log':
+  "/environment/{environmentId}/log":
     get:
       summary: List environment deployment logs
       operationId: listEnvironmentLog
       description: This returns the last 1000 environment deployment logs.
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Logs
       responses:
-        '200':
+        "200":
           description: List logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentLogResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/logs':
+                $ref: "#/components/schemas/EnvironmentLogResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/logs":
     get:
       summary: List environment deployment logs v2
       operationId: listEnvironmentLogs
       description: This returns the last 1000 environment deployment logs v2
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
         - in: query
           name: version
           schema:
@@ -5718,45 +5718,45 @@ paths:
       tags:
         - Environment Logs
       responses:
-        '200':
+        "200":
           description: List logs v2
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentLogsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploymentHistory':
+                $ref: "#/components/schemas/EnvironmentLogsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploymentHistory":
     get:
       summary: List environment deployments
-      description: 'List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter'
+      description: "List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter"
       operationId: listEnvironmentDeploymentHistory
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/startId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/startId"
       tags:
         - Environment Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploymentHistoryV2':
+                $ref: "#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploymentHistoryV2":
     get:
       summary: List environment deployments
-      description: 'List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter'
+      description: "List previous and current environment deployments with the status deployment and the related services. By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter"
       operationId: listEnvironmentDeploymentHistoryV2
       parameters:
         - in: query
@@ -5769,18 +5769,18 @@ paths:
       tags:
         - Environment Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryEnvironmentPaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: pqsu5pghhay1j
     parameters:
@@ -5790,56 +5790,56 @@ paths:
         name: environmentId
         in: path
         required: true
-  '/environment/{environmentId}/deploymentBuildUsageReport':
+  "/environment/{environmentId}/deploymentBuildUsageReport":
     post:
       summary: Generate a Grafana snapshot report showing build runner pod usage for a specific deployment
       description: Generate a Grafana snapshot report that shows the resource usage (CPU, memory) of build runner pods for a specific deployment execution. The report is publicly accessible for the specified duration.
       operationId: generateDeploymentBuildUsageReport
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Deployment History
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeploymentBuildUsageReportRequest'
+              $ref: "#/components/schemas/DeploymentBuildUsageReportRequest"
       responses:
-        '201':
+        "201":
           description: Build usage report snapshot has been successfully generated
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentBuildUsageReportResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/environmentVariable':
+                $ref: "#/components/schemas/DeploymentBuildUsageReportResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/environmentVariable":
     get:
       summary: List environment variables
       operationId: listEnvironmentEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Variable
       responses:
-        '200':
+        "200":
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariableResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnvironmentVariableResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add an environment variable to the environment
       description: |
@@ -5848,30 +5848,30 @@ paths:
           - If the environment variable value points toward an existing environment variable key, it will be considered as an alias.
       operationId: createEnvironmentEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableRequest'
+              $ref: "#/components/schemas/EnvironmentVariableRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/environmentVariable/{environmentVariableId}':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/environmentVariable/{environmentVariableId}":
     delete:
       summary: Delete an environment variable from an environment
       description: |
@@ -5880,19 +5880,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteEnvironmentEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Environment Variable
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an environment variable belonging to the environment
       description: |
@@ -5902,8 +5902,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editEnvironmentEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Environment Variable
       requestBody:
@@ -5911,23 +5911,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
+              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/environmentVariable/{environmentVariableId}/override':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/environmentVariable/{environmentVariableId}/override":
     post:
       summary: Create an environment variable override at the environment level
       description: |
@@ -5938,31 +5938,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createEnvironmentEnvironmentVariableOverride
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/environmentVariable/{environmentVariableId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/environmentVariable/{environmentVariableId}/alias":
     post:
       summary: Create an environment variable alias at the environment level
       description: |
@@ -5974,51 +5974,51 @@ paths:
         - You can't create an alias on an alias
       operationId: createEnvironmentEnvironmentVariableAlias
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/secret':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/secret":
     get:
       summary: List environment secrets
       operationId: listEnvironmentSecrets
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Secret
       responses:
-        '200':
+        "200":
           description: List environment secrets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/SecretResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add a secret to the environment
       description: |
@@ -6027,30 +6027,30 @@ paths:
           - If the secret value points toward an existing secret key, it will be considered as an alias.
       operationId: createEnvironmentSecret
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretRequest'
+              $ref: "#/components/schemas/SecretRequest"
       responses:
-        '201':
+        "201":
           description: Added a secret
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/secret/{secretId}':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/secret/{secretId}":
     delete:
       summary: Delete a secret from the environment
       description: |
@@ -6059,19 +6059,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well  operationId: deleteEnvironmentSecret
       operationId: deleteEnvironmentSecret
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Environment Secret
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a secret belonging to the environment
       description: |
@@ -6081,8 +6081,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editEnvironmentSecret
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Environment Secret
       requestBody:
@@ -6090,23 +6090,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretEditRequest'
+              $ref: "#/components/schemas/SecretEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/secret/{secretId}/override':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/secret/{secretId}/override":
     post:
       summary: Create a secret override at the environment level
       description: |
@@ -6117,31 +6117,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createEnvironmentSecretOverride
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Environment Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/secret/{secretId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/secret/{secretId}/alias":
     post:
       summary: Create a secret alias at the environment level
       description: |
@@ -6153,57 +6153,57 @@ paths:
         - You can't create an alias on an alias
       operationId: createEnvironmentSecretAlias
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Environment Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/databaseConfiguration':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/databaseConfiguration":
     get:
-      summary: 'List eligible database types, versions and modes for the environment'
+      summary: "List eligible database types, versions and modes for the environment"
       operationId: listEnvironmentDatabaseConfig
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Databases
       responses:
-        '200':
+        "200":
           description: List eligible database
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DatabaseConfigurationResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/terraformExport':
+                $ref: "#/components/schemas/DatabaseConfigurationResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/terraformExport":
     get:
       summary: Export full environment and its resources into Terraform manifests
       operationId: exportEnvironmentConfigurationIntoTerraform
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
         - name: exportSecrets
           in: query
           description: export Secrets from configuration and include them into Terraform export
@@ -6214,91 +6214,91 @@ paths:
       tags:
         - Environment Export
       responses:
-        '200':
+        "200":
           description: Export full environment and its resources into Terraform manifests (ZIP file)
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /defaultApplicationAdvancedSettings:
     get:
       summary: List default application advanced settings
       operationId: getDefaultApplicationAdvancedSettings
-      description: 'Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)'
+      description: "Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)"
       tags:
         - Applications
       responses:
-        '200':
+        "200":
           description: Default application advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/ApplicationAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
   /defaultClusterAdvancedSettings:
     get:
       summary: List default cluster advanced settings
-      description: 'Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/cluster-advanced-settings/)'
+      description: "Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/cluster-advanced-settings/)"
       operationId: getDefaultClusterAdvancedSettings
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: Default cluster advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/ClusterAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
   /defaultContainerAdvancedSettings:
     get:
       summary: List default container advanced settings
-      description: 'Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)'
+      description: "Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)"
       operationId: getDefaultContainerAdvancedSettings
       tags:
         - Containers
       responses:
-        '200':
+        "200":
           description: Default container advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/ContainerAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
   /defaultJobAdvancedSettings:
     get:
       summary: List default job advanced settings
-      description: 'Default values for each setting is available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)'
+      description: "Default values for each setting is available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)"
       operationId: getDefaultJobAdvancedSettings
       tags:
         - Jobs
       responses:
-        '200':
+        "200":
           description: Default job advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/JobAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
   /defaultHelmAdvancedSettings:
     get:
       summary: List default helm advanced settings
@@ -6306,37 +6306,37 @@ paths:
       tags:
         - Helms
       responses:
-        '200':
+        "200":
           description: Default helm advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-  '/application/{applicationId}':
+                $ref: "#/components/schemas/HelmAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+  "/application/{applicationId}":
     get:
       summary: Get application by ID
       operationId: getApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Main Calls
       responses:
-        '200':
+        "200":
           description: Get application by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/Application"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit application
       description: |
@@ -6345,251 +6345,251 @@ paths:
         - For storage edition, if you provide a storage id, we will update the corresponding storage. If you don't we will create a new one. If you remove a storage from the payload, we will delete it.
       operationId: editApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationEditRequest'
+              $ref: "#/components/schemas/ApplicationEditRequest"
       responses:
-        '200':
+        "200":
           description: Edit application
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Application"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Application name within the environment is already taken
     delete:
       summary: Delete application
       description: To delete the application you must have the admin permission
       operationId: deleteApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/status':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/status":
     get:
       summary: Get application status
       operationId: getApplicationStatus
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Main Calls
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/deploymentRestriction':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/deploymentRestriction":
     get:
       summary: Get application deployment restrictions
       description: Get application deployment restrictions
       operationId: getApplicationDeploymentRestrictions
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Deployment Restriction
       responses:
-        '200':
+        "200":
           description: Get application deployment restrictions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationDeploymentRestrictionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ApplicationDeploymentRestrictionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create an application deployment restriction
       description: Create an application deployment restriction
       operationId: createApplicationDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/ApplicationDeploymentRestrictionRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationDeploymentRestriction'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '409':
+                $ref: "#/components/schemas/ApplicationDeploymentRestriction"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "409":
           description: An application deployment restriction with same properties already exists for this application
-  '/application/{applicationId}/deploymentRestriction/{deploymentRestrictionId}':
+  "/application/{applicationId}/deploymentRestriction/{deploymentRestrictionId}":
     put:
       summary: Edit an application deployment restriction
       description: Edit an application deployment restriction
       operationId: editApplicationDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/deploymentRestrictionId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/deploymentRestrictionId"
       tags:
         - Application Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/ApplicationDeploymentRestrictionRequest"
       responses:
-        '200':
+        "200":
           description: Edit an application deployment restriction
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationDeploymentRestriction'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ApplicationDeploymentRestriction"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete an application deployment restriction
       description: Delete an application deployment restriction
       operationId: deleteApplicationDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/deploymentRestrictionId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/deploymentRestrictionId"
       tags:
         - Application Deployment Restriction
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/contributor':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/contributor":
     get:
       summary: List contributors
       operationId: listApplicationContributor
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Main Calls
       responses:
-        '200':
+        "200":
           description: List application contributors
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/commit':
+                $ref: "#/components/schemas/UserResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/commit":
     get:
       summary: List last commits
       description: Returns list of the last 100 commits made on the repository linked to the application
       operationId: listApplicationCommit
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/startId'
-        - $ref: '#/components/parameters/gitCommitId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/startId"
+        - $ref: "#/components/parameters/gitCommitId"
       tags:
         - Application Main Calls
       responses:
-        '200':
+        "200":
           description: List commits
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommitResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/deploy':
+                $ref: "#/components/schemas/CommitResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/deploy":
     post:
       summary: Deploy application
       description: You must provide a git commit id
       operationId: deployApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeployRequest'
+              $ref: "#/components/schemas/DeployRequest"
       responses:
-        '202':
+        "202":
           description: Deploy application
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/application/{applicationId}/uninstall':
+  "/application/{applicationId}/uninstall":
     post:
       summary: Uninstall application
       description: |
         Delete the resources of an application but keep the Qovery config.
       operationId: uninstallApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Actions
       requestBody:
@@ -6599,23 +6599,23 @@ paths:
               type: object
               properties: {}
       responses:
-        '202':
-          description: 'Delete the compute and data of the service, but keep Qovery configuration'
+        "202":
+          description: "Delete the compute and data of the service, but keep Qovery configuration"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '204':
+                $ref: "#/components/schemas/Status"
+        "204":
           description: No deployment has been triggered
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: vrnx0mllgta48
@@ -6625,102 +6625,102 @@ paths:
         name: applicationId
         in: path
         required: true
-  '/application/{applicationId}/stop':
+  "/application/{applicationId}/stop":
     post:
       summary: Stop application
       operationId: stopApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Actions
       responses:
-        '202':
+        "202":
           description: Application stop has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Application is already stopped or an operation is in progress
-  '/application/{applicationId}/redeploy':
+  "/application/{applicationId}/redeploy":
     post:
       summary: Redeploy application
       operationId: redeployApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Actions
       responses:
-        '202':
+        "202":
           description: Application redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/application/{applicationId}/restart-service':
+  "/application/{applicationId}/restart-service":
     post:
       summary: Reboot application
       operationId: rebootApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Actions
       responses:
-        '202':
+        "202":
           description: Application reboot has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/application/{applicationId}/deploymentHistory':
+  "/application/{applicationId}/deploymentHistory":
     get:
       summary: List application deploys
-      description: 'By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id'
+      description: "By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id"
       operationId: listApplicationDeploymentHistory
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/startId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/startId"
       tags:
         - Application Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryPaginatedResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/deploymentHistoryV2':
+                $ref: "#/components/schemas/DeploymentHistoryPaginatedResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/deploymentHistoryV2":
     get:
       summary: List application deploys
-      description: 'By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id'
+      description: "By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter. You can also filter by status (FAILED or SUCCESS), and git_commit_id"
       operationId: listApplicationDeploymentHistoryV2
       parameters:
         - in: query
@@ -6733,18 +6733,18 @@ paths:
       tags:
         - Application Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: 59xza5oe7uvet
     parameters:
@@ -6753,86 +6753,86 @@ paths:
         name: applicationId
         in: path
         required: true
-  '/application/{applicationId}/environmentVariable':
+  "/application/{applicationId}/environmentVariable":
     get:
       summary: List environment variables
       operationId: listApplicationEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Environment Variable
       responses:
-        '200':
+        "200":
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariableResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnvironmentVariableResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add an environment variable to the application
       description: |
         - Add an environment variable to the application.
       operationId: createApplicationEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableRequest'
+              $ref: "#/components/schemas/EnvironmentVariableRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/environmentVariable/import':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/environmentVariable/import":
     post:
       summary: Import variables
-      description: 'Import environment variables in a defined scope, with a defined visibility.'
+      description: "Import environment variables in a defined scope, with a defined visibility."
       operationId: importEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableImportRequest'
+              $ref: "#/components/schemas/VariableImportRequest"
       responses:
-        '201':
+        "201":
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableImport'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/environmentVariable/{environmentVariableId}':
+                $ref: "#/components/schemas/VariableImport"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/environmentVariable/{environmentVariableId}":
     delete:
       summary: Delete an environment variable from an application
       description: |
@@ -6841,19 +6841,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteApplicationEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Application Environment Variable
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an environment variable belonging to the application
       description: |
@@ -6863,8 +6863,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editApplicationEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Application Environment Variable
       requestBody:
@@ -6872,23 +6872,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
+              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/environmentVariable/{environmentVariableId}/override':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/environmentVariable/{environmentVariableId}/override":
     post:
       summary: Create an environment variable override at the application level
       description: |
@@ -6899,31 +6899,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createApplicationEnvironmentVariableOverride
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/environmentVariable/{environmentVariableId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/environmentVariable/{environmentVariableId}/alias":
     post:
       summary: Create an environment variable alias at the application level
       description: |
@@ -6935,82 +6935,82 @@ paths:
         - You can't create an alias on an alias
       operationId: createApplicationEnvironmentVariableAlias
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Application Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/secret':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/secret":
     get:
       summary: List application secrets
-      description: 'Secrets are like environment variables, but they are secured and can''t be revealed.'
+      description: "Secrets are like environment variables, but they are secured and can't be revealed."
       operationId: listApplicationSecrets
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Secret
       responses:
-        '200':
+        "200":
           description: List secrets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/SecretResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add a secret to the application
       description: |
         - Add a secret to the application.
       operationId: createApplicationSecret
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretRequest'
+              $ref: "#/components/schemas/SecretRequest"
       responses:
-        '201':
+        "201":
           description: Add a secret
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/secret/{secretId}':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/secret/{secretId}":
     delete:
       summary: Delete a secret from an application
       description: |
@@ -7019,19 +7019,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well
       operationId: deleteApplicationSecret
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Application Secret
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a secret belonging to the application
       description: |
@@ -7041,8 +7041,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION)
       operationId: editApplicationSecret
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Application Secret
       requestBody:
@@ -7050,23 +7050,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretEditRequest'
+              $ref: "#/components/schemas/SecretEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/secret/{secretId}/override':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/secret/{secretId}/override":
     post:
       summary: Create a secret override at the application level
       description: |
@@ -7077,31 +7077,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createApplicationSecretOverride
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Application Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/secret/{secretId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/secret/{secretId}/alias":
     post:
       summary: Create a secret alias at the application level
       description: |
@@ -7113,265 +7113,265 @@ paths:
         - You can't create an alias on an alias
       operationId: createApplicationSecretAlias
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Application Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/customDomain':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/customDomain":
     get:
       summary: List application custom domains
       operationId: listApplicationCustomDomain
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Custom Domain
       responses:
-        '200':
+        "200":
           description: List custom domains
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomainResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CustomDomainResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add custom domain to the application.
       description: Add a custom domain to this application in order not to use qovery autogenerated domain
       operationId: createApplicationCustomDomain
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomDomainRequest'
+              $ref: "#/components/schemas/CustomDomainRequest"
       responses:
-        '201':
+        "201":
           description: Added application custom domain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/customDomain/{customDomainId}':
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/customDomain/{customDomainId}":
     put:
       summary: Edit a Custom Domain
       description: To edit a Custom Domain you must have the project user permission
       operationId: editCustomDomain
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Application Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomDomainRequest'
+              $ref: "#/components/schemas/CustomDomainRequest"
       responses:
-        '200':
+        "200":
           description: Edit a CustomDomain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a Custom Domain
       description: To delete an CustomDomain you must have the project user permission
       operationId: deleteCustomDomain
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Application Custom Domain
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/customDomain/{customDomainId}/status':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/customDomain/{customDomainId}/status":
     get:
       summary: Get Custom Domain status
       operationId: getCustomDomainStatus
       parameters:
-        - $ref: '#/components/parameters/applicationId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/applicationId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Application Custom Domain
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/checkCustomDomain':
+                $ref: "#/components/schemas/CustomDomain"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/checkCustomDomain":
     get:
       summary: Check Application Custom Domain
       operationId: checkApplicationCustomDomain
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Custom Domain
       responses:
-        '200':
+        "200":
           description: Check Application Custom Domain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckedCustomDomainsResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/log':
+                $ref: "#/components/schemas/CheckedCustomDomainsResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/log":
     get:
       summary: List logs
       operationId: listApplicationLog
       description: This will list the last 1000 logs of the application
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Logs
       responses:
-        '200':
+        "200":
           description: List logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/network':
+                $ref: "#/components/schemas/LogResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/network":
     get:
       summary: Get Application Network information
       description: Get status of the application network settings.
       operationId: getApplicationNetwork
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Configuration
       responses:
-        '200':
+        "200":
           description: Network information
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationNetwork'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ApplicationNetwork"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit Application Network
       description: Edit the Network settings of the application.
       operationId: editApplicationNetwork
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationNetworkRequest'
+              $ref: "#/components/schemas/ApplicationNetworkRequest"
       responses:
-        '201':
+        "201":
           description: Updated application network setting
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationNetwork'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/link':
+                $ref: "#/components/schemas/ApplicationNetwork"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/link":
     get:
       summary: List all URLs of the application
       description: This will return all the custom domains and Qovery autogenerated domain for the given application
       operationId: listApplicationLinks
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Main Calls
       responses:
-        '200':
+        "200":
           description: List links
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LinkResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/advancedSettings':
+                $ref: "#/components/schemas/LinkResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/advancedSettings":
     get:
       summary: Get advanced settings
       description: |
@@ -7379,100 +7379,100 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)
       operationId: getAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Configuration
       responses:
-        '200':
+        "200":
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ApplicationAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Application Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationAdvancedSettings'
+              $ref: "#/components/schemas/ApplicationAdvancedSettings"
       responses:
-        '201':
+        "201":
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationAdvancedSettings'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/application/{applicationId}/clone':
+                $ref: "#/components/schemas/ApplicationAdvancedSettings"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/application/{applicationId}/clone":
     post:
       summary: Clone application
       description: This will create a new application with the same configuration on the targeted environment Id.
       operationId: cloneApplication
       parameters:
-        - $ref: '#/components/parameters/applicationId'
+        - $ref: "#/components/parameters/applicationId"
       tags:
         - Applications
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneServiceRequest'
+              $ref: "#/components/schemas/CloneServiceRequest"
       responses:
-        '202':
+        "202":
           description: Application clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Application"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/container/{containerId}':
+  "/container/{containerId}":
     get:
       summary: Get container by ID
       operationId: getContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Main Calls
       responses:
-        '200':
+        "200":
           description: Get container by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ContainerResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit container
       description: |
@@ -7481,105 +7481,105 @@ paths:
         - For storage edition, if you provide a storage id, we will update the corresponding storage. If you don't we will create a new one. If you remove a storage from the payload, we will delete it.
       operationId: editContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerRequest'
+              $ref: "#/components/schemas/ContainerRequest"
       responses:
-        '200':
+        "200":
           description: Edit container
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/ContainerResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Container name within the environment is already taken
     delete:
       summary: Delete container
       description: To delete the container you must have the admin permission
       operationId: deleteContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/status':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/status":
     get:
       summary: Get container status
       operationId: getContainerStatus
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Main Calls
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/deploymentHistory':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/deploymentHistory":
     get:
       summary: List container deployments
       description: Returns the 20 last container deployments
       operationId: listContainerDeploymentHistory
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/PaginationData'
+                  - $ref: "#/components/schemas/PaginationData"
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: '#/components/schemas/DeploymentHistoryContainer'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/deploymentHistoryV2':
+                          $ref: "#/components/schemas/DeploymentHistoryContainer"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/deploymentHistoryV2":
     get:
       summary: List container deployments
       description: Returns the 20 last container deployments
       operationId: listContainerDeploymentHistoryV2
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
         - in: query
           name: pageSize
           description: The number of deployments to return in the current page
@@ -7590,21 +7590,21 @@ paths:
       tags:
         - Container Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: qfy5ueb8cyebe
-  '/container/{containerId}/advancedSettings':
+  "/container/{containerId}/advancedSettings":
     get:
       summary: Get advanced settings
       description: |
@@ -7612,88 +7612,88 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)
       operationId: getContainerAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Configuration
       responses:
-        '200':
+        "200":
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ContainerAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editContainerAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerAdvancedSettings'
+              $ref: "#/components/schemas/ContainerAdvancedSettings"
       responses:
-        '201':
+        "201":
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerAdvancedSettings'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/deploy':
+                $ref: "#/components/schemas/ContainerAdvancedSettings"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/deploy":
     post:
       summary: Deploy container
       description: You must provide a container image tag
       operationId: deployContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerDeployRequest'
+              $ref: "#/components/schemas/ContainerDeployRequest"
       responses:
-        '202':
+        "202":
           description: Deploy container
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/container/{containerId}/uninstall':
+  "/container/{containerId}/uninstall":
     post:
       summary: Uninstall container
       description: Delete the resources of the container but keep Qovery configuration
       operationId: uninstallContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Actions
       requestBody:
@@ -7703,23 +7703,23 @@ paths:
               type: object
               properties: {}
       responses:
-        '202':
-          description: 'Delete the compute and data of the service, but keep Qovery configuration'
+        "202":
+          description: "Delete the compute and data of the service, but keep Qovery configuration"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '204':
+                $ref: "#/components/schemas/Status"
+        "204":
           description: No deployment has been triggered
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: tyqhmv3tdihmm
@@ -7729,155 +7729,155 @@ paths:
         name: containerId
         in: path
         required: true
-  '/container/{containerId}/stop':
+  "/container/{containerId}/stop":
     post:
       summary: Stop container
       operationId: stopContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Actions
       responses:
-        '202':
+        "202":
           description: Container stop has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Container is already stopped or an operation is in progress
-  '/container/{containerId}/redeploy':
+  "/container/{containerId}/redeploy":
     post:
       summary: Redeploy container
       operationId: redeployContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Actions
       responses:
-        '202':
+        "202":
           description: Container redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/container/{containerId}/restart-service':
+  "/container/{containerId}/restart-service":
     post:
       summary: Reboot container
       operationId: rebootContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Actions
       responses:
-        '202':
+        "202":
           description: Container reboot has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/container/{containerId}/environmentVariable':
+  "/container/{containerId}/environmentVariable":
     get:
       summary: List environment variables
       operationId: listContainerEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Environment Variable
       responses:
-        '200':
+        "200":
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariableResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnvironmentVariableResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add an environment variable to the container
       description: |
         - Add an environment variable to the container.
       operationId: createContainerEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableRequest'
+              $ref: "#/components/schemas/EnvironmentVariableRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/environmentVariable/import':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/environmentVariable/import":
     post:
       summary: Import variables
-      description: 'Import environment variables in a defined scope, with a defined visibility.'
+      description: "Import environment variables in a defined scope, with a defined visibility."
       operationId: importContainerEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableImportRequest'
+              $ref: "#/components/schemas/VariableImportRequest"
       responses:
-        '201':
+        "201":
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableImport'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/environmentVariable/{environmentVariableId}':
+                $ref: "#/components/schemas/VariableImport"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/environmentVariable/{environmentVariableId}":
     delete:
       summary: Delete an environment variable from a container
       description: |
@@ -7886,19 +7886,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteContainerEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Container Environment Variable
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an environment variable belonging to the container
       description: |
@@ -7908,8 +7908,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editContainerEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Container Environment Variable
       requestBody:
@@ -7917,23 +7917,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
+              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/environmentVariable/{environmentVariableId}/override':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/environmentVariable/{environmentVariableId}/override":
     post:
       summary: Create an environment variable override at the container level
       description: |
@@ -7944,31 +7944,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createContainerEnvironmentVariableOverride
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/environmentVariable/{environmentVariableId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/environmentVariable/{environmentVariableId}/alias":
     post:
       summary: Create an environment variable alias at the container level
       description: |
@@ -7980,82 +7980,82 @@ paths:
         - You can't create an alias on an alias
       operationId: createContainerEnvironmentVariableAlias
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Container Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/secret':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/secret":
     get:
       summary: List container secrets
-      description: 'Secrets are like environment variables, but they are secured and can''t be revealed.'
+      description: "Secrets are like environment variables, but they are secured and can't be revealed."
       operationId: listContainerSecrets
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Secret
       responses:
-        '200':
+        "200":
           description: List secrets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/SecretResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add a secret to the container
       description: |
         - Add a secret to the container.
       operationId: createContainerSecret
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretRequest'
+              $ref: "#/components/schemas/SecretRequest"
       responses:
-        '201':
+        "201":
           description: Add a secret
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/secret/{secretId}':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/secret/{secretId}":
     delete:
       summary: Delete a secret from an container
       description: |
@@ -8064,19 +8064,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well
       operationId: deleteContainerSecret
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Container Secret
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a secret belonging to the container
       description: |
@@ -8086,8 +8086,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editContainerSecret
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Container Secret
       requestBody:
@@ -8095,23 +8095,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretEditRequest'
+              $ref: "#/components/schemas/SecretEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/secret/{secretId}/override':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/secret/{secretId}/override":
     post:
       summary: Create a secret override at the container level
       description: |
@@ -8122,31 +8122,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createContainerSecretOverride
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Container Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/secret/{secretId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/secret/{secretId}/alias":
     post:
       summary: Create a secret alias at the container level
       description: |
@@ -8158,568 +8158,568 @@ paths:
         - You can't create an alias on an alias
       operationId: createContainerSecretAlias
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Container Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/customDomain':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/customDomain":
     get:
       summary: List container custom domains
       operationId: listContainerCustomDomain
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Custom Domain
       responses:
-        '200':
+        "200":
           description: List custom domains
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomainResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CustomDomainResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add custom domain to the container.
       description: Add a custom domain to this container in order not to use qovery autogenerated domain
       operationId: createContainerCustomDomain
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomDomainRequest'
+              $ref: "#/components/schemas/CustomDomainRequest"
       responses:
-        '201':
+        "201":
           description: Added container custom domain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/customDomain/{customDomainId}':
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/customDomain/{customDomainId}":
     put:
       summary: Edit a Custom Domain
       description: To edit a Custom Domain  you must have the project user permission
       operationId: editContainerCustomDomain
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Container Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomDomainRequest'
+              $ref: "#/components/schemas/CustomDomainRequest"
       responses:
-        '200':
+        "200":
           description: Edit a CustomDomain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a Custom Domain
       description: To delete an CustomDomain you must have the project user permission
       operationId: deleteContainerCustomDomain
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Container Custom Domain
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/customDomain/{customDomainId}/status':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/customDomain/{customDomainId}/status":
     get:
       summary: Get Custom Domain status
       operationId: getContainerCustomDomainStatus
       parameters:
-        - $ref: '#/components/parameters/containerId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/containerId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Container Custom Domain
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/checkCustomDomain':
+                $ref: "#/components/schemas/CustomDomain"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/checkCustomDomain":
     get:
       summary: Check Container Custom Domain
       operationId: checkContainerCustomDomain
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Custom Domain
       responses:
-        '200':
+        "200":
           description: Check Container Custom Domain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckedCustomDomainsResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/log':
+                $ref: "#/components/schemas/CheckedCustomDomainsResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/log":
     get:
       summary: List logs
       operationId: listContainerLog
       description: This will list the last 1000 logs of the container
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Logs
       responses:
-        '200':
+        "200":
           description: List logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/network':
+                $ref: "#/components/schemas/LogResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/network":
     get:
       summary: Get Container Network information
       description: Get status of the container network settings.
       operationId: getContainerNetwork
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Configuration
       responses:
-        '200':
+        "200":
           description: Network information
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerNetwork'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ContainerNetwork"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit Container Network
       description: Edit the Network settings of the container.
       operationId: editContainerNetwork
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerNetworkRequest'
+              $ref: "#/components/schemas/ContainerNetworkRequest"
       responses:
-        '201':
+        "201":
           description: Updated container network setting
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerNetwork'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/link':
+                $ref: "#/components/schemas/ContainerNetwork"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/link":
     get:
       summary: List all URLs of the container
       description: This will return all the custom domains and Qovery autogenerated domain for the given container
       operationId: listContainerLinks
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Container Main Calls
       responses:
-        '200':
+        "200":
           description: List links
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LinkResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/container/{containerId}/clone':
+                $ref: "#/components/schemas/LinkResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/container/{containerId}/clone":
     post:
       summary: Clone container
       description: This will create a new container with the same configuration on the targeted environment Id.
       operationId: cloneContainer
       parameters:
-        - $ref: '#/components/parameters/containerId'
+        - $ref: "#/components/parameters/containerId"
       tags:
         - Containers
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneServiceRequest'
+              $ref: "#/components/schemas/CloneServiceRequest"
       responses:
-        '202':
+        "202":
           description: Container clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/ContainerResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/environment/{environmentId}/database':
+  "/environment/{environmentId}/database":
     get:
       summary: List environment databases
       operationId: listDatabase
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Databases
       responses:
-        '200':
+        "200":
           description: List databases
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DatabaseResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DatabaseResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a database
       operationId: createDatabase
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Databases
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DatabaseRequest'
+              $ref: "#/components/schemas/DatabaseRequest"
       responses:
-        '201':
-          description: 'Create database '
+        "201":
+          description: "Create database "
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Database'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Database"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Database name within the environment is already taken
-  '/environment/{environmentId}/database/status':
+  "/environment/{environmentId}/database/status":
     get:
       summary: List all environment databases statuses
       description: Returns a list of databases with only their id and status.
       operationId: getEnvironmentDatabaseStatus
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Databases
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}':
+                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}":
     get:
       summary: Get database by ID
       operationId: getDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       responses:
-        '200':
+        "200":
           description: Get database  by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Database'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/Database"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
-      summary: 'Edit a database '
+      summary: "Edit a database "
       description: To edit a database  you must have the admin permission
       operationId: editDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DatabaseEditRequest'
+              $ref: "#/components/schemas/DatabaseEditRequest"
       responses:
-        '200':
-          description: 'Edit a database '
+        "200":
+          description: "Edit a database "
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Database'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Database"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Database  name within the environment is already taken
     delete:
-      summary: 'Delete a database '
+      summary: "Delete a database "
       description: To delete a database you must have the admin permission
       operationId: deleteDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/status':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/status":
     get:
       summary: Get database status
       operationId: getDatabaseStatus
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/version':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/version":
     get:
       summary: List eligible versions for the database
       operationId: listDatabaseVersion
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       responses:
-        '200':
+        "200":
           description: List eligible versions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/masterCredentials':
+                $ref: "#/components/schemas/VersionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/masterCredentials":
     get:
       summary: Get master credentials of the database
       operationId: getDatabaseMasterCredentials
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       responses:
-        '200':
+        "200":
           description: get credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Credentials'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/Credentials"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit database  master credentials
       operationId: editDatabaseCredentials
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CredentialsRequest'
+              $ref: "#/components/schemas/CredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Edit database credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Credentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/application':
+                $ref: "#/components/schemas/Credentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/application":
     get:
       summary: List applications using the database
       operationId: listDatabaseApplication
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Application
       responses:
-        '200':
+        "200":
           description: List linked applications
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApplicationResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/application/{targetApplicationId}':
+                $ref: "#/components/schemas/ApplicationResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/application/{targetApplicationId}":
     delete:
-      summary: 'Remove an application from this database '
+      summary: "Remove an application from this database "
       operationId: removeApplicationFromDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
-        - $ref: '#/components/parameters/targetApplicationId'
+        - $ref: "#/components/parameters/databaseId"
+        - $ref: "#/components/parameters/targetApplicationId"
       tags:
         - Database Application
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/redeploy':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/redeploy":
     post:
       summary: Redeploy database
       operationId: redeployDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
         - in: query
           name: applyImmediately
           schema:
@@ -8729,72 +8729,72 @@ paths:
       tags:
         - Database Actions
       responses:
-        '202':
+        "202":
           description: Database redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/database/{databaseId}/restart-service':
+  "/database/{databaseId}/restart-service":
     post:
       summary: Retart database
       operationId: rebootDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Actions
       responses:
-        '202':
+        "202":
           description: Database reboot has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/database/{databaseId}/stop':
+  "/database/{databaseId}/stop":
     post:
       summary: Stop database
       operationId: stopDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Actions
       responses:
-        '202':
+        "202":
           description: Database  stop has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/database/{databaseId}/deploy':
+  "/database/{databaseId}/deploy":
     post:
-      summary: 'Deploy database '
+      summary: "Deploy database "
       operationId: deployDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
         - in: query
           name: applyImmediately
           schema:
@@ -8804,44 +8804,44 @@ paths:
       tags:
         - Database Actions
       responses:
-        '202':
-          description: 'Deploy database '
+        "202":
+          description: "Deploy database "
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/database/{databaseId}/uninstall':
+  "/database/{databaseId}/uninstall":
     post:
       summary: Uninstall database
       operationId: uninstallDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Database Actions
       responses:
-        '202':
-          description: 'Delete the compute and data of the service, but keep Qovery configuration'
+        "202":
+          description: "Delete the compute and data of the service, but keep Qovery configuration"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '204':
+                $ref: "#/components/schemas/Status"
+        "204":
           description: No deployment has been triggered
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: dn8xf9tcthfqn
@@ -8857,37 +8857,37 @@ paths:
         name: databaseId
         in: path
         required: true
-  '/database/{databaseId}/deploymentHistory':
+  "/database/{databaseId}/deploymentHistory":
     get:
       summary: List database deploys
       description: By default it returns the 20 last results. The response is paginated.
       operationId: listDatabaseDeploymentHistory
       parameters:
-        - $ref: '#/components/parameters/databaseId'
-        - $ref: '#/components/parameters/startId'
+        - $ref: "#/components/parameters/databaseId"
+        - $ref: "#/components/parameters/startId"
       tags:
         - Database Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/PaginationData'
+                  - $ref: "#/components/schemas/PaginationData"
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: '#/components/schemas/DeploymentHistoryDatabase'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/deploymentHistoryV2':
+                          $ref: "#/components/schemas/DeploymentHistoryDatabase"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/deploymentHistoryV2":
     get:
       summary: List database deploys
       description: By default it returns the 20 last results. The response is paginated.
@@ -8903,18 +8903,18 @@ paths:
       tags:
         - Database Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: mzftpr17opgzp
     parameters:
@@ -8924,102 +8924,102 @@ paths:
         name: databaseId
         in: path
         required: true
-  '/database/{databaseId}/backup':
+  "/database/{databaseId}/backup":
     get:
       summary: List database  backups
-      description: 'By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter'
+      description: "By default it returns the 20 last results. The response is paginated. In order to request the next page, you can use the startId query parameter"
       operationId: listDatabaseBackup
       parameters:
-        - $ref: '#/components/parameters/databaseId'
-        - $ref: '#/components/parameters/startId'
+        - $ref: "#/components/parameters/databaseId"
+        - $ref: "#/components/parameters/startId"
       tags:
         - Backups
       responses:
-        '200':
+        "200":
           description: List backups
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BackupPaginatedResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/BackupPaginatedResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
-      summary: 'Add a backup to the Database '
+      summary: "Add a backup to the Database "
       operationId: addBackupDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Backups
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BackupRequest'
+              $ref: "#/components/schemas/BackupRequest"
       responses:
-        '201':
+        "201":
           description: Added backup
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Backup'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/backup/{backupId}':
+                $ref: "#/components/schemas/Backup"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/backup/{backupId}":
     delete:
       summary: Remove database  backup
       operationId: removeDatabaseBackup
       parameters:
-        - $ref: '#/components/parameters/databaseId'
-        - $ref: '#/components/parameters/backupId'
+        - $ref: "#/components/parameters/databaseId"
+        - $ref: "#/components/parameters/backupId"
       tags:
         - Backups
       responses:
-        '204':
-          $ref: '#/components/responses/204'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/database/{databaseId}/clone':
+        "204":
+          $ref: "#/components/responses/204"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/database/{databaseId}/clone":
     post:
       summary: Clone database
       description: This will create a new database with the same configuration on the targeted environment Id.
       operationId: cloneDatabase
       parameters:
-        - $ref: '#/components/parameters/databaseId'
+        - $ref: "#/components/parameters/databaseId"
       tags:
         - Databases
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneServiceRequest'
+              $ref: "#/components/schemas/CloneServiceRequest"
       responses:
-        '202':
+        "202":
           description: Database clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Database'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Database"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
   /account:
     get:
@@ -9028,14 +9028,14 @@ paths:
       tags:
         - Account Info
       responses:
-        '200':
+        "200":
           description: Get account info
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AccountInfo'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/AccountInfo"
+        "401":
+          $ref: "#/components/responses/401"
     put:
       summary: Edit account information
       operationId: editAccountInformation
@@ -9045,18 +9045,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AccountInfoEditRequest'
+              $ref: "#/components/schemas/AccountInfoEditRequest"
       responses:
-        '200':
+        "200":
           description: Edit application
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AccountInfo'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/AccountInfo"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
   /account/gitAuthProvider:
     get:
       deprecated: true
@@ -9065,14 +9065,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        '200':
+        "200":
           description: Get account
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitAuthProviderResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitAuthProviderResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/github/repository:
     get:
       deprecated: true
@@ -9081,14 +9081,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        '200':
+        "200":
           description: Get github repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/github/repository/branch:
     get:
       deprecated: true
@@ -9103,14 +9103,14 @@ paths:
             type: string
           description: The name of the repository where to retrieve the branches
       responses:
-        '200':
+        "200":
           description: Get github repository branches
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/gitlab/repository:
     get:
       deprecated: true
@@ -9119,14 +9119,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        '200':
+        "200":
           description: Get gitlab repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/gitlab/repository/branch:
     get:
       deprecated: true
@@ -9141,14 +9141,14 @@ paths:
             type: string
           description: The name of the repository to retrieve the branches
       responses:
-        '200':
+        "200":
           description: Get gitlab repository branches
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/bitbucket/repository:
     get:
       deprecated: true
@@ -9157,14 +9157,14 @@ paths:
       tags:
         - Git repositories
       responses:
-        '200':
+        "200":
           description: Get bitbucket repositories
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitRepositoryResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/bitbucket/repository/branch:
     get:
       deprecated: true
@@ -9179,14 +9179,14 @@ paths:
             type: string
           description: The name of the repository where to retrieve the branches
       responses:
-        '200':
+        "200":
           description: Get bitbucket repository branches
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitRepositoryBranchResponseList'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/GitRepositoryBranchResponseList"
+        "401":
+          $ref: "#/components/responses/401"
   /account/referral:
     get:
       summary: Get your referral information
@@ -9194,14 +9194,14 @@ paths:
       tags:
         - Referral & Rewards
       responses:
-        '200':
+        "200":
           description: Get referral info
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Referral'
-        '401':
-          $ref: '#/components/responses/401'
+                $ref: "#/components/schemas/Referral"
+        "401":
+          $ref: "#/components/responses/401"
   /account/rewardClaim:
     post:
       summary: Claim a reward
@@ -9213,9 +9213,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RewardClaim'
+              $ref: "#/components/schemas/RewardClaim"
       responses:
-        '200':
+        "200":
           description: Claim reward
   /admin/userSignUp:
     get:
@@ -9225,18 +9225,18 @@ paths:
       tags:
         - User Sign Up
       responses:
-        '200':
-          description: 'If a previous sign up request for the same user has been found, the information is returned in the payload'
+        "200":
+          description: "If a previous sign up request for the same user has been found, the information is returned in the payload"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SignUp'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/SignUp"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Send Sign Up request
       description: Send a Sign Up request containing the user information
@@ -9247,266 +9247,266 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SignUpRequest'
+              $ref: "#/components/schemas/SignUpRequest"
       responses:
-        '200':
+        "200":
           description: Sign up request stored
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/helm':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/helm":
     get:
       summary: List helms
       operationId: listHelms
       parameters:
-        - $ref: '#/components/parameters/environmentId'
-        - $ref: '#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1'
+        - $ref: "#/components/parameters/environmentId"
+        - $ref: "#/paths/~1environment~1%7BenvironmentId%7D~1job/get/parameters/1"
       tags:
         - Helms
       responses:
-        '200':
+        "200":
           description: List helms
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a helm
       operationId: createHelm
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Helms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmRequest'
+              $ref: "#/components/schemas/HelmRequest"
       responses:
-        '201':
+        "201":
           description: Create helm
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/HelmResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Helm name within the environment is already taken
-  '/environment/{environmentId}/helmDefaultValues':
+  "/environment/{environmentId}/helmDefaultValues":
     post:
       summary: Get helm default values
       operationId: createHelmDefaultValues
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Helms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmDefaultValuesRequest'
+              $ref: "#/components/schemas/HelmDefaultValuesRequest"
       responses:
-        '201':
+        "201":
           description: helm values
           content:
             text/plain:
               schema:
                 type: string
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/helm/status':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/helm/status":
     get:
       summary: List all environment helm statuses
       description: Returns a list of helms with only their id and status.
       operationId: getEnvironmentHelmStatus
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Helms
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}':
+                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}":
     get:
       summary: Get helm by ID
       operationId: getHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Main Calls
       responses:
-        '200':
+        "200":
           description: Get helm by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit helm
       description: |
         - To edit the helm you must have the admin permission.
       operationId: editHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmRequest'
+              $ref: "#/components/schemas/HelmRequest"
       responses:
-        '200':
+        "200":
           description: Edit helm
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/HelmResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Helm name within the environment is already taken
     delete:
       summary: Delete helm
       description: To delete the helm you must have the admin permission
       operationId: deleteHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/commit':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/commit":
     get:
       summary: List last helm commits
       description: Returns list of the last 100 commits made on the repository linked to helm
       operationId: listHelmCommit
       parameters:
-        - $ref: '#/components/parameters/helmId'
-        - $ref: '#/components/parameters/helmOf'
+        - $ref: "#/components/parameters/helmId"
+        - $ref: "#/components/parameters/helmOf"
       tags:
         - Helm Main Calls
       responses:
-        '200':
+        "200":
           description: List Helm commits
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommitResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/advancedSettings':
+                $ref: "#/components/schemas/CommitResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/advancedSettings":
     get:
       summary: Get advanced settings
       description: Get list and values of the advanced settings of the helm.
       operationId: getHelmAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Configuration
       responses:
-        '200':
+        "200":
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editHelmAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmAdvancedSettings'
+              $ref: "#/components/schemas/HelmAdvancedSettings"
       responses:
-        '201':
+        "201":
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmAdvancedSettings'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/deploy':
+                $ref: "#/components/schemas/HelmAdvancedSettings"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/deploy":
     post:
       summary: Deploy helm
       description: You must provide a git commit id or a helm version depending on the source location of your code (git vs helm repository).
       operationId: deployHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
         - name: forceEvent
           in: query
           required: false
@@ -9514,38 +9514,38 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned helm hasn't the target event provided, the helm won't be deployed.
           schema:
-            $ref: '#/components/schemas/HelmForceEvent'
+            $ref: "#/components/schemas/HelmForceEvent"
       tags:
         - Helm Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmDeployRequest'
+              $ref: "#/components/schemas/HelmDeployRequest"
       responses:
-        '202':
+        "202":
           description: Deploy helm
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/helm/{helmId}/uninstall':
+  "/helm/{helmId}/uninstall":
     post:
       summary: Uninstall helm
       description: Delete the resources of the helm but keep Qovery configuration
       operationId: uninstallHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Actions
       requestBody:
@@ -9554,23 +9554,23 @@ paths:
             schema:
               type: object
       responses:
-        '202':
-          description: 'Delete the compute and data of the service, but keep Qovery configuration'
+        "202":
+          description: "Delete the compute and data of the service, but keep Qovery configuration"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '204':
+                $ref: "#/components/schemas/Status"
+        "204":
           description: No deployment has been triggered
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: cdps3bcv0l0wa
@@ -9580,12 +9580,12 @@ paths:
         name: helmId
         in: path
         required: true
-  '/helm/{helmId}/redeploy':
+  "/helm/{helmId}/redeploy":
     post:
       summary: Redeploy helm
       operationId: redeployHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
         - name: forceEvent
           in: query
           required: false
@@ -9593,98 +9593,98 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned helm hasn't the target event provided, the helm won't be deployed.
           schema:
-            $ref: '#/components/schemas/HelmForceEvent'
+            $ref: "#/components/schemas/HelmForceEvent"
       tags:
         - Helm Actions
       responses:
-        '202':
+        "202":
           description: Helm redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/helm/{helmId}/stop':
+  "/helm/{helmId}/stop":
     post:
       summary: Stop helm
       operationId: stopHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Actions
       responses:
-        '202':
+        "202":
           description: Helm stop has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Helm is already stopped or an operation is in progress
-  '/helm/{helmId}/status':
+  "/helm/{helmId}/status":
     get:
       summary: Get helm status
       operationId: getHelmStatus
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Main Calls
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/deploymentHistory':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/deploymentHistory":
     get:
       summary: List helm deployments
       description: Returns the 20 last helm deployments
       operationId: listHelmDeploymentHistory
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/PaginationData'
+                  - $ref: "#/components/schemas/PaginationData"
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: '#/components/schemas/DeploymentHistoryHelmResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/deploymentHistoryV2':
+                          $ref: "#/components/schemas/DeploymentHistoryHelmResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/deploymentHistoryV2":
     get:
       summary: List helm deployments
       description: Returns the 20 last helm deployments
@@ -9700,18 +9700,18 @@ paths:
       tags:
         - Helm Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: fn9qd5qn7dhdv
     parameters:
@@ -9721,416 +9721,416 @@ paths:
         name: helmId
         in: path
         required: true
-  '/helm/{helmId}/deploymentRestriction':
+  "/helm/{helmId}/deploymentRestriction":
     get:
       summary: Get helm deployment restrictions
       description: Get helm deployment restrictions
       operationId: getHelmDeploymentRestrictions
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Deployment Restriction
       responses:
-        '200':
+        "200":
           description: Get helm deployment restrictions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmDeploymentRestrictionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmDeploymentRestrictionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a helm deployment restriction
       description: Create a helm deployment restriction
       operationId: createHelmDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/HelmDeploymentRestrictionRequest"
       responses:
-        '201':
+        "201":
           description: Added an helm deployment restriction
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmDeploymentRestrictionResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '409':
+                $ref: "#/components/schemas/HelmDeploymentRestrictionResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "409":
           description: A Helm deployment restriction with same properties already exists for this helm
-  '/helm/{helmId}/deploymentRestriction/{deploymentRestrictionId}':
+  "/helm/{helmId}/deploymentRestriction/{deploymentRestrictionId}":
     put:
       summary: Edit a helm deployment restriction
       description: Edit a helm deployment restriction
       operationId: editHelmDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/helmId'
-        - $ref: '#/components/parameters/deploymentRestrictionId'
+        - $ref: "#/components/parameters/helmId"
+        - $ref: "#/components/parameters/deploymentRestrictionId"
       tags:
         - Helm Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/HelmDeploymentRestrictionRequest"
       responses:
-        '200':
+        "200":
           description: Edit a helm deployment restriction
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmDeploymentRestrictionResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/HelmDeploymentRestrictionResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a helm deployment restriction
       description: Delete a helm deployment restriction
       operationId: deleteHelmDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/helmId'
-        - $ref: '#/components/parameters/deploymentRestrictionId'
+        - $ref: "#/components/parameters/helmId"
+        - $ref: "#/components/parameters/deploymentRestrictionId"
       tags:
         - Helm Deployment Restriction
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/clone':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/clone":
     post:
       summary: Clone helm
       description: This will create a new helm with the same configuration on the targeted environment Id.
       operationId: cloneHelm
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneServiceRequest'
+              $ref: "#/components/schemas/CloneServiceRequest"
       responses:
-        '202':
+        "202":
           description: Helm clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/HelmResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/helm/{helmId}/link':
+  "/helm/{helmId}/link":
     get:
       summary: List all URLs of the helm
       description: This will return all the custom domains and Qovery autogenerated domain for the given helm
       operationId: listHelmLinks
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Main Calls
       responses:
-        '200':
+        "200":
           description: List links
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LinkResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/customDomain':
+                $ref: "#/components/schemas/LinkResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/customDomain":
     get:
       summary: List helm custom domains
       description: List the custom domains of this helm
       operationId: listHelmCustomDomain
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Custom Domain
       responses:
-        '200':
+        "200":
           description: List custom domains
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomainResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CustomDomainResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add custom domain to the helm.
       description: Add a custom domain to this helm in order not to use qovery autogenerated domain
       operationId: createHelmCustomDomain
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomDomainRequest'
+              $ref: "#/components/schemas/CustomDomainRequest"
       responses:
-        '201':
+        "201":
           description: Added helm custom domain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/customDomain/{customDomainId}':
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/customDomain/{customDomainId}":
     put:
       summary: Edit a Custom Domain
       description: To edit a Custom Domain you must have the project user permission
       operationId: editHelmCustomDomain
       parameters:
-        - $ref: '#/components/parameters/helmId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/helmId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Helm Custom Domain
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomDomainRequest'
+              $ref: "#/components/schemas/CustomDomainRequest"
       responses:
-        '200':
+        "200":
           description: Edit a CustomDomain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a Custom Domain
       description: To delete an CustomDomain you must have the project user permission
       operationId: deleteHelmCustomDomain
       parameters:
-        - $ref: '#/components/parameters/helmId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/helmId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Helm Custom Domain
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     get:
       summary: Get a Custom Domain
       description: Get a custom domain
       operationId: getHelmCustomDomain
       parameters:
-        - $ref: '#/components/parameters/helmId'
-        - $ref: '#/components/parameters/customDomainId'
+        - $ref: "#/components/parameters/helmId"
+        - $ref: "#/components/parameters/customDomainId"
       tags:
         - Helm Custom Domain
       responses:
-        '200':
+        "200":
           description: Get a CustomDomain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomDomain'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/helm/{helmId}/checkCustomDomain':
+                $ref: "#/components/schemas/CustomDomain"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/helm/{helmId}/checkCustomDomain":
     get:
       summary: Check Helm Custom Domain
       operationId: checkHelmCustomDomain
       parameters:
-        - $ref: '#/components/parameters/helmId'
+        - $ref: "#/components/parameters/helmId"
       tags:
         - Helm Custom Domain
       responses:
-        '200':
+        "200":
           description: Check Helm Custom Domain
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckedCustomDomainsResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/checkDockerfile':
+                $ref: "#/components/schemas/CheckedCustomDomainsResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/checkDockerfile":
     post:
       summary: Check dockerfile configuration is correct
       operationId: checkDockerfile
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DockerfileCheckRequest'
+              $ref: "#/components/schemas/DockerfileCheckRequest"
       responses:
-        '200':
+        "200":
           description: Information about the dockerfile
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerfileCheckResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/checkHelmRepository':
+                $ref: "#/components/schemas/DockerfileCheckResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/checkHelmRepository":
     post:
       summary: Check helm repository configuration is correct
       operationId: checkHelmRepository
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HelmCheckRequest'
+              $ref: "#/components/schemas/HelmCheckRequest"
       responses:
-        '200':
+        "200":
           description: Information about the helm repository
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmCheckResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/checkContainerImage':
+                $ref: "#/components/schemas/HelmCheckResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/checkContainerImage":
     post:
       summary: Check container image configuration is correct
       operationId: checkContainerImage
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContainerImageCheckRequest'
+              $ref: "#/components/schemas/ContainerImageCheckRequest"
       responses:
-        '200':
+        "200":
           description: Information about the image
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerImageCheckResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/checkGitFile':
+                $ref: "#/components/schemas/ContainerImageCheckResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/checkGitFile":
     post:
       summary: Check git file configuration is correct
       operationId: checkGitFile
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GitFileCheckRequest'
+              $ref: "#/components/schemas/GitFileCheckRequest"
       responses:
-        '200':
+        "200":
           description: Information about the image
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitFileCheckResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/job':
+                $ref: "#/components/schemas/GitFileCheckResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/job":
     get:
       summary: List jobs
       operationId: listJobs
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
         - name: toUpdate
           in: query
           description: return (or not) results that must be updated
@@ -10141,139 +10141,139 @@ paths:
       tags:
         - Jobs
       responses:
-        '200':
+        "200":
           description: List jobs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/JobResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a job
       operationId: createJob
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Jobs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobRequest'
+              $ref: "#/components/schemas/JobRequest"
       responses:
-        '201':
+        "201":
           description: Create job
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/JobResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Job name within the environment is already taken
-  '/environment/{environmentId}/job/status':
+  "/environment/{environmentId}/job/status":
     get:
       summary: List all environment job statuses
       description: Returns a list of jobs with only their id and status.
       operationId: getEnvironmentJobStatus
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Jobs
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReferenceObjectStatusResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}':
+                $ref: "#/components/schemas/ReferenceObjectStatusResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}":
     get:
       summary: Get job by ID
       operationId: getJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Main Calls
       responses:
-        '200':
+        "200":
           description: Get job by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/JobResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit job
       description: |
         - To edit the job you must have the admin permission.
       operationId: editJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobRequest'
+              $ref: "#/components/schemas/JobRequest"
       responses:
-        '200':
+        "200":
           description: Edit job
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/JobResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Job name within the environment is already taken
     delete:
       summary: Delete job
       description: To delete the job you must have the admin permission
       operationId: deleteJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/advancedSettings':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/advancedSettings":
     get:
       summary: Get advanced settings
       description: |
@@ -10281,57 +10281,57 @@ paths:
         Default values for each setting are available in [our documentation](https://hub.qovery.com/docs/using-qovery/configuration/advanced-settings/)
       operationId: getJobAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Configuration
       responses:
-        '200':
+        "200":
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/JobAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit advanced settings
       description: Edit advanced settings by returning table of advanced settings.
       operationId: editJobAdvancedSettings
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Configuration
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobAdvancedSettings'
+              $ref: "#/components/schemas/JobAdvancedSettings"
       responses:
-        '201':
+        "201":
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobAdvancedSettings'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/deploy':
+                $ref: "#/components/schemas/JobAdvancedSettings"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/deploy":
     post:
       summary: Deploy job
       description: You must provide a git commit id or an image tag depending on the source location of your code (git vs image repository).
       operationId: deployJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
         - name: forceEvent
           in: query
           required: false
@@ -10339,38 +10339,38 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned job hasn't the target event provided, the job won't be deployed.
           schema:
-            $ref: '#/components/schemas/JobForceEvent'
+            $ref: "#/components/schemas/JobForceEvent"
       tags:
         - Job Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobDeployRequest'
+              $ref: "#/components/schemas/JobDeployRequest"
       responses:
-        '202':
+        "202":
           description: Deploy job
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/job/{jobId}/uninstall':
+  "/job/{jobId}/uninstall":
     post:
       summary: Uninstall job
       description: Delete the resources of the job but keep Qovery configuration
       operationId: uninstallJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Actions
       requestBody:
@@ -10380,23 +10380,23 @@ paths:
               type: object
               properties: {}
       responses:
-        '202':
-          description: 'Delete the compute and data of the service, but keep Qovery configuration'
+        "202":
+          description: "Delete the compute and data of the service, but keep Qovery configuration"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '204':
+                $ref: "#/components/schemas/Status"
+        "204":
           description: No deployment has been triggered
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: s4xgct6hdxymt
@@ -10406,12 +10406,12 @@ paths:
         name: jobId
         in: path
         required: true
-  '/job/{jobId}/redeploy':
+  "/job/{jobId}/redeploy":
     post:
       summary: Redeploy job
       operationId: redeployJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
         - name: forceEvent
           in: query
           required: false
@@ -10419,42 +10419,42 @@ paths:
             When filled, it indicates the target event to be deployed.  
             If the concerned job hasn't the target event provided, the job won't be deployed.
           schema:
-            $ref: '#/components/schemas/JobForceEvent'
+            $ref: "#/components/schemas/JobForceEvent"
       tags:
         - Job Actions
       responses:
-        '202':
+        "202":
           description: Job redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/terraform/{terraformId}/redeploy':
+  "/terraform/{terraformId}/redeploy":
     post:
       summary: Redeploy terraform
       operationId: redeployTerraform
       responses:
-        '202':
+        "202":
           description: Terraform redeploy has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: 69fa5itbg5w43
@@ -10466,80 +10466,80 @@ paths:
         name: terraformId
         in: path
         required: true
-  '/job/{jobId}/stop':
+  "/job/{jobId}/stop":
     post:
       summary: Stop job
       operationId: stopJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Actions
       responses:
-        '202':
+        "202":
           description: Job stop has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Job is already stopped or an operation is in progress
-  '/job/{jobId}/status':
+  "/job/{jobId}/status":
     get:
       summary: Get job status
       operationId: getJobStatus
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Main Calls
       responses:
-        '200':
+        "200":
           description: Get status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/deploymentHistory':
+                $ref: "#/components/schemas/Status"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/deploymentHistory":
     get:
       summary: List job deployments
       description: Returns the 20 last job deployments
       operationId: listJobDeploymentHistory
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/PaginationData'
+                  - $ref: "#/components/schemas/PaginationData"
                   - type: object
                     properties:
                       results:
                         type: array
                         items:
-                          $ref: '#/components/schemas/DeploymentHistoryJobResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/deploymentHistoryV2':
+                          $ref: "#/components/schemas/DeploymentHistoryJobResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/deploymentHistoryV2":
     get:
       summary: List job deployments
       description: Returns the 20 last job deployments
@@ -10555,18 +10555,18 @@ paths:
       tags:
         - Job Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: mcu1nwkl3q2bb
     parameters:
@@ -10576,184 +10576,184 @@ paths:
         name: jobId
         in: path
         required: true
-  '/job/{jobId}/deploymentRestriction':
+  "/job/{jobId}/deploymentRestriction":
     get:
       summary: Get job deployment restrictions
       description: Get job deployment restrictions
       operationId: getJobDeploymentRestrictions
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Deployment Restriction
       responses:
-        '200':
+        "200":
           description: Get job deployment restrictions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobDeploymentRestrictionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/JobDeploymentRestrictionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a job deployment restriction
       description: Create a job deployment restriction
       operationId: createJobDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/JobDeploymentRestrictionRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobDeploymentRestrictionResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '409':
+                $ref: "#/components/schemas/JobDeploymentRestrictionResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "409":
           description: A Job deployment restriction with same properties already exists for this job
-  '/job/{jobId}/deploymentRestriction/{deploymentRestrictionId}':
+  "/job/{jobId}/deploymentRestriction/{deploymentRestrictionId}":
     put:
       summary: Edit a job deployment restriction
       description: Edit a job deployment restriction
       operationId: editJobDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/deploymentRestrictionId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/deploymentRestrictionId"
       tags:
         - Job Deployment Restriction
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/JobDeploymentRestrictionRequest"
       responses:
-        '200':
+        "200":
           description: Edit a job deployment restriction
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobDeploymentRestrictionResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/JobDeploymentRestrictionResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a job deployment restriction
       description: Delete a job deployment restriction
       operationId: deleteJobDeploymentRestriction
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/deploymentRestrictionId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/deploymentRestrictionId"
       tags:
         - Job Deployment Restriction
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/environmentVariable':
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/environmentVariable":
     get:
       summary: List environment variables
       operationId: listJobEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Environment Variable
       responses:
-        '200':
+        "200":
           description: List environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariableResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnvironmentVariableResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add an environment variable to the job
       description: |
         - Add an environment variable to the job.
       operationId: createJobEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableRequest'
+              $ref: "#/components/schemas/EnvironmentVariableRequest"
       responses:
-        '201':
+        "201":
           description: Added an environment variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/environmentVariable/import':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/environmentVariable/import":
     post:
       summary: Import variables
-      description: 'Import environment variables in a defined scope, with a defined visibility.'
+      description: "Import environment variables in a defined scope, with a defined visibility."
       operationId: importJobEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableImportRequest'
+              $ref: "#/components/schemas/VariableImportRequest"
       responses:
-        '201':
+        "201":
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableImport'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/environmentVariable/{environmentVariableId}':
+                $ref: "#/components/schemas/VariableImport"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/environmentVariable/{environmentVariableId}":
     delete:
       summary: Delete an environment variable from a job
       description: |
@@ -10762,19 +10762,19 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteJobEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Job Environment Variable
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit an environment variable belonging to the job
       description: |
@@ -10784,8 +10784,8 @@ paths:
         - An override can only have a scope lower to the variable it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editJobEnvironmentVariable
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Job Environment Variable
       requestBody:
@@ -10793,23 +10793,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnvironmentVariableEditRequest'
+              $ref: "#/components/schemas/EnvironmentVariableEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the environment variable value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/environmentVariable/{environmentVariableId}/override':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/environmentVariable/{environmentVariableId}/override":
     post:
       summary: Create an environment variable override at the job level
       description: |
@@ -10820,31 +10820,31 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" field of the newly created variable
       operationId: createJobEnvironmentVariableOverride
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/environmentVariable/{environmentVariableId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/environmentVariable/{environmentVariableId}/alias":
     post:
       summary: Create an environment variable alias at the job level
       description: |
@@ -10856,82 +10856,82 @@ paths:
         - You can't create an alias on an alias
       operationId: createJobEnvironmentVariableAlias
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/environmentVariableId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/environmentVariableId"
       tags:
         - Job Environment Variable
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvironmentVariable'
-        '400':
+                $ref: "#/components/schemas/EnvironmentVariable"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/secret':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/secret":
     get:
       summary: List job secrets
-      description: 'Secrets are like environment variables, but they are secured and can''t be revealed.'
+      description: "Secrets are like environment variables, but they are secured and can't be revealed."
       operationId: listJobSecrets
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Secret
       responses:
-        '200':
+        "200":
           description: List secrets
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/SecretResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Add a secret to the job
       description: |
         - Add a secret to the job.
       operationId: createJobSecret
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Job Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretRequest'
+              $ref: "#/components/schemas/SecretRequest"
       responses:
-        '201':
+        "201":
           description: Add a secret
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/secret/{secretId}':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/secret/{secretId}":
     delete:
       summary: Delete a secret from an job
       description: |
@@ -10940,19 +10940,19 @@ paths:
         - If you delete a secret having override or alias, the associated override/alias will be deleted as well
       operationId: deleteJobSecret
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Job Secret
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a secret belonging to the job
       description: |
@@ -10962,8 +10962,8 @@ paths:
         - An override can only have a scope lower to the secret it is overriding (hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > CONTAINER)
       operationId: editJobSecret
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Job Secret
       requestBody:
@@ -10971,23 +10971,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SecretEditRequest'
+              $ref: "#/components/schemas/SecretEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited the secret value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/secret/{secretId}/override':
+                $ref: "#/components/schemas/Secret"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/secret/{secretId}/override":
     post:
       summary: Create a secret override at the job level
       description: |
@@ -10998,31 +10998,31 @@ paths:
         - Information regarding the overridden_secret will be exposed in the "overridden_secret" field of the newly created secret
       operationId: createJobSecretOverride
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Job Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Value'
+              $ref: "#/components/schemas/Value"
       responses:
-        '201':
+        "201":
           description: Create secret override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/secret/{secretId}/alias':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/secret/{secretId}/alias":
     post:
       summary: Create a secret alias at the job level
       description: |
@@ -11034,129 +11034,129 @@ paths:
         - You can't create an alias on an alias
       operationId: createJobSecretAlias
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/secretId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/secretId"
       tags:
         - Job Secret
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Key'
+              $ref: "#/components/schemas/Key"
       responses:
-        '201':
+        "201":
           description: Create secret alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Secret'
-        '400':
+                $ref: "#/components/schemas/Secret"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is BUILT_IN > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/commit':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/commit":
     get:
       summary: List last job commits
       description: Returns list of the last 100 commits made on the repository linked to the job
       operationId: listJobCommit
       parameters:
-        - $ref: '#/components/parameters/jobId'
-        - $ref: '#/components/parameters/startId'
-        - $ref: '#/components/parameters/gitCommitId'
+        - $ref: "#/components/parameters/jobId"
+        - $ref: "#/components/parameters/startId"
+        - $ref: "#/components/parameters/gitCommitId"
       tags:
         - Job Main Calls
       responses:
-        '200':
+        "200":
           description: List job commits
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommitResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/job/{jobId}/clone':
+                $ref: "#/components/schemas/CommitResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/job/{jobId}/clone":
     post:
       summary: Clone job
       description: This will create a new job with the same configuration on the targeted environment Id.
       operationId: cloneJob
       parameters:
-        - $ref: '#/components/parameters/jobId'
+        - $ref: "#/components/parameters/jobId"
       tags:
         - Jobs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneServiceRequest'
+              $ref: "#/components/schemas/CloneServiceRequest"
       responses:
-        '202':
+        "202":
           description: Job clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/JobResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/service/{serviceId}/deploymentStage':
+  "/service/{serviceId}/deploymentStage":
     get:
       summary: Get Service Deployment Stage
       operationId: getServiceDeploymentStage
       parameters:
-        - $ref: '#/components/parameters/serviceId'
+        - $ref: "#/components/parameters/serviceId"
       tags:
         - Deployment Stage Main Calls
       responses:
-        '200':
+        "200":
           description: Get Service Deployment Stage
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentStageResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/service/{serviceId}/gitWebhookStatus':
+                $ref: "#/components/schemas/DeploymentStageResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/service/{serviceId}/gitWebhookStatus":
     get:
       summary: Get git webhook status for a service
-      description: 'Returns the webhook status for a git-based service. Checks if the Qovery webhook is correctly configured on the git provider (GitHub, GitLab, or Bitbucket).'
+      description: "Returns the webhook status for a git-based service. Checks if the Qovery webhook is correctly configured on the git provider (GitHub, GitLab, or Bitbucket)."
       operationId: getServiceGitWebhookStatus
       parameters:
-        - $ref: '#/components/parameters/serviceId'
+        - $ref: "#/components/parameters/serviceId"
       tags:
         - Service Main Calls
       responses:
-        '200':
+        "200":
           description: Webhook status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitWebhookStatusResponse'
-        '400':
+                $ref: "#/components/schemas/GitWebhookStatusResponse"
+        "400":
           description: Service does not have a git source
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/service/{serviceId}/gitWebhook/sync':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/service/{serviceId}/gitWebhook/sync":
     post:
       summary: Synchronize git webhook for a service
       description: |
@@ -11167,27 +11167,27 @@ paths:
         Works with GitHub, GitLab, and Bitbucket repositories.
       operationId: syncServiceGitWebhook
       parameters:
-        - $ref: '#/components/parameters/serviceId'
+        - $ref: "#/components/parameters/serviceId"
       tags:
         - Service Main Calls
       responses:
-        '200':
+        "200":
           description: Webhook synchronized successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GitWebhookStatusResponse'
-        '400':
+                $ref: "#/components/schemas/GitWebhookStatusResponse"
+        "400":
           description: Service does not have a git source
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '422':
-          description: 'Cannot configure webhook (provider-specific issues, insufficient permissions)'
-        '429':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "422":
+          description: "Cannot configure webhook (provider-specific issues, insufficient permissions)"
+        "429":
           description: Git provider rate limit exceeded
   /variable:
     get:
@@ -11201,13 +11201,13 @@ paths:
           schema:
             type: string
             format: uuid
-          description: 'it filters the list by returning only the variables accessible by the selected parent_id. This field shall contain the id of a project, environment or service depending on the selected scope. Example, if scope = APPLICATION and parent_id=<application_id>, the result will contain any variable accessible by the application. The result will contain also any variable declared at an higher scope.'
+          description: "it filters the list by returning only the variables accessible by the selected parent_id. This field shall contain the id of a project, environment or service depending on the selected scope. Example, if scope = APPLICATION and parent_id=<application_id>, the result will contain any variable accessible by the application. The result will contain also any variable declared at an higher scope."
         - in: query
           name: scope
           required: true
           schema:
-            $ref: '#/components/schemas/APIVariableScopeEnum'
-          description: 'the type of the parent_id (application, project, environment etc..).'
+            $ref: "#/components/schemas/APIVariableScopeEnum"
+          description: "the type of the parent_id (application, project, environment etc..)."
         - in: query
           name: is_secret
           schema:
@@ -11217,18 +11217,18 @@ paths:
       tags:
         - Variable Main Calls
       responses:
-        '200':
+        "200":
           description: List variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/VariableResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create a variable
       description: |
@@ -11240,23 +11240,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableRequest'
+              $ref: "#/components/schemas/VariableRequest"
       responses:
-        '201':
+        "201":
           description: Create a variable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/variable/{variableId}/alias':
+                $ref: "#/components/schemas/VariableResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/variable/{variableId}/alias":
     post:
       summary: Create a variable alias
       description: |
@@ -11268,30 +11268,30 @@ paths:
         - You can't create an alias on an alias
       operationId: createVariableAlias
       parameters:
-        - $ref: '#/components/parameters/variableId'
+        - $ref: "#/components/parameters/variableId"
       tags:
         - Variable Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableAliasRequest'
+              $ref: "#/components/schemas/VariableAliasRequest"
       responses:
-        '201':
+        "201":
           description: Create variable alias
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableResponse'
-        '400':
+                $ref: "#/components/schemas/VariableResponse"
+        "400":
           description: Can't create an alias on a higher scope. Aliases can only be created from one scope to a lower scope. Scope hierarchy is ORGANIZATION > PROJECT > ENVIRONMENT > CONTAINER
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/variable/{variableId}/override':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/variable/{variableId}/override":
     post:
       summary: Create a variable override
       description: |
@@ -11302,30 +11302,30 @@ paths:
         - Information regarding the overridden_variable will be exposed in the "overridden_variable" or in the "overridden_secret" field of the newly created variable
       operationId: createVariableOverride
       parameters:
-        - $ref: '#/components/parameters/variableId'
+        - $ref: "#/components/parameters/variableId"
       tags:
         - Variable Main Calls
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableOverrideRequest'
+              $ref: "#/components/schemas/VariableOverrideRequest"
       responses:
-        '201':
+        "201":
           description: Create variable override
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableResponse'
-        '400':
+                $ref: "#/components/schemas/VariableResponse"
+        "400":
           description: Can't create an override on a higher scope. Overrides can only be created from one scope to a lower scope. Scope hierarchy is ORGANIZATION > PROJECT > ENVIRONMENT > APPLICATION
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/variable/{variableId}':
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/variable/{variableId}":
     delete:
       summary: Delete a variable
       description: |
@@ -11334,18 +11334,18 @@ paths:
         - If you delete a variable having override or alias, the associated override/alias will be deleted as well
       operationId: deleteVariable
       parameters:
-        - $ref: '#/components/parameters/variableId'
+        - $ref: "#/components/parameters/variableId"
       tags:
         - Variable Main Calls
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a variable
       description: |
@@ -11354,7 +11354,7 @@ paths:
         - For an alias, you can't edit the value
       operationId: editVariable
       parameters:
-        - $ref: '#/components/parameters/variableId'
+        - $ref: "#/components/parameters/variableId"
       tags:
         - Variable Main Calls
       requestBody:
@@ -11362,26 +11362,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableEditRequest'
+              $ref: "#/components/schemas/VariableEditRequest"
       responses:
-        '200':
+        "200":
           description: Edited variable value
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/VariableResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /variable/import:
     post:
       summary: Import variables
-      description: 'Import environment variables in a defined scope, with a defined visibility.'
+      description: "Import environment variables in a defined scope, with a defined visibility."
       operationId: importEnvironmentVariables
       parameters:
         - in: query
@@ -11395,7 +11395,7 @@ paths:
           name: service_type
           required: true
           schema:
-            $ref: '#/components/schemas/ServiceTypeForVariableEnum'
+            $ref: "#/components/schemas/ServiceTypeForVariableEnum"
           description: service type
       tags:
         - Variable Main Calls
@@ -11403,23 +11403,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VariableImportRequest'
+              $ref: "#/components/schemas/VariableImportRequest"
       responses:
-        '201':
+        "201":
           description: Import environment variables
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableImport'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/cleanFailedJobs':
+                $ref: "#/components/schemas/VariableImport"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/cleanFailedJobs":
     parameters:
       - schema:
           type: string
@@ -11431,7 +11431,7 @@ paths:
       tags:
         - Environment Actions
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -11473,7 +11473,7 @@ paths:
                       id: j5zm35sm6zxp4
                     type: string
                     format: uuid
-  '/job/{jobId}/cleanFailedJob':
+  "/job/{jobId}/cleanFailedJob":
     parameters:
       - schema:
           type: string
@@ -11485,7 +11485,7 @@ paths:
       tags:
         - Job Actions
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -11503,7 +11503,7 @@ paths:
       operationId: cleanFailedJob
       x-stoplight:
         id: eu77thczavme3
-  '/environment/{environmentId}/lifecycleTemplate':
+  "/environment/{environmentId}/lifecycleTemplate":
     parameters:
       - schema:
           type: string
@@ -11518,19 +11518,19 @@ paths:
       x-stoplight:
         id: 597v5i445zf0v
       responses:
-        '200':
+        "200":
           description: List available lifecyle templates for this environment
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LifecycleTemplateListResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/lifecycleTemplate/{lifecycleTemplateId}':
+                $ref: "#/components/schemas/LifecycleTemplateListResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/lifecycleTemplate/{lifecycleTemplateId}":
     parameters:
       - schema:
           type: string
@@ -11550,19 +11550,19 @@ paths:
       x-stoplight:
         id: yatyf4hs2kwc0
       responses:
-        '200':
+        "200":
           description: Lifecycle template
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LifecycleTemplateResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/containerRegistry/{containerRegistryId}/associatedServices':
+                $ref: "#/components/schemas/LifecycleTemplateResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/containerRegistry/{containerRegistryId}/associatedServices":
     parameters:
       - schema:
           type: string
@@ -11579,23 +11579,23 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Get organization container registry associated services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerRegistryAssociatedServicesResponseList'
-        '401':
+                $ref: "#/components/schemas/ContainerRegistryAssociatedServicesResponseList"
+        "401":
           description: Access token is missing or invalid
-        '403':
+        "403":
           description: Access forbidden
-        '404':
+        "404":
           description: Resource not found
       operationId: getContainerRegistryAssociatedServices
       x-stoplight:
         id: dgh8t73nqaetm
       description: Get organization container registry associated services
-  '/organization/{organizationId}/helmRepository/{helmRepositoryId}/associatedServices':
+  "/organization/{organizationId}/helmRepository/{helmRepositoryId}/associatedServices":
     parameters:
       - schema:
           type: string
@@ -11612,23 +11612,23 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Get organization helm repository associated services
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HelmRepositoryAssociatedServicesResponseList'
-        '401':
-          description: ' Access token is missing or invalid'
-        '403':
+                $ref: "#/components/schemas/HelmRepositoryAssociatedServicesResponseList"
+        "401":
+          description: " Access token is missing or invalid"
+        "403":
           description: AccessForbidden
-        '404':
+        "404":
           description: ResourceNot Found
       operationId: getHelmRepositoryAssociatedServices
       x-stoplight:
         id: 5jvrv87m4tk5s
       description: Get organization helm repository associated services
-  '/cluster/{clusterId}/token':
+  "/cluster/{clusterId}/token":
     parameters:
       - schema:
           type: string
@@ -11639,7 +11639,7 @@ paths:
       summary: Get cluster token by clusterId
       tags: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -11683,7 +11683,7 @@ paths:
       operationId: get-cluster-token-by-clusterId
       x-stoplight:
         id: zggx5u9ayalz7
-  '/helm/{helmId}/listServices':
+  "/helm/{helmId}/listServices":
     parameters:
       - schema:
           type: string
@@ -11695,24 +11695,24 @@ paths:
       tags:
         - Helm Main Calls
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/KubernetesServiceResponseList'
-        '401':
-          description: ' Access token is missing or invalid'
-        '403':
+                $ref: "#/components/schemas/KubernetesServiceResponseList"
+        "401":
+          description: " Access token is missing or invalid"
+        "403":
           description: Resource not found
-        '404':
+        "404":
           description: Not Found
       operationId: getHelmKubernetesServices
       x-stoplight:
         id: 7cl74u6hzmccd
       description: Get helm kubernetes services
-  '/environment/{environmentId}/services':
+  "/environment/{environmentId}/services":
     parameters:
       - schema:
           type: string
@@ -11724,7 +11724,7 @@ paths:
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: Service List
           content:
             application/json:
@@ -11739,25 +11739,25 @@ paths:
                       x-stoplight:
                         id: lzycmwmefigki
                       oneOf:
-                        - $ref: '#/components/schemas/Application'
-                        - $ref: '#/components/schemas/ContainerResponse'
-                        - $ref: '#/components/schemas/Database'
-                        - $ref: '#/components/schemas/HelmResponse'
-                        - $ref: '#/components/schemas/JobResponse'
-                        - $ref: '#/components/schemas/TerraformResponse'
+                        - $ref: "#/components/schemas/Application"
+                        - $ref: "#/components/schemas/ContainerResponse"
+                        - $ref: "#/components/schemas/Database"
+                        - $ref: "#/components/schemas/HelmResponse"
+                        - $ref: "#/components/schemas/JobResponse"
+                        - $ref: "#/components/schemas/TerraformResponse"
                       discriminator:
                         propertyName: service_type
                         mapping:
-                          APPLICATION: '#/components/schemas/Application'
-                          CONTAINER: '#/components/schemas/ContainerResponse'
-                          DATABASE: '#/components/schemas/Database'
-                          HELM: '#/components/schemas/HelmResponse'
-                          JOB: '#/components/schemas/JobResponse'
-                          TERRAFORM: '#/components/schemas/TerraformResponse'
+                          APPLICATION: "#/components/schemas/Application"
+                          CONTAINER: "#/components/schemas/ContainerResponse"
+                          DATABASE: "#/components/schemas/Database"
+                          HELM: "#/components/schemas/HelmResponse"
+                          JOB: "#/components/schemas/JobResponse"
+                          TERRAFORM: "#/components/schemas/TerraformResponse"
       operationId: listServicesByEnvironmentId
       x-stoplight:
         id: 9adquhr5t6qx3
-  '/cluster/{clusterId}/lock':
+  "/cluster/{clusterId}/lock":
     parameters:
       - schema:
           type: string
@@ -11769,17 +11769,17 @@ paths:
       tags:
         - Clusters
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterLock'
-        '401':
+                $ref: "#/components/schemas/ClusterLock"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not Found
       operationId: lockCluster
       x-stoplight:
@@ -11789,15 +11789,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterLockRequest'
+              $ref: "#/components/schemas/ClusterLockRequest"
     delete:
       summary: Unlock Cluster
       tags:
         - Clusters
       responses:
-        '204':
+        "204":
           description: No Content
-        '401':
+        "401":
           description: |-
             Unauthorized responses:
                     '204':
@@ -11808,15 +11808,15 @@ paths:
                       $ref: '#/components/responses/403'
                     '404':
                       $ref: '#/components/responses/404'
-        '403':
+        "403":
           description: Forbidden
-        '404':
-          description: ''
+        "404":
+          description: ""
       operationId: unlock-cluster
       x-stoplight:
         id: vkn00s3mt1vew
       description: Unlock a cluster
-  '/cluster/{clusterId}/events':
+  "/cluster/{clusterId}/events":
     get:
       summary: List Cluster Kubernetes Events
       description: List Cluster Kubernetes Events
@@ -11824,14 +11824,14 @@ paths:
       tags:
         - Clusters
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
         - in: query
           name: from_date_time
           description: |
             The start date time to fetch events from, following ISO-8601 format.  
             The `+` character must be escaped (`%2B`)
           required: true
-          example: '2025-03-03T09:00:00+00:00'
+          example: "2025-03-03T09:00:00+00:00"
           schema:
             type: string
             nullable: false
@@ -11841,7 +11841,7 @@ paths:
             The end date time to fetch events from, following ISO-8601 format.  
             The `+` character must be escaped (`%2B`)
           required: true
-          example: '2025-03-03T03:00:00+00:00'
+          example: "2025-03-03T03:00:00+00:00"
           schema:
             type: string
             nullable: false
@@ -11861,7 +11861,7 @@ paths:
           name: reporting_component
           description: The name of the reporting component used to filter events.
       responses:
-        '200':
+        "200":
           description: List Cluster Kubernetes Events
           content:
             application/json:
@@ -11913,7 +11913,7 @@ paths:
                           x-stoplight:
                             id: 5pap12d1475w9
                           format: date-time
-  '/cluster/{clusterId}/metrics':
+  "/cluster/{clusterId}/metrics":
     get:
       summary: Fetch cluster metrics
       description: Fetch cluster metrics.
@@ -11921,7 +11921,7 @@ paths:
       tags:
         - Clusters
       parameters:
-        - $ref: '#/components/parameters/clusterId'
+        - $ref: "#/components/parameters/clusterId"
         - in: query
           name: endpoint
           schema:
@@ -11991,13 +11991,13 @@ paths:
           in: query
           name: range
       responses:
-        '200':
+        "200":
           description: Cluster Metrics
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterMetricsResponse'
-  '/organization/{organizationId}/lock':
+                $ref: "#/components/schemas/ClusterMetricsResponse"
+  "/organization/{organizationId}/lock":
     parameters:
       - schema:
           type: string
@@ -12009,18 +12009,18 @@ paths:
       tags:
         - Organization Cluster Lock
       responses:
-        '200':
+        "200":
           description: OK
           headers: {}
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterLockList'
-        '401':
+                $ref: "#/components/schemas/ClusterLockList"
+        "401":
           description: Unauthorized
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not Found
       operationId: list-cluster-lock
       x-stoplight:
@@ -12030,12 +12030,12 @@ paths:
       summary: Get Deployment Status By DeploymentRequestId
       tags: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnvDeploymentStatus'
+                $ref: "#/components/schemas/EnvDeploymentStatus"
       operationId: getDeploymentStatusByDeploymentRequestId
       x-stoplight:
         id: dtvjdlz9teqld
@@ -12047,13 +12047,13 @@ paths:
           name: deploymentRequestId
           required: true
     parameters: []
-  '/organization/{organizationId}/services':
+  "/organization/{organizationId}/services":
     get:
       summary: List Services By OrganizationId
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Service List
           content:
             application/json:
@@ -12065,7 +12065,7 @@ paths:
                     x-stoplight:
                       id: gjtgeehwg4lb9
                     items:
-                      $ref: '#/components/schemas/ServiceLightResponse'
+                      $ref: "#/components/schemas/ServiceLightResponse"
       operationId: listServicesByOrganizationId
       x-stoplight:
         id: qvqb4d0bpjy0v
@@ -12090,13 +12090,13 @@ paths:
         name: organizationId
         in: path
         required: true
-  '/organization/{organizationId}/environments':
+  "/organization/{organizationId}/environments":
     get:
       summary: List Environments By OrganizationId
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: Environment List
           content:
             application/json:
@@ -12106,7 +12106,7 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/OrganizationEnvironmentResponse'
+                      $ref: "#/components/schemas/OrganizationEnvironmentResponse"
       operationId: listEnvironmentsByOrganizationId
     parameters:
       - schema:
@@ -12114,12 +12114,12 @@ paths:
         name: organizationId
         in: path
         required: true
-  '/organization/{organizationId}/parseTerraformVariablesFromGitRepo':
+  "/organization/{organizationId}/parseTerraformVariablesFromGitRepo":
     post:
       summary: Parse Terraform variables from Git repository
       operationId: parseTerraformVariablesFromGitRepo
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       requestBody:
@@ -12127,9 +12127,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformVariableParsingRequest'
+              $ref: "#/components/schemas/TerraformVariableParsingRequest"
       responses:
-        '200':
+        "200":
           description: List of Terraform variable definitions
           content:
             application/json:
@@ -12139,21 +12139,21 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/TerraformVariableDefinition'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/listTfVarsFilesFromGitRepo':
+                      $ref: "#/components/schemas/TerraformVariableDefinition"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/listTfVarsFilesFromGitRepo":
     post:
       summary: List Terraform tfvars files from Git repository
       operationId: listTfVarsFilesFromGitRepo
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Main Calls
       requestBody:
@@ -12161,9 +12161,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TfVarsListRequest'
+              $ref: "#/components/schemas/TfVarsListRequest"
       responses:
-        '200':
+        "200":
           description: List of Terraform tfvars files with their variables
           content:
             application/json:
@@ -12173,16 +12173,16 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/TfVarsFileResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/environment/{environmentId}/deploymentQueue':
+                      $ref: "#/components/schemas/TfVarsFileResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/environment/{environmentId}/deploymentQueue":
     parameters:
       - schema:
           type: string
@@ -12195,7 +12195,7 @@ paths:
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -12207,11 +12207,11 @@ paths:
                     x-stoplight:
                       id: zbjhuwhtkvxkj
                     items:
-                      $ref: '#/components/schemas/QueuedDeploymentRequestWithStages'
+                      $ref: "#/components/schemas/QueuedDeploymentRequestWithStages"
       operationId: listDeploymentRequestByEnvironmentId
       x-stoplight:
         id: 0zhr0vfxayg96
-  '/service/{serviceId}/deploymentQueue':
+  "/service/{serviceId}/deploymentQueue":
     parameters:
       - schema:
           type: string
@@ -12224,7 +12224,7 @@ paths:
       tags:
         - Environment Main Calls
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -12234,11 +12234,11 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/QueuedDeploymentRequestForService'
+                      $ref: "#/components/schemas/QueuedDeploymentRequestForService"
       operationId: listDeploymentRequestByServiceId
       x-stoplight:
         id: augmimjz30ix3
-  '/{serviceType}/{serviceId}/ingressDeploymentStatus':
+  "/{serviceType}/{serviceId}/ingressDeploymentStatus":
     parameters:
       - schema:
           type: string
@@ -12260,84 +12260,84 @@ paths:
       tags:
         - service_status
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IngressDeploymentStatusResponse'
+                $ref: "#/components/schemas/IngressDeploymentStatusResponse"
       operationId: getIngressDeploymentStatus
       x-stoplight:
         id: cji3h6qjunupa
-  '/organization/{organizationId}/azure/credentials':
+  "/organization/{organizationId}/azure/credentials":
     get:
       summary: List Azure credentials
       operationId: listAzureCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: list credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentialsResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentialsResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     post:
       summary: Create Azure credentials set
       operationId: createAzureCredentials
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Cloud Provider Credentials
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AzureCredentialsRequest'
+              $ref: "#/components/schemas/AzureCredentialsRequest"
       responses:
-        '201':
+        "201":
           description: Credentials created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/azure/credentials/{credentialsId}':
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/azure/credentials/{credentialsId}":
     get:
       summary: Get a set of Azure credentials
       operationId: getAzureCredentials
       tags:
         - Cloud Provider Credentials
       responses:
-        '200':
+        "200":
           description: Get a set of Azure credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit a set of Azure credentials
       operationId: editAzureCredentials
@@ -12347,36 +12347,36 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AzureCredentialsRequest'
+              $ref: "#/components/schemas/AzureCredentialsRequest"
       responses:
-        '200':
+        "200":
           description: Edit a set of Azure credentials
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterCredentials'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterCredentials"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
       summary: Delete a set of Azure credentials
       operationId: deleteAzureCredentials
       tags:
         - Cloud Provider Credentials
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     parameters:
       - schema:
           type: string
@@ -12399,40 +12399,40 @@ paths:
       x-stoplight:
         id: pccuw0fgrkcyf
       responses:
-        '200':
+        "200":
           description: list regions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterRegionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterRegionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /azure/clusterFeature:
     get:
       summary: List Azure features available
       tags:
         - Cloud Provider
       responses:
-        '200':
+        "200":
           description: list features available for Azure cloud provider
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterFeatureResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/ClusterFeatureResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: listAzureFeatures
       x-stoplight:
         id: gjin553b2f7mz
-  '/environment/{environmentId}/terraform':
+  "/environment/{environmentId}/terraform":
     get:
       summary: List terraforms
       operationId: listTerraforms
@@ -12441,18 +12441,18 @@ paths:
       tags:
         - Terraforms
       responses:
-        '200':
+        "200":
           description: List terraforms
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/TerraformResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     parameters:
       - schema:
           type: string
@@ -12471,51 +12471,51 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformRequest'
+              $ref: "#/components/schemas/TerraformRequest"
       responses:
-        '201':
+        "201":
           description: Create terraform
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/TerraformResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Terraform name within the environment is already taken
-  '/environment/{environmentId}/link':
+  "/environment/{environmentId}/link":
     get:
       summary: List environment services links
       operationId: listEnvironmentServicesLinks
       parameters:
-        - $ref: '#/components/parameters/environmentId'
+        - $ref: "#/components/parameters/environmentId"
       tags:
         - Environment
       responses:
-        '200':
+        "200":
           description: List environment services links
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LinkResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/LinkResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       x-stoplight:
         id: 94az7c0v1enav
       description: List services links of an environment
-  '/terraform/{terraformId}':
+  "/terraform/{terraformId}":
     parameters:
-      - $ref: '#/components/parameters/terraformId'
+      - $ref: "#/components/parameters/terraformId"
     get:
       summary: Get terraform by ID
       tags:
@@ -12524,18 +12524,18 @@ paths:
       x-stoplight:
         id: s1dctms0dixdl
       responses:
-        '200':
+        "200":
           description: Get terrafor by ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/TerraformResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Edit Terraform
       tags:
@@ -12547,23 +12547,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformRequest'
+              $ref: "#/components/schemas/TerraformRequest"
       responses:
-        '200':
+        "200":
           description: Edit Terraform
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/TerraformResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Terraform name within the environment is already taken
     delete:
       summary: Delete Terraform
@@ -12573,28 +12573,28 @@ paths:
       x-stoplight:
         id: 518sjlmziel46
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       parameters:
         - in: query
           name: resources_only
           schema:
             type: boolean
             default: false
-          description: 'When true, only resources are deleted and Qovery configuration is kept.'
+          description: "When true, only resources are deleted and Qovery configuration is kept."
         - in: query
           name: force_terraform_action
           required: false
           schema:
-            $ref: '#/components/schemas/DeleteTerraformAction'
+            $ref: "#/components/schemas/DeleteTerraformAction"
           description: Force a specific action to be executed by Terraform during deletion.
-  '/terraform/{terraformId}/advancedSettings':
+  "/terraform/{terraformId}/advancedSettings":
     get:
       summary: Get Advanced settings
       tags:
@@ -12603,18 +12603,18 @@ paths:
       x-stoplight:
         id: hth6esl7sqliu
       responses:
-        '200':
+        "200":
           description: Advanced settings list
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/TerraformAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     parameters:
       - schema:
           type: string
@@ -12633,65 +12633,65 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformAdvancedSettings'
+              $ref: "#/components/schemas/TerraformAdvancedSettings"
       responses:
-        '201':
+        "201":
           description: Updated advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformAdvancedSettings'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/terraform/{terraformId}/deploy':
+                $ref: "#/components/schemas/TerraformAdvancedSettings"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/terraform/{terraformId}/deploy":
     post:
       summary: Deploy terraform
       description: You must provide a git commit id.
       operationId: deployTerraform
       parameters:
-        - $ref: '#/components/parameters/terraformId'
+        - $ref: "#/components/parameters/terraformId"
       tags:
         - Terraform Actions
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformDeployRequest'
+              $ref: "#/components/schemas/TerraformDeployRequest"
       responses:
-        '202':
+        "202":
           description: Deploy terraform
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/Status"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/terraform/{terraformId}/uninstall':
+  "/terraform/{terraformId}/uninstall":
     post:
       summary: Uninstall terraform
       description: Delete the resources of the terraform but keep Qovery configuration
       operationId: uninstallTerraform
       parameters:
-        - $ref: '#/components/parameters/terraformId'
+        - $ref: "#/components/parameters/terraformId"
         - in: query
           name: force_terraform_action
           required: false
           schema:
-            $ref: '#/components/schemas/DeleteTerraformAction'
+            $ref: "#/components/schemas/DeleteTerraformAction"
           description: Force a specific action to be executed by Terraform during uninstall.
       tags:
         - Terraform Actions
@@ -12702,23 +12702,23 @@ paths:
               type: object
               properties: {}
       responses:
-        '202':
-          description: 'Delete the compute and data of the service, but keep Qovery configuration'
+        "202":
+          description: "Delete the compute and data of the service, but keep Qovery configuration"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Status'
-        '204':
+                $ref: "#/components/schemas/Status"
+        "204":
           description: No deployment has been triggered
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
       x-stoplight:
         id: awjvr4y02cr23
@@ -12734,16 +12734,16 @@ paths:
       tags:
         - Terraforms
       responses:
-        '200':
+        "200":
           description: Default terraform advanced settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformAdvancedSettings'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/TerraformAdvancedSettings"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
       operationId: getDefaultTerraformAdvancedSettings
       x-stoplight:
         id: 5qcyy764ewhk3
@@ -12754,48 +12754,48 @@ paths:
         - Terraform Main Calls
       operationId: listTerraformVersions
       responses:
-        '200':
+        "200":
           description: List available Terraform versions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformVersionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/terraform/{terraformId}/clone':
+                $ref: "#/components/schemas/TerraformVersionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/terraform/{terraformId}/clone":
     post:
       summary: Clone terraform
       description: This will create a new terraform with the same configuration on the targeted environment Id.
       operationId: cloneTerraform
       parameters:
-        - $ref: '#/components/parameters/terraformId'
+        - $ref: "#/components/parameters/terraformId"
       tags:
         - Terraforms
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloneServiceRequest'
+              $ref: "#/components/schemas/CloneServiceRequest"
       responses:
-        '202':
+        "202":
           description: Terraform clone has been requested
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '409':
+                $ref: "#/components/schemas/TerraformResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
           description: Operation is in progress
-  '/terraform/{terraformId}/deploymentHistoryV2':
+  "/terraform/{terraformId}/deploymentHistoryV2":
     parameters:
       - schema:
           type: string
@@ -12817,44 +12817,44 @@ paths:
       tags:
         - Terraform Deployment History
       responses:
-        '200':
+        "200":
           description: List deployment history
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/DeploymentHistoryServicePaginatedResponseListV2"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: listTerraformDeploymentHistoryV2
       x-stoplight:
         id: qxm14ubc0l5dq
-  '/terraform/{terraformId}/commit':
+  "/terraform/{terraformId}/commit":
     get:
       summary: List last commits
       description: Returns list of the last 100 commits made on the repository linked to the terraform service
       operationId: listTerraformCommit
       parameters:
-        - $ref: '#/components/parameters/terraformId'
+        - $ref: "#/components/parameters/terraformId"
       tags:
         - Terraform Main Calls
       responses:
-        '200':
+        "200":
           description: List commits
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommitResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/terraform/{terraformId}/deploymentRestriction':
+                $ref: "#/components/schemas/CommitResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/terraform/{terraformId}/deploymentRestriction":
     parameters:
       - schema:
           type: string
@@ -12867,18 +12867,18 @@ paths:
       tags:
         - Terraform Deployment Restriction
       responses:
-        '200':
+        "200":
           description: Get terraform deployment restrictions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformDeploymentRestrictionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/TerraformDeploymentRestrictionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: getTerraformDeploymentRestrictions
       x-stoplight:
         id: q3y44x1wdigcd
@@ -12891,26 +12891,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/TerraformDeploymentRestrictionRequest"
       responses:
-        '201':
+        "201":
           description: Added an terraform deployment restriction
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformDeploymentRestrictionResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '409':
+                $ref: "#/components/schemas/TerraformDeploymentRestrictionResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "409":
           description: A terraform deployment restriction with same properties already exists for this terraform
       operationId: createTerraformDeploymentRestriction
       x-stoplight:
         id: l6192gxde3sbv
-  '/terraform/{terraformId}/deploymentRestriction/{deploymentRestrictionId}':
+  "/terraform/{terraformId}/deploymentRestriction/{deploymentRestrictionId}":
     parameters:
       - schema:
           type: string
@@ -12933,22 +12933,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerraformDeploymentRestrictionRequest'
+              $ref: "#/components/schemas/TerraformDeploymentRestrictionRequest"
       responses:
-        '200':
+        "200":
           description: Edit a terraform deployment restriction
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformDeploymentRestrictionResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/TerraformDeploymentRestrictionResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: editTerraformDeploymentRestriction
       x-stoplight:
         id: w3jp2xci6bogt
@@ -12958,20 +12958,20 @@ paths:
       tags:
         - Terraform Deployment Restriction
       responses:
-        '204':
-          $ref: '#/components/responses/204-deletion'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "204":
+          $ref: "#/components/responses/204-deletion"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: deleteTerraformDeploymentRestriction
       x-stoplight:
         id: d896flm9ibi54
-  '/terraform/{terraformId}/terraformResources':
+  "/terraform/{terraformId}/terraformResources":
     parameters:
-      - $ref: '#/components/parameters/terraformId'
+      - $ref: "#/components/parameters/terraformId"
     get:
       summary: Get terraform resources from latest deployment
       description: Returns the list of Terraform resources from the most recent deployment execution
@@ -12981,19 +12981,19 @@ paths:
       x-stoplight:
         id: terraform-resources-get
       responses:
-        '200':
+        "200":
           description: List of terraform resources from latest deployment
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TerraformResourcesResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/credentials':
+                $ref: "#/components/schemas/TerraformResourcesResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/credentials":
     parameters:
       - schema:
           type: string
@@ -13005,19 +13005,19 @@ paths:
       tags:
         - Organization Main Calls
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationCrendentialsResponseList'
-        '400':
+                $ref: "#/components/schemas/OrganizationCrendentialsResponseList"
+        "400":
           description: Bad Request
       operationId: listOrganizationCredentials
       x-stoplight:
         id: 2jm9tyqfhw4xf
       description: List credentials of an organization and their associated clusters
-  '/cluster/{clusterId}/logs':
+  "/cluster/{clusterId}/logs":
     parameters:
       - schema:
           type: string
@@ -13027,12 +13027,12 @@ paths:
     get:
       summary: Fetch cluster logs
       responses:
-        '200':
+        "200":
           description: Cluster Logs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClusterLogsResponse'
+                $ref: "#/components/schemas/ClusterLogsResponse"
       operationId: get-cluster-logs
       tags:
         - Clusters
@@ -13082,45 +13082,45 @@ paths:
             type: string
           in: query
           name: time
-  '/organization/{organizationId}/enterpriseconnection':
+  "/organization/{organizationId}/enterpriseconnection":
     get:
       summary: List enterprise connections
       operationId: listOrganizationEnterpriseConnections
       parameters:
-        - $ref: '#/components/parameters/organizationId'
+        - $ref: "#/components/parameters/organizationId"
       tags:
         - Organization Enterprise Connection
       responses:
-        '200':
+        "200":
           description: List enterprise connections
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnterpriseConnectionResponseList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-  '/organization/{organizationId}/alert-receivers':
+                $ref: "#/components/schemas/EnterpriseConnectionResponseList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+  "/organization/{organizationId}/alert-receivers":
     get:
       summary: List alert receivers
       tags:
         - Alert Receivers
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertReceiverList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AlertReceiverList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: getAlertReceivers
       x-stoplight:
         id: 3cqb2xpmir9n8
@@ -13133,72 +13133,72 @@ paths:
         schema:
           type: string
           format: uuid
-  '/organization/{organizationId}/enterpriseconnection/{connectionName}':
+  "/organization/{organizationId}/enterpriseconnection/{connectionName}":
     get:
       summary: Get enterprise connection
       operationId: getOrganizationEnterpriseConnection
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/connectionName'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/connectionName"
       tags:
         - Organization Enterprise Connection
       responses:
-        '200':
+        "200":
           description: Get enterprise connection
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnterpriseConnectionDto'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnterpriseConnectionDto"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     put:
       summary: Update enterprise connection
       operationId: updateOrganizationEnterpriseConnection
       parameters:
-        - $ref: '#/components/parameters/organizationId'
-        - $ref: '#/components/parameters/connectionName'
+        - $ref: "#/components/parameters/organizationId"
+        - $ref: "#/components/parameters/connectionName"
       tags:
         - Organization Enterprise Connection
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnterpriseConnectionDto'
+              $ref: "#/components/schemas/EnterpriseConnectionDto"
       responses:
-        '200':
+        "200":
           description: Update enterprise connection
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnterpriseConnectionDto'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/EnterpriseConnectionDto"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /alert-receivers:
     post:
       summary: Create alert receiver
       tags:
         - Alert Receivers
       responses:
-        '201':
-          description: ' Alert receiver successfully created'
+        "201":
+          description: " Alert receiver successfully created"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertReceiverResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/AlertReceiverResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
       operationId: createAlertReceiver
       x-stoplight:
         id: 56wdp3pyd4jfy
@@ -13207,27 +13207,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertReceiverCreationRequest'
-  '/alert-receivers/{alertReceiverId}':
+              $ref: "#/components/schemas/AlertReceiverCreationRequest"
+  "/alert-receivers/{alertReceiverId}":
     parameters:
-      - $ref: '#/components/parameters/alertReceiverId'
+      - $ref: "#/components/parameters/alertReceiverId"
     get:
       summary: Get alert receiver
       tags:
         - Alert Receivers
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertReceiverResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AlertReceiverResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: getAlertReceiver
       x-stoplight:
         id: z0qs6btegz9c3
@@ -13237,20 +13237,20 @@ paths:
       tags:
         - Alert Receivers
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertReceiverResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AlertReceiverResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: editAlertReceiver
       x-stoplight:
         id: lcy99zdslr1cb
@@ -13259,20 +13259,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertReceiverEditRequest'
+              $ref: "#/components/schemas/AlertReceiverEditRequest"
     delete:
       summary: Delete alert receiver
       tags:
         - Alert Receivers
       responses:
-        '204':
+        "204":
           description: Alert receiver successfully deleted
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: deleteAlertReceiver
       x-stoplight:
         id: vwt0mube2wcb6
@@ -13283,18 +13283,18 @@ paths:
       tags:
         - Alert Rules
       responses:
-        '201':
+        "201":
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertRuleResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
+                $ref: "#/components/schemas/AlertRuleResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
       operationId: createAlertRule
       x-stoplight:
         id: htbtqo7s45dzg
@@ -13303,27 +13303,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertRuleCreationRequest'
-  '/alert-rules/{alertRuleId}':
+              $ref: "#/components/schemas/AlertRuleCreationRequest"
+  "/alert-rules/{alertRuleId}":
     parameters:
-      - $ref: '#/components/parameters/alertRuleId'
+      - $ref: "#/components/parameters/alertRuleId"
     get:
       summary: Get alert rule
       tags:
         - Alert Rules
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertRuleResponse'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AlertRuleResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: getAlertRule
       x-stoplight:
         id: qfitd78wejspk
@@ -13333,20 +13333,20 @@ paths:
       tags:
         - Alert Rules
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertRuleResponse'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AlertRuleResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: editAlertRule
       x-stoplight:
         id: cj5a3t08qw1aj
@@ -13355,66 +13355,66 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertRuleEditRequest'
+              $ref: "#/components/schemas/AlertRuleEditRequest"
     delete:
       summary: Delete alert rule
       tags:
         - Alert Rules
       responses:
-        '204':
+        "204":
           description: Alert rule successfully deleted
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: deleteAlertRule
       x-stoplight:
         id: 812453spx2l0f
       description: Delete an alert rule
-  '/organization/{organizationId}/alert-rules':
+  "/organization/{organizationId}/alert-rules":
     parameters:
-      - $ref: '#/components/parameters/organizationId'
+      - $ref: "#/components/parameters/organizationId"
     get:
       summary: List alert rules
       tags:
         - Alert Rules
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AlertRuleList'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+                $ref: "#/components/schemas/AlertRuleList"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: getAlertRules
       x-stoplight:
         id: xkza3tt52gwse
       description: Retrieve all alert rules for a specific organization
-  '/alert-receivers/{alertReceiverId}/validate':
+  "/alert-receivers/{alertReceiverId}/validate":
     parameters:
-      - $ref: '#/components/parameters/alertReceiverId'
+      - $ref: "#/components/parameters/alertReceiverId"
     post:
       summary: Validate Existing Alert Receiver
       tags:
         - Alert Receivers
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: validateExistingAlertReceiver
       x-stoplight:
         id: uz8sv9wwxy3ib
@@ -13423,23 +13423,23 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertReceiverValidationRequest'
+              $ref: "#/components/schemas/AlertReceiverValidationRequest"
   /alert-receivers/validate:
     post:
       summary: Validate New Alert Receiver
       tags:
         - Alert Receivers
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
       operationId: validateNewAlertReceiver
       x-stoplight:
         id: jqejmmiehaxlm
@@ -13447,7 +13447,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertReceiverCreationValidationRequest'
+              $ref: "#/components/schemas/AlertReceiverCreationValidationRequest"
       description: Validate a future alert receiver by sending a test message.
 components:
   parameters:
@@ -13813,7 +13813,7 @@ components:
         argocd_url:
           type: string
           description: The URL of the ArgoCD instance (e.g. https://argocd.example.com)
-          example: 'https://argocd.example.com'
+          example: "https://argocd.example.com"
         argocd_token:
           type: string
           description: ArgoCD API authentication token
@@ -13835,7 +13835,7 @@ components:
           format: uuid
         argocd_url:
           type: string
-          example: 'https://argocd.example.com'
+          example: "https://argocd.example.com"
         argocd_token:
           type: string
           description: Always returned as REDACTED
@@ -13881,13 +13881,13 @@ components:
             - kubernetes
           properties:
             kubernetes:
-              $ref: '#/components/schemas/TerraformBackendKubernetes'
+              $ref: "#/components/schemas/TerraformBackendKubernetes"
         - type: object
           required:
             - user_provided
           properties:
             user_provided:
-              $ref: '#/components/schemas/TerraformBackendUserProvided'
+              $ref: "#/components/schemas/TerraformBackendUserProvided"
       description: Configuration for Terraform backend - exactly one backend type must be specified
     TerraformBackendKubernetes:
       type: object
@@ -13944,9 +13944,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_type:
-          $ref: '#/components/schemas/APIVariableTypeEnum'
+          $ref: "#/components/schemas/APIVariableTypeEnum"
         description:
           type: string
           x-stoplight:
@@ -13982,6 +13982,17 @@ components:
             Define how you want pods affinity to behave:
             * `Preferred` allows, but does not require, pods of a given service are not co-located (or co-hosted) on a single node
             * `Requirred` ensures that the pods of a given service are not co-located (or co-hosted) on a single node (safer in term of availability but can be expensive depending on the number of replicas)
+        deployment.topology_spread.zone:
+          type: string
+          enum:
+            - Disabled
+            - ScheduleAnyway
+            - DoNotSchedule
+          description: |
+            Define how you want pods to be spread across availability zones:
+            * `Disabled` no topology spread constraints are applied
+            * `ScheduleAnyway` pods are spread across zones on a best-effort basis (soft constraint)
+            * `DoNotSchedule` pods must be evenly spread across zones with a maxSkew of 1 (hard constraint)
         deployment.lifecycle.post_start_exec_command:
           type: array
           x-stoplight:
@@ -14031,7 +14042,7 @@ components:
           type: boolean
           x-stoplight:
             id: am7oh5tdono3z
-          description: 'When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available'
+          description: "When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available"
         network.ingress.enable_cors:
           type: boolean
         network.ingress.cors_allow_origin:
@@ -14127,8 +14138,8 @@ components:
             Mounts the container's root filesystem as read-only
     Application:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/ServiceStorage'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/ServiceStorage"
         - type: object
           required:
             - environment
@@ -14138,9 +14149,9 @@ components:
             - service_type
           properties:
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             git_repository:
-              $ref: '#/components/schemas/ApplicationGitRepository'
+              $ref: "#/components/schemas/ApplicationGitRepository"
             maximum_cpu:
               type: integer
               description: Maximum cpu that can be allocated to the application based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu
@@ -14162,7 +14173,7 @@ components:
               type: string
               description: give a description to this application
             build_mode:
-              $ref: '#/components/schemas/BuildModeEnum'
+              $ref: "#/components/schemas/BuildModeEnum"
             dockerfile_path:
               type: string
               description: The path of the associated Dockerfile. Only if you are using build_mode = DOCKER
@@ -14195,7 +14206,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             auto_preview:
               type: boolean
               description: |
@@ -14204,7 +14215,7 @@ components:
                 If not specified, it takes the value of the `auto_preview` property from the associated environment.
               default: true
             ports:
-              $ref: '#/components/schemas/ServicePortResponseList'
+              $ref: "#/components/schemas/ServicePortResponseList"
             arguments:
               type: array
               items:
@@ -14216,9 +14227,9 @@ components:
               type: boolean
               description: Specify if the application will be automatically updated after receiving a new commit.
             annotations_groups:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
             labels_groups:
-              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
             icon_uri:
               type: string
               format: uri
@@ -14226,7 +14237,7 @@ components:
               x-stoplight:
                 id: b8karc43pdxpu
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
             docker_target_build_stage:
               type: string
               x-stoplight:
@@ -14234,11 +14245,11 @@ components:
               description: The target build stage in the Dockerfile to build
               nullable: true
             autoscaling:
-              $ref: '#/components/schemas/AutoscalingPolicyResponse'
+              $ref: "#/components/schemas/AutoscalingPolicyResponse"
     ApplicationDeploymentRestriction:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/ApplicationDeploymentRestrictionRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/ApplicationDeploymentRestrictionRequest"
     ApplicationDeploymentRestrictionRequest:
       type: object
       required:
@@ -14247,12 +14258,12 @@ components:
         - value
       properties:
         mode:
-          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
         type:
-          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
         value:
           type: string
-          description: 'For `PATH` restrictions, the value must not start with `/`'
+          description: "For `PATH` restrictions, the value must not start with `/`"
           example: application1/src/
     ApplicationDeploymentRestrictionResponseList:
       type: object
@@ -14260,10 +14271,10 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ApplicationDeploymentRestriction'
+            $ref: "#/components/schemas/ApplicationDeploymentRestriction"
     ApplicationEditRequest:
       allOf:
-        - $ref: '#/components/schemas/ServiceStorageRequest'
+        - $ref: "#/components/schemas/ServiceStorageRequest"
         - type: object
           required:
             - healthchecks
@@ -14275,9 +14286,9 @@ components:
               type: string
               description: give a description to this application
             git_repository:
-              $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+              $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
             build_mode:
-              $ref: '#/components/schemas/BuildModeEnum'
+              $ref: "#/components/schemas/BuildModeEnum"
             dockerfile_path:
               type: string
               description: The path of the associated Dockerfile
@@ -14313,7 +14324,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             auto_preview:
               type: boolean
               description: |
@@ -14322,7 +14333,7 @@ components:
                 If not specified, it takes the value of the `auto_preview` property from the associated environment.
               default: true
             ports:
-              $ref: '#/components/schemas/ServicePortResponseList'
+              $ref: "#/components/schemas/ServicePortResponseList"
             arguments:
               type: array
               items:
@@ -14335,9 +14346,9 @@ components:
               description: Specify if the application will be automatically updated after receiving a new commit.
               nullable: true
             annotations_groups:
-              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
+              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
             labels_groups:
-              $ref: '#/components/schemas/ServiceLabelsRequestList'
+              $ref: "#/components/schemas/ServiceLabelsRequestList"
             icon_uri:
               type: string
               format: uri
@@ -14347,7 +14358,7 @@ components:
               description: The target build stage in the Dockerfile to build
               nullable: true
             autoscaling:
-              $ref: '#/components/schemas/AutoscalingPolicyRequest'
+              $ref: "#/components/schemas/AutoscalingPolicyRequest"
     ApplicationGitRepository:
       type: object
       required:
@@ -14359,7 +14370,7 @@ components:
         has_access:
           type: boolean
         provider:
-          $ref: '#/components/schemas/GitProviderEnum'
+          $ref: "#/components/schemas/GitProviderEnum"
         owner:
           type: string
           example: John Doe
@@ -14394,7 +14405,7 @@ components:
         git_token_name:
           type: string
           nullable: true
-      title: ''
+      title: ""
     ApplicationGitRepositoryRequest:
       type: object
       required:
@@ -14406,7 +14417,7 @@ components:
         url:
           type: string
           description: application git repository URL
-          example: 'https://github.com/Qovery/simple-node-app'
+          example: "https://github.com/Qovery/simple-node-app"
         branch:
           type: string
           description: |
@@ -14423,7 +14434,7 @@ components:
           description: The git token id on Qovery side
           nullable: true
         provider:
-          $ref: '#/components/schemas/GitProviderEnum'
+          $ref: "#/components/schemas/GitProviderEnum"
     ApplicationNetwork:
       type: object
       properties:
@@ -14470,7 +14481,7 @@ components:
           type: boolean
           description: is the default port to use for domain
         protocol:
-          $ref: '#/components/schemas/PortProtocolEnum'
+          $ref: "#/components/schemas/PortProtocolEnum"
         public_path:
           type: string
           description: |-
@@ -14487,7 +14498,7 @@ components:
     ServicePortResponseList:
       type: array
       items:
-        $ref: '#/components/schemas/ServicePort'
+        $ref: "#/components/schemas/ServicePort"
     ServicePortRequest:
       type: object
       properties:
@@ -14519,7 +14530,7 @@ components:
                 type: boolean
                 description: is the default port to use for domain
               protocol:
-                $ref: '#/components/schemas/PortProtocolEnum'
+                $ref: "#/components/schemas/PortProtocolEnum"
               public_path:
                 type: string
                 description: |-
@@ -14536,7 +14547,7 @@ components:
     ServiceAnnotationsRequestList:
       type: array
       items:
-        $ref: '#/components/schemas/ServiceAnnotationRequest'
+        $ref: "#/components/schemas/ServiceAnnotationRequest"
     ServiceAnnotationRequest:
       type: object
       required:
@@ -14548,7 +14559,7 @@ components:
     ServiceLabelsRequestList:
       type: array
       items:
-        $ref: '#/components/schemas/ServiceLabelRequest'
+        $ref: "#/components/schemas/ServiceLabelRequest"
     ServiceLabelRequest:
       type: object
       required:
@@ -14559,8 +14570,8 @@ components:
           format: uuid
     ApplicationRequest:
       allOf:
-        - $ref: '#/components/schemas/ServiceStorageRequest'
-        - $ref: '#/components/schemas/ServicePortRequest'
+        - $ref: "#/components/schemas/ServiceStorageRequest"
+        - $ref: "#/components/schemas/ServicePortRequest"
         - type: object
           required:
             - name
@@ -14575,9 +14586,9 @@ components:
               description: give a description to this application
               nullable: true
             git_repository:
-              $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+              $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
             build_mode:
-              $ref: '#/components/schemas/BuildModeEnum'
+              $ref: "#/components/schemas/BuildModeEnum"
             dockerfile_path:
               type: string
               description: The path of the associated Dockerfile. Only if you are using build_mode = DOCKER
@@ -14613,7 +14624,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             auto_preview:
               type: boolean
               description: |
@@ -14633,9 +14644,9 @@ components:
               description: Specify if the application will be automatically updated after receiving a new commit.
               nullable: true
             annotations_groups:
-              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
+              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
             labels_groups:
-              $ref: '#/components/schemas/ServiceLabelsRequestList'
+              $ref: "#/components/schemas/ServiceLabelsRequestList"
             icon_uri:
               type: string
               format: uri
@@ -14649,14 +14660,14 @@ components:
               description: The target build stage in the Dockerfile to build
               nullable: true
             autoscaling:
-              $ref: '#/components/schemas/AutoscalingPolicyRequest'
+              $ref: "#/components/schemas/AutoscalingPolicyRequest"
     ApplicationResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Application'
+            $ref: "#/components/schemas/Application"
     ServiceStorage:
       type: object
       properties:
@@ -14674,7 +14685,7 @@ components:
                 type: string
                 format: uuid
               type:
-                $ref: '#/components/schemas/StorageTypeEnum'
+                $ref: "#/components/schemas/StorageTypeEnum"
               size:
                 type: integer
                 description: unit is GB
@@ -14698,7 +14709,7 @@ components:
                 type: string
                 format: uuid
               type:
-                $ref: '#/components/schemas/StorageTypeEnum'
+                $ref: "#/components/schemas/StorageTypeEnum"
               size:
                 type: integer
                 description: |
@@ -14716,7 +14727,7 @@ components:
         - is_mandatory
       properties:
         kind:
-          $ref: '#/components/schemas/ContainerRegistryKindEnum'
+          $ref: "#/components/schemas/ContainerRegistryKindEnum"
         required_config:
           type: object
           additionalProperties: true
@@ -14728,7 +14739,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/AvailableContainerRegistryResponse'
+            $ref: "#/components/schemas/AvailableContainerRegistryResponse"
     AvailableHelmRepositoryResponse:
       type: object
       required:
@@ -14737,7 +14748,7 @@ components:
         - is_mandatory
       properties:
         kind:
-          $ref: '#/components/schemas/HelmRepositoryKindEnum'
+          $ref: "#/components/schemas/HelmRepositoryKindEnum"
         required_config:
           type: object
           additionalProperties: true
@@ -14749,11 +14760,11 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/AvailableHelmRepositoryResponse'
+            $ref: "#/components/schemas/AvailableHelmRepositoryResponse"
     AwsCredentialsRequest:
       oneOf:
-        - $ref: '#/components/schemas/AwsRoleCredentialsRequest'
-        - $ref: '#/components/schemas/AwsStaticCredentialsRequest'
+        - $ref: "#/components/schemas/AwsRoleCredentialsRequest"
+        - $ref: "#/components/schemas/AwsStaticCredentialsRequest"
     AwsStaticCredentialsRequest:
       required:
         - name
@@ -14792,16 +14803,16 @@ components:
           type: string
     Backup:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/BackupRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/BackupRequest"
         - type: object
           properties:
             status:
-              $ref: '#/components/schemas/Status'
+              $ref: "#/components/schemas/Status"
     BackupPaginatedResponseList:
       allOf:
-        - $ref: '#/components/schemas/PaginationData'
-        - $ref: '#/components/schemas/BackupResponseList'
+        - $ref: "#/components/schemas/PaginationData"
+        - $ref: "#/components/schemas/BackupResponseList"
     BackupRequest:
       type: object
       required:
@@ -14818,7 +14829,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Backup'
+            $ref: "#/components/schemas/Backup"
     Base:
       type: object
       required:
@@ -14852,7 +14863,7 @@ components:
           type: string
           format: email
           example: forrest@gump.com
-          description: 'email used for billing, and to receive all invoices by email'
+          description: "email used for billing, and to receive all invoices by email"
           nullable: true
         address:
           type: string
@@ -14864,7 +14875,7 @@ components:
           nullable: true
         zip:
           type: string
-          example: '36744'
+          example: "36744"
           nullable: true
         state:
           type: string
@@ -14904,7 +14915,7 @@ components:
           type: string
           format: email
           example: forrest@gump.com
-          description: 'email used for billing, and to receive all invoices by email'
+          description: "email used for billing, and to receive all invoices by email"
         address:
           type: string
           example: 21 Jenny Street
@@ -14913,7 +14924,7 @@ components:
           example: Greenbow
         zip:
           type: string
-          example: '36744'
+          example: "36744"
         state:
           type: string
           example: Alabama
@@ -14970,7 +14981,7 @@ components:
           type: string
           format: uuid
         mode:
-          $ref: '#/components/schemas/EnvironmentModeEnum'
+          $ref: "#/components/schemas/EnvironmentModeEnum"
         apply_deployment_rule:
           type: boolean
           default: false
@@ -15000,7 +15011,7 @@ components:
         regions:
           type: array
           items:
-            $ref: '#/components/schemas/ClusterRegion'
+            $ref: "#/components/schemas/ClusterRegion"
     CloudProviderEnum:
       type: string
       enum:
@@ -15015,7 +15026,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/CloudProvider'
+            $ref: "#/components/schemas/CloudProvider"
     CloudVendorEnum:
       type: string
       enum:
@@ -15032,7 +15043,7 @@ components:
         - ON_PREMISE
     Cluster:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - organization
@@ -15041,7 +15052,7 @@ components:
             - cloud_provider
           properties:
             organization:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             name:
               type: string
               description: name is case-insensitive
@@ -15050,7 +15061,7 @@ components:
             region:
               type: string
             cloud_provider:
-              $ref: '#/components/schemas/CloudVendorEnum'
+              $ref: "#/components/schemas/CloudVendorEnum"
             min_running_nodes:
               type: integer
               default: 1
@@ -15077,9 +15088,9 @@ components:
             instance_type:
               type: string
               example: T3A_LARGE
-              description: 'the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType'
+              description: "the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType"
             kubernetes:
-              $ref: '#/components/schemas/KubernetesEnum'
+              $ref: "#/components/schemas/KubernetesEnum"
             cpu:
               type: integer
               example: 10000
@@ -15090,9 +15101,9 @@ components:
               description: unit is MB. 1024 MB = 1GB
             estimated_cloud_provider_cost:
               type: integer
-              description: 'This is an estimation of the cost this cluster will represent on your cloud proider bill, based on your current configuration'
+              description: "This is an estimation of the cost this cluster will represent on your cloud proider bill, based on your current configuration"
             status:
-              $ref: '#/components/schemas/ClusterStateEnum'
+              $ref: "#/components/schemas/ClusterStateEnum"
             has_access:
               type: boolean
             version:
@@ -15113,19 +15124,19 @@ components:
             features:
               type: array
               items:
-                $ref: '#/components/schemas/ClusterFeatureResponse'
+                $ref: "#/components/schemas/ClusterFeatureResponse"
             deployment_status:
-              $ref: '#/components/schemas/ClusterDeploymentStatusEnum'
+              $ref: "#/components/schemas/ClusterDeploymentStatusEnum"
             metrics_parameters:
-              $ref: '#/components/schemas/MetricsParameters'
+              $ref: "#/components/schemas/MetricsParameters"
             infrastructure_outputs:
-              $ref: '#/components/schemas/InfrastructureOutputs'
+              $ref: "#/components/schemas/InfrastructureOutputs"
             infrastructure_charts_parameters:
-              $ref: '#/components/schemas/ClusterInfrastructureChartsParameters'
+              $ref: "#/components/schemas/ClusterInfrastructureChartsParameters"
             keda:
-              $ref: '#/components/schemas/ClusterKeda'
+              $ref: "#/components/schemas/ClusterKeda"
             labels_groups:
-              $ref: '#/components/schemas/ClusterLabelsGroupList'
+              $ref: "#/components/schemas/ClusterLabelsGroupList"
     ClusterDeleteMode:
       type: string
       description: |
@@ -15151,7 +15162,7 @@ components:
           type: string
           description: log date creation
           format: date-time
-          example: '2022-06-22T14:20:17.733084815Z'
+          example: "2022-06-22T14:20:17.733084815Z"
         step:
           description: log step
           example: Create
@@ -15227,7 +15238,7 @@ components:
                   description: technical details about the error
         details:
           type: object
-          description: 'Present only for `info`, `warning` and `debug` logs'
+          description: "Present only for `info`, `warning` and `debug` logs"
           properties:
             provider_kind:
               type: string
@@ -15252,7 +15263,7 @@ components:
       type: object
       properties:
         cloud_provider:
-          $ref: '#/components/schemas/CloudProviderEnum'
+          $ref: "#/components/schemas/CloudProviderEnum"
         credentials:
           type: object
           properties:
@@ -15267,7 +15278,7 @@ components:
       type: object
       properties:
         cloud_provider:
-          $ref: '#/components/schemas/CloudProviderEnum'
+          $ref: "#/components/schemas/CloudProviderEnum"
         credentials:
           type: object
           properties:
@@ -15295,21 +15306,21 @@ components:
             type: string
     ClusterCredentials:
       oneOf:
-        - $ref: '#/components/schemas/AwsStaticClusterCredentials'
-        - $ref: '#/components/schemas/ScalewayClusterCredentials'
-        - $ref: '#/components/schemas/GenericClusterCredentials'
-        - $ref: '#/components/schemas/AwsRoleClusterCredentials'
-        - $ref: '#/components/schemas/AzureStaticClusterCredentials'
-        - $ref: '#/components/schemas/GcpStaticClusterCredentials'
+        - $ref: "#/components/schemas/AwsStaticClusterCredentials"
+        - $ref: "#/components/schemas/ScalewayClusterCredentials"
+        - $ref: "#/components/schemas/GenericClusterCredentials"
+        - $ref: "#/components/schemas/AwsRoleClusterCredentials"
+        - $ref: "#/components/schemas/AzureStaticClusterCredentials"
+        - $ref: "#/components/schemas/GcpStaticClusterCredentials"
       discriminator:
         propertyName: object_type
         mapping:
-          AWS: '#/components/schemas/AwsStaticClusterCredentials'
-          AWS_ROLE: '#/components/schemas/AwsRoleClusterCredentials'
-          SCW: '#/components/schemas/ScalewayClusterCredentials'
-          OTHER: '#/components/schemas/GenericClusterCredentials'
-          AZURE: '#/components/schemas/AzureStaticClusterCredentials'
-          GCP: '#/components/schemas/GcpStaticClusterCredentials'
+          AWS: "#/components/schemas/AwsStaticClusterCredentials"
+          AWS_ROLE: "#/components/schemas/AwsRoleClusterCredentials"
+          SCW: "#/components/schemas/ScalewayClusterCredentials"
+          OTHER: "#/components/schemas/GenericClusterCredentials"
+          AZURE: "#/components/schemas/AzureStaticClusterCredentials"
+          GCP: "#/components/schemas/GcpStaticClusterCredentials"
     AwsStaticClusterCredentials:
       x-stoplight:
         id: s0aosg7la96hp
@@ -15419,7 +15430,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ClusterCredentials'
+            $ref: "#/components/schemas/ClusterCredentials"
     ClusterFeatureResponse:
       type: object
       properties:
@@ -15453,7 +15464,7 @@ components:
           example: true
         cloud_provider_feature_documentation:
           type: string
-          example: 'https://cloud.provider.doc/feature'
+          example: "https://cloud.provider.doc/feature"
           nullable: true
         is_qovery_paying_feature:
           type: boolean
@@ -15461,7 +15472,7 @@ components:
           example: true
         qovery_feature_documentation:
           type: string
-          example: 'https://qovery.doc/feature'
+          example: "https://qovery.doc/feature"
           nullable: true
         value_type:
           type: string
@@ -15471,19 +15482,19 @@ components:
         value_object:
           nullable: true
           oneOf:
-            - $ref: '#/components/schemas/ClusterFeatureStringResponse'
-            - $ref: '#/components/schemas/ClusterFeatureBooleanResponse'
-            - $ref: '#/components/schemas/ClusterFeatureAwsExistingVpcResponse'
-            - $ref: '#/components/schemas/ClusterFeatureGcpExistingVpcResponse'
-            - $ref: '#/components/schemas/ClusterFeatureKarpenterParametersResponse'
+            - $ref: "#/components/schemas/ClusterFeatureStringResponse"
+            - $ref: "#/components/schemas/ClusterFeatureBooleanResponse"
+            - $ref: "#/components/schemas/ClusterFeatureAwsExistingVpcResponse"
+            - $ref: "#/components/schemas/ClusterFeatureGcpExistingVpcResponse"
+            - $ref: "#/components/schemas/ClusterFeatureKarpenterParametersResponse"
           discriminator:
             propertyName: type
             mapping:
-              STRING: '#/components/schemas/ClusterFeatureStringResponse'
-              BOOLEAN: '#/components/schemas/ClusterFeatureBooleanResponse'
-              AWS_USER_PROVIDED_NETWORK: '#/components/schemas/ClusterFeatureAwsExistingVpcResponse'
-              GCP_USER_PROVIDED_NETWORK: '#/components/schemas/ClusterFeatureGcpExistingVpcResponse'
-              KARPENTER: '#/components/schemas/ClusterFeatureKarpenterParametersResponse'
+              STRING: "#/components/schemas/ClusterFeatureStringResponse"
+              BOOLEAN: "#/components/schemas/ClusterFeatureBooleanResponse"
+              AWS_USER_PROVIDED_NETWORK: "#/components/schemas/ClusterFeatureAwsExistingVpcResponse"
+              GCP_USER_PROVIDED_NETWORK: "#/components/schemas/ClusterFeatureGcpExistingVpcResponse"
+              KARPENTER: "#/components/schemas/ClusterFeatureKarpenterParametersResponse"
         is_value_updatable:
           type: boolean
           default: false
@@ -15508,7 +15519,7 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
+          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
         value:
           type: string
     ClusterFeatureBooleanResponse:
@@ -15518,7 +15529,7 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
+          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
         value:
           type: boolean
     ClusterFeatureAwsExistingVpcResponse:
@@ -15528,9 +15539,9 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
+          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
         value:
-          $ref: '#/components/schemas/ClusterFeatureAwsExistingVpc'
+          $ref: "#/components/schemas/ClusterFeatureAwsExistingVpc"
     ClusterFeatureGcpExistingVpcResponse:
       type: object
       required:
@@ -15538,9 +15549,9 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
+          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
         value:
-          $ref: '#/components/schemas/ClusterFeatureGcpExistingVpc'
+          $ref: "#/components/schemas/ClusterFeatureGcpExistingVpc"
     ClusterFeatureAwsExistingVpc:
       type: object
       required:
@@ -15667,7 +15678,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ClusterFeatureResponse'
+            $ref: "#/components/schemas/ClusterFeatureResponse"
     ClusterInstanceTypeResponseList:
       type: object
       properties:
@@ -15697,7 +15708,7 @@ components:
                 example: 8
               bandwidth_in_gbps:
                 type: string
-                example: '5.2'
+                example: "5.2"
               bandwidth_guarantee:
                 type: string
                 example: UpTo
@@ -15705,9 +15716,9 @@ components:
                 type: string
                 example: ARM64
               gpu_info:
-                $ref: '#/components/schemas/ClusterInstanceGpuInfo'
+                $ref: "#/components/schemas/ClusterInstanceGpuInfo"
               attributes:
-                $ref: '#/components/schemas/ClusterInstanceAttributes'
+                $ref: "#/components/schemas/ClusterInstanceAttributes"
     ClusterReadinessStatus:
       type: object
       properties:
@@ -15744,7 +15755,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ClusterRegion'
+            $ref: "#/components/schemas/ClusterRegion"
     ClusterRequest:
       type: object
       required:
@@ -15760,9 +15771,9 @@ components:
         region:
           type: string
         cloud_provider:
-          $ref: '#/components/schemas/CloudVendorEnum'
+          $ref: "#/components/schemas/CloudVendorEnum"
         cloud_provider_credentials:
-          $ref: '#/components/schemas/ClusterCloudProviderInfoRequest'
+          $ref: "#/components/schemas/ClusterCloudProviderInfoRequest"
         min_running_nodes:
           type: integer
           default: 1
@@ -15789,9 +15800,9 @@ components:
         instance_type:
           type: string
           example: T3A_LARGE
-          description: 'the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType'
+          description: "the instance type to be used for this cluster. The list of values can be retrieved via the endpoint /{CloudProvider}/instanceType"
         kubernetes:
-          $ref: '#/components/schemas/KubernetesEnum'
+          $ref: "#/components/schemas/KubernetesEnum"
         production:
           type: boolean
           description: specific flag to indicate that this cluster is a production one
@@ -15814,31 +15825,31 @@ components:
                 oneOf:
                   - type: string
                   - type: boolean
-                  - $ref: '#/components/schemas/ClusterFeatureAwsExistingVpc'
-                  - $ref: '#/components/schemas/ClusterFeatureGcpExistingVpc'
-                  - $ref: '#/components/schemas/ClusterFeatureKarpenterParameters'
+                  - $ref: "#/components/schemas/ClusterFeatureAwsExistingVpc"
+                  - $ref: "#/components/schemas/ClusterFeatureGcpExistingVpc"
+                  - $ref: "#/components/schemas/ClusterFeatureKarpenterParameters"
         metrics_parameters:
-          $ref: '#/components/schemas/MetricsParameters'
+          $ref: "#/components/schemas/MetricsParameters"
         infrastructure_charts_parameters:
-          $ref: '#/components/schemas/ClusterInfrastructureChartsParameters'
+          $ref: "#/components/schemas/ClusterInfrastructureChartsParameters"
         keda:
-          $ref: '#/components/schemas/ClusterKeda'
+          $ref: "#/components/schemas/ClusterKeda"
         labels_groups:
-          $ref: '#/components/schemas/ClusterLabelsGroupList'
+          $ref: "#/components/schemas/ClusterLabelsGroupList"
     ClusterResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Cluster'
+            $ref: "#/components/schemas/Cluster"
     ClusterLogsResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ClusterLogs'
+            $ref: "#/components/schemas/ClusterLogs"
     ClusterRoutingTable:
       type: object
       properties:
@@ -15884,29 +15895,29 @@ components:
           type: string
           format: uuid
         status:
-          $ref: '#/components/schemas/ClusterStateEnum'
+          $ref: "#/components/schemas/ClusterStateEnum"
         is_deployed:
           type: boolean
         next_k8s_available_version:
           type: string
           nullable: true
-          example: '1.28'
+          example: "1.28"
         last_execution_id:
           type: string
           example: f73e3833-922a-48a5-9dbd-6163f43f9143-1656410242
         cluster_lock:
-          $ref: '#/components/schemas/ClusterLock'
+          $ref: "#/components/schemas/ClusterLock"
         last_deployment_date:
           type: string
           format: date-time
-          example: '2022-06-22T14:20:17.733084815Z'
+          example: "2022-06-22T14:20:17.733084815Z"
     ClusterStatusResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ClusterStatus'
+            $ref: "#/components/schemas/ClusterStatus"
     ClusterAdvancedSettings:
       type: object
       properties:
@@ -16012,7 +16023,7 @@ components:
           type: integer
           deprecated: true
         registry.mirroring_mode:
-          $ref: '#/components/schemas/RegistryMirroringModeEnum'
+          $ref: "#/components/schemas/RegistryMirroringModeEnum"
         nginx.vcpu.request_in_milli_cpu:
           type: integer
           description: vcpu request in millicores
@@ -16098,7 +16109,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Commit'
+            $ref: "#/components/schemas/Commit"
     CompanySizeEnum:
       type: string
       enum:
@@ -16130,6 +16141,17 @@ components:
             Define how you want pods affinity to behave:
             * `Preferred` allows, but does not require, pods of a given service are not co-located (or co-hosted) on a single node
             * `Requirred` ensures that the pods of a given service are not co-located (or co-hosted) on a single node (safer in term of availability but can be expensive depending on the number of replicas)
+        deployment.topology_spread.zone:
+          type: string
+          enum:
+            - Disabled
+            - ScheduleAnyway
+            - DoNotSchedule
+          description: |
+            Define how you want pods to be spread across availability zones:
+            * `Disabled` no topology spread constraints are applied
+            * `ScheduleAnyway` pods are spread across zones on a best-effort basis (soft constraint)
+            * `DoNotSchedule` pods must be evenly spread across zones with a maxSkew of 1 (hard constraint)
         deployment.update_strategy.type:
           type: string
           enum:
@@ -16150,7 +16172,7 @@ components:
           type: boolean
           x-stoplight:
             id: xrdjy3znm8mpg
-          description: 'When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available'
+          description: "When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available"
         network.ingress.enable_cors:
           type: boolean
         network.ingress.cors_allow_origin:
@@ -16310,7 +16332,7 @@ components:
         name:
           type: string
         kind:
-          $ref: '#/components/schemas/ContainerRegistryKindEnum'
+          $ref: "#/components/schemas/ContainerRegistryKindEnum"
         description:
           type: string
         url:
@@ -16373,7 +16395,7 @@ components:
               type: string
               x-stoplight:
                 id: mzi9w1zsswj47
-              description: 'For ECR, you can either set a static access_key or use a role arn that we are going to assume'
+              description: "For ECR, you can either set a static access_key or use a role arn that we are going to assume"
             azure_tenant_id:
               type: string
               x-stoplight:
@@ -16386,13 +16408,13 @@ components:
               description: Required if kind is `AZURE_CR`.
     ContainerRegistryResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
             kind:
-              $ref: '#/components/schemas/ContainerRegistryKindEnum'
+              $ref: "#/components/schemas/ContainerRegistryKindEnum"
             description:
               type: string
             url:
@@ -16480,24 +16502,24 @@ components:
           type: string
           description: URL of the container registry
         kind:
-          $ref: '#/components/schemas/ContainerRegistryKindEnum'
+          $ref: "#/components/schemas/ContainerRegistryKindEnum"
     ContainerRegistryResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ContainerRegistryResponse'
+            $ref: "#/components/schemas/ContainerRegistryResponse"
     ContainerVersionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ContainerVersionResponse'
+            $ref: "#/components/schemas/ContainerVersionResponse"
     HelmRepositoryResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -16505,7 +16527,7 @@ components:
             name:
               type: string
             kind:
-              $ref: '#/components/schemas/HelmRepositoryKindEnum'
+              $ref: "#/components/schemas/HelmRepositoryKindEnum"
             description:
               type: string
             url:
@@ -16574,7 +16596,7 @@ components:
         name:
           type: string
         kind:
-          $ref: '#/components/schemas/HelmRepositoryKindEnum'
+          $ref: "#/components/schemas/HelmRepositoryKindEnum"
         description:
           type: string
         url:
@@ -16628,14 +16650,14 @@ components:
               description: Required if kind is `AZURE_CR`.
             role_arn:
               type: string
-              description: 'For ECR, you can either set a static access_key or use a role arn that we are going to assume'
+              description: "For ECR, you can either set a static access_key or use a role arn that we are going to assume"
     HelmVersionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/HelmVersionResponse'
+            $ref: "#/components/schemas/HelmVersionResponse"
     HelmVersionResponse:
       type: object
       properties:
@@ -16651,11 +16673,11 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/HelmRepositoryResponse'
+            $ref: "#/components/schemas/HelmRepositoryResponse"
     ContainerRequest:
       allOf:
-        - $ref: '#/components/schemas/ServiceStorageRequest'
-        - $ref: '#/components/schemas/ServicePortRequest'
+        - $ref: "#/components/schemas/ServiceStorageRequest"
+        - $ref: "#/components/schemas/ServicePortRequest"
         - type: object
           required:
             - name
@@ -16722,7 +16744,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             auto_preview:
               type: boolean
               description: |
@@ -16736,9 +16758,9 @@ components:
                 The new image tag shall be communicated via the "Auto Deploy container" endpoint https://api-doc.qovery.com/#tag/Containers/operation/autoDeployContainerEnvironments
               nullable: true
             annotations_groups:
-              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
+              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
             labels_groups:
-              $ref: '#/components/schemas/ServiceLabelsRequestList'
+              $ref: "#/components/schemas/ServiceLabelsRequestList"
             icon_uri:
               type: string
               format: uri
@@ -16746,12 +16768,12 @@ components:
               x-stoplight:
                 id: jiypvl6nd63dm
             autoscaling:
-              $ref: '#/components/schemas/AutoscalingPolicyRequest'
+              $ref: "#/components/schemas/AutoscalingPolicyRequest"
     ContainerResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/ServiceStorage'
-        - $ref: '#/components/schemas/ContainerSource'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/ServiceStorage"
+        - $ref: "#/components/schemas/ContainerSource"
         - type: object
           required:
             - environment
@@ -16770,7 +16792,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             maximum_cpu:
               type: integer
               description: Maximum cpu that can be allocated to the container based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu
@@ -16829,7 +16851,7 @@ components:
                 Note: -1 means that there is no limit.
               default: 1
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             auto_preview:
               type: boolean
               description: |
@@ -16837,16 +16859,16 @@ components:
                 If enabled, a preview environment will be automatically cloned when `/preview` endpoint is called.  
                 If not specified, it takes the value of the `auto_preview` property from the associated environment.
             ports:
-              $ref: '#/components/schemas/ServicePortResponseList'
+              $ref: "#/components/schemas/ServicePortResponseList"
             auto_deploy:
               type: boolean
               description: |
                 Specify if the container will be automatically updated after receiving a new image tag. 
                 The new image tag shall be communicated via the "Auto Deploy container" endpoint https://api-doc.qovery.com/#tag/Containers/operation/autoDeployContainerEnvironments
             annotations_groups:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
             labels_groups:
-              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
             icon_uri:
               type: string
               format: uri
@@ -16854,16 +16876,16 @@ components:
               x-stoplight:
                 id: o2bdci7ak3bmz
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
             autoscaling:
-              $ref: '#/components/schemas/AutoscalingPolicyResponse'
+              $ref: "#/components/schemas/AutoscalingPolicyResponse"
     ContainerResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ContainerResponse'
+            $ref: "#/components/schemas/ContainerResponse"
     ContainerSource:
       type: object
       required:
@@ -16886,7 +16908,7 @@ components:
           type: string
           description: tag of the image container
         registry:
-          $ref: '#/components/schemas/ContainerRegistryProviderDetailsResponse'
+          $ref: "#/components/schemas/ContainerRegistryProviderDetailsResponse"
     Cost:
       type: object
       required:
@@ -16976,7 +16998,7 @@ components:
           example: 2025
         last_digit:
           type: string
-          example: '7890'
+          example: "7890"
         is_expired:
           type: boolean
         brand:
@@ -17009,12 +17031,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/CreditCard'
+            $ref: "#/components/schemas/CreditCard"
     CurrentCost:
       type: object
       properties:
         plan:
-          $ref: '#/components/schemas/PlanEnum'
+          $ref: "#/components/schemas/PlanEnum"
         remaining_trial_day:
           type: integer
           description: number of days remaining before the end of the trial period
@@ -17025,18 +17047,18 @@ components:
           nullable: true
           format: date-time
         cost:
-          $ref: '#/components/schemas/Cost'
+          $ref: "#/components/schemas/Cost"
     CustomDomain:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/CustomDomainRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/CustomDomainRequest"
         - type: object
           properties:
             validation_domain:
               type: string
               description: URL provided by Qovery. You must create a CNAME on your DNS provider using that URL
             status:
-              $ref: '#/components/schemas/CustomDomainStatusEnum'
+              $ref: "#/components/schemas/CustomDomainStatusEnum"
             generate_certificate:
               type: boolean
               description: to control if a certificate has to be generated for this custom domain by Qovery. The default value is `true`. This flag should be set to `false` if a CDN or other entities are managing the certificate for the specified domain and the traffic is proxied by the CDN to Qovery.
@@ -17073,7 +17095,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/CustomDomain'
+            $ref: "#/components/schemas/CustomDomain"
     CustomDomainStatusEnum:
       type: string
       enum:
@@ -17081,8 +17103,8 @@ components:
       example: VALIDATION_PENDING
     Database:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/DatabaseRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/DatabaseRequest"
         - type: object
           required:
             - environment
@@ -17090,7 +17112,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             host:
               type: string
             port:
@@ -17110,24 +17132,24 @@ components:
             instance_type:
               type: string
               example: db.t3.medium
-              description: 'Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field is null for container DB.'
+              description: "Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field is null for container DB."
             disk_type:
               type: string
               nullable: true
-              description: 'EBS disk type for the database. Only applicable for MANAGED mode (gp2 or gp3). Null for CONTAINER mode.'
+              description: "EBS disk type for the database. Only applicable for MANAGED mode (gp2 or gp3). Null for CONTAINER mode."
               enum:
                 - gp2
                 - gp3
             annotations_groups:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
             labels_groups:
-              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
             icon_uri:
               type: string
               format: uri
               description: Icon URI representing the database.
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
     DatabaseAccessibilityEnum:
       type: string
       default: PRIVATE
@@ -17138,18 +17160,18 @@ components:
       type: object
       properties:
         database_type:
-          $ref: '#/components/schemas/DatabaseTypeEnum'
+          $ref: "#/components/schemas/DatabaseTypeEnum"
         version:
           type: array
           items:
-            $ref: '#/components/schemas/DatabaseVersionMode'
+            $ref: "#/components/schemas/DatabaseVersionMode"
     DatabaseConfigurationResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/DatabaseConfiguration'
+            $ref: "#/components/schemas/DatabaseConfiguration"
     DatabaseEditRequest:
       type: object
       properties:
@@ -17161,9 +17183,9 @@ components:
           description: give a description to this database
         version:
           type: string
-          example: '10.1'
+          example: "10.1"
         accessibility:
-          $ref: '#/components/schemas/DatabaseAccessibilityEnum'
+          $ref: "#/components/schemas/DatabaseAccessibilityEnum"
         cpu:
           type: integer
           description: |
@@ -17191,11 +17213,11 @@ components:
         instance_type:
           type: string
           example: db.t3.medium
-          description: 'Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB.'
+          description: "Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB."
         annotations_groups:
-          $ref: '#/components/schemas/ServiceAnnotationsRequestList'
+          $ref: "#/components/schemas/ServiceAnnotationsRequestList"
         labels_groups:
-          $ref: '#/components/schemas/ServiceLabelsRequestList'
+          $ref: "#/components/schemas/ServiceLabelsRequestList"
         icon_uri:
           type: string
           format: uri
@@ -17206,7 +17228,7 @@ components:
           enum:
             - gp2
             - gp3
-          description: 'EBS disk type for MANAGED AWS databases. Allowed values: gp2, gp3. Only applicable for MANAGED mode.'
+          description: "EBS disk type for MANAGED AWS databases. Allowed values: gp2, gp3. Only applicable for MANAGED mode."
     DatabaseModeEnum:
       type: string
       enum:
@@ -17227,14 +17249,14 @@ components:
           type: string
           description: give a description to this database
         type:
-          $ref: '#/components/schemas/DatabaseTypeEnum'
+          $ref: "#/components/schemas/DatabaseTypeEnum"
         version:
           type: string
-          example: '10.1'
+          example: "10.1"
         mode:
-          $ref: '#/components/schemas/DatabaseModeEnum'
+          $ref: "#/components/schemas/DatabaseModeEnum"
         accessibility:
-          $ref: '#/components/schemas/DatabaseAccessibilityEnum'
+          $ref: "#/components/schemas/DatabaseAccessibilityEnum"
         cpu:
           type: integer
           description: |
@@ -17245,7 +17267,7 @@ components:
         instance_type:
           type: string
           example: db.t3.medium
-          description: 'Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB.'
+          description: "Database instance type to be used for this database. The list of values can be retrieved via the endpoint /{CloudProvider}/managedDatabase/instanceType/{region}/{dbType}. This field SHOULD NOT be set for container DB."
         memory:
           type: integer
           description: |
@@ -17264,9 +17286,9 @@ components:
           description: unit is GB
           default: 10
         annotations_groups:
-          $ref: '#/components/schemas/ServiceAnnotationsRequestList'
+          $ref: "#/components/schemas/ServiceAnnotationsRequestList"
         labels_groups:
-          $ref: '#/components/schemas/ServiceLabelsRequestList'
+          $ref: "#/components/schemas/ServiceLabelsRequestList"
         icon_uri:
           type: string
           format: uri
@@ -17279,7 +17301,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Database'
+            $ref: "#/components/schemas/Database"
     DatabaseTypeEnum:
       type: string
       enum:
@@ -17292,9 +17314,9 @@ components:
       properties:
         name:
           type: string
-          example: '10.1'
+          example: "10.1"
         supported_mode:
-          $ref: '#/components/schemas/DatabaseModeEnum'
+          $ref: "#/components/schemas/DatabaseModeEnum"
     DeployAllRequest:
       type: object
       properties:
@@ -17367,7 +17389,7 @@ components:
         terraforms:
           type: array
           items:
-            $ref: '#/components/schemas/TerraformDeployRequest'
+            $ref: "#/components/schemas/TerraformDeployRequest"
     DeployRequest:
       type: object
       required:
@@ -17378,16 +17400,16 @@ components:
           description: Commit ID to deploy
     DeploymentHistory:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
               description: name of the service
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             status:
-              $ref: '#/components/schemas/DeploymentHistoryStatusEnum'
+              $ref: "#/components/schemas/DeploymentHistoryStatusEnum"
     DeploymentHistoryTriggerAction:
       x-stoplight:
         id: 1hzy6riqo7lq4
@@ -17404,25 +17426,25 @@ components:
         - UNINSTALL
     DeploymentHistoryApplication:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             status:
-              $ref: '#/components/schemas/StateEnum'
+              $ref: "#/components/schemas/StateEnum"
     DeploymentHistoryDatabase:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
               description: name of the service
             status:
-              $ref: '#/components/schemas/StateEnum'
+              $ref: "#/components/schemas/StateEnum"
     DeploymentHistoryAuditingData:
       x-stoplight:
         id: 5oovmby4u1mxw
@@ -17447,17 +17469,17 @@ components:
           x-stoplight:
             id: hf405wx2g73py
         origin:
-          $ref: '#/components/schemas/OrganizationEventOrigin'
+          $ref: "#/components/schemas/OrganizationEventOrigin"
     DeploymentHistoryContainer:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
               description: name of the container
             status:
-              $ref: '#/components/schemas/StateEnum'
+              $ref: "#/components/schemas/StateEnum"
             image_name:
               type: string
             tag:
@@ -17470,35 +17492,35 @@ components:
               type: string
     DeploymentHistoryEnvironment:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             status:
-              $ref: '#/components/schemas/StateEnum'
+              $ref: "#/components/schemas/StateEnum"
             origin:
-              $ref: '#/components/schemas/OrganizationEventOrigin'
+              $ref: "#/components/schemas/OrganizationEventOrigin"
             triggered_by:
               type: string
             applications:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryApplication'
+                $ref: "#/components/schemas/DeploymentHistoryApplication"
             containers:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryContainer'
+                $ref: "#/components/schemas/DeploymentHistoryContainer"
             databases:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryDatabase'
+                $ref: "#/components/schemas/DeploymentHistoryDatabase"
             jobs:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryJobResponse'
+                $ref: "#/components/schemas/DeploymentHistoryJobResponse"
             helms:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryHelmResponse'
+                $ref: "#/components/schemas/DeploymentHistoryHelmResponse"
     DeploymentHistoryEnvironmentV2:
       x-stoplight:
         id: j6o3qzzhhu0me
@@ -17530,11 +17552,11 @@ components:
                 id: 6o54s8cbk0lo6
               format: uuid
         auditing_data:
-          $ref: '#/components/schemas/DeploymentHistoryAuditingData'
+          $ref: "#/components/schemas/DeploymentHistoryAuditingData"
         status:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         trigger_action:
-          $ref: '#/components/schemas/DeploymentHistoryTriggerAction'
+          $ref: "#/components/schemas/DeploymentHistoryTriggerAction"
         total_duration:
           type: string
           x-stoplight:
@@ -17545,9 +17567,9 @@ components:
           x-stoplight:
             id: rz2b0h9r3p6tv
           items:
-            $ref: '#/components/schemas/DeploymentHistoryStage'
+            $ref: "#/components/schemas/DeploymentHistoryStage"
         action_status:
-          $ref: '#/components/schemas/DeploymentHistoryActionStatus'
+          $ref: "#/components/schemas/DeploymentHistoryActionStatus"
     DeploymentHistoryStage:
       type: object
       x-stoplight:
@@ -17563,7 +17585,7 @@ components:
           x-stoplight:
             id: e1fv4x2xo0wo0
         status:
-          $ref: '#/components/schemas/StageStatusEnum'
+          $ref: "#/components/schemas/StageStatusEnum"
         duration:
           type: string
           x-stoplight:
@@ -17574,7 +17596,7 @@ components:
           x-stoplight:
             id: sel4jtb8tbjwz
           items:
-            $ref: '#/components/schemas/DeploymentHistoryService'
+            $ref: "#/components/schemas/DeploymentHistoryService"
     JobLifecyleSchedule:
       type: object
       x-stoplight:
@@ -17648,19 +17670,19 @@ components:
                 id: 0hb95ufaj9z82
               format: uuid
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
             execution_id:
               type: string
               x-stoplight:
                 id: 9ww6nh5lrwg37
         status:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         auditing_data:
-          $ref: '#/components/schemas/DeploymentHistoryAuditingData'
+          $ref: "#/components/schemas/DeploymentHistoryAuditingData"
         details:
-          $ref: '#/components/schemas/DeploymentHistoryServiceDetails'
+          $ref: "#/components/schemas/DeploymentHistoryServiceDetails"
         status_details:
-          $ref: '#/components/schemas/StatusDetails'
+          $ref: "#/components/schemas/StatusDetails"
         icon_uri:
           type: string
           x-stoplight:
@@ -17682,7 +17704,7 @@ components:
             - build_pod_name
           properties:
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             build_pod_name:
               type: string
               description: The build pod name prefix for monitoring build runner usage. Format build-{execution_id}-0
@@ -17715,20 +17737,20 @@ components:
             tag:
               type: string
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             schedule:
               type: object
               properties:
                 on_start:
-                  $ref: '#/components/schemas/JobLifecyleSchedule'
+                  $ref: "#/components/schemas/JobLifecyleSchedule"
                 on_stop:
-                  $ref: '#/components/schemas/JobLifecyleSchedule'
+                  $ref: "#/components/schemas/JobLifecyleSchedule"
                 on_delete:
-                  $ref: '#/components/schemas/JobLifecyleSchedule'
+                  $ref: "#/components/schemas/JobLifecyleSchedule"
                 cron_job:
-                  $ref: '#/components/schemas/JobCronSchedule'
+                  $ref: "#/components/schemas/JobCronSchedule"
                 lifecycle_type:
-                  $ref: '#/components/schemas/JobLifecycleTypeEnum'
+                  $ref: "#/components/schemas/JobLifecycleTypeEnum"
             job_type:
               x-stoplight:
                 id: tz8apy1pqi9c5
@@ -17743,7 +17765,7 @@ components:
           type: object
           properties:
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             repository:
               type: object
               properties:
@@ -17754,44 +17776,44 @@ components:
       type: object
     DeploymentHistoryEnvironmentPaginatedResponseList:
       allOf:
-        - $ref: '#/components/schemas/PaginationData'
+        - $ref: "#/components/schemas/PaginationData"
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryEnvironment'
+                $ref: "#/components/schemas/DeploymentHistoryEnvironment"
     DeploymentHistoryEnvironmentPaginatedResponseListV2:
       allOf:
-        - $ref: '#/components/schemas/PaginationData'
+        - $ref: "#/components/schemas/PaginationData"
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryEnvironmentV2'
+                $ref: "#/components/schemas/DeploymentHistoryEnvironmentV2"
       x-stoplight:
         id: 0anfgzdi689ht
     DeploymentHistoryServicePaginatedResponseListV2:
       allOf:
-        - $ref: '#/components/schemas/PaginationData'
+        - $ref: "#/components/schemas/PaginationData"
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistoryService'
+                $ref: "#/components/schemas/DeploymentHistoryService"
       x-stoplight:
         id: e2g667def2r2z
     DeploymentHistoryPaginatedResponseList:
       allOf:
-        - $ref: '#/components/schemas/PaginationData'
+        - $ref: "#/components/schemas/PaginationData"
         - type: object
           properties:
             results:
               type: array
               items:
-                $ref: '#/components/schemas/DeploymentHistory'
+                $ref: "#/components/schemas/DeploymentHistory"
     DeploymentHistoryStatusEnum:
       type: string
       enum:
@@ -17811,7 +17833,7 @@ components:
       example: PATH
     Environment:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -17825,9 +17847,9 @@ components:
               type: string
               description: name is case insensitive
             organization:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             project:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             last_updated_by:
               type: string
               format: uuid
@@ -17842,7 +17864,7 @@ components:
                   type: string
                   example: us-east-2
             mode:
-              $ref: '#/components/schemas/EnvironmentModeEnum'
+              $ref: "#/components/schemas/EnvironmentModeEnum"
             cluster_id:
               type: string
               format: uuid
@@ -17855,14 +17877,14 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Environment'
+            $ref: "#/components/schemas/Environment"
     EnvironmentOverviewResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/EnvironmentOverviewResponse'
+            $ref: "#/components/schemas/EnvironmentOverviewResponse"
     EnvironmentOverviewResponse:
       type: object
       required:
@@ -17885,15 +17907,15 @@ components:
         name:
           type: string
         mode:
-          $ref: '#/components/schemas/EnvironmentModeEnum'
+          $ref: "#/components/schemas/EnvironmentModeEnum"
         cluster:
-          $ref: '#/components/schemas/ClusterOverviewResponse'
+          $ref: "#/components/schemas/ClusterOverviewResponse"
           nullable: true
         service_count:
           type: integer
           format: int32
         deployment_status:
-          $ref: '#/components/schemas/EnvironmentStatus'
+          $ref: "#/components/schemas/EnvironmentStatus"
           nullable: true
     ClusterOverviewResponse:
       type: object
@@ -17909,12 +17931,12 @@ components:
         name:
           type: string
         cloud_provider:
-          $ref: '#/components/schemas/CloudVendorEnum'
+          $ref: "#/components/schemas/CloudVendorEnum"
         is_demo:
           type: boolean
     EnvironmentDeploymentRule:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - timezone
@@ -17937,15 +17959,15 @@ components:
             start_time:
               type: string
               format: date-time
-              example: '1970-01-01T08:00:00.000Z'
+              example: "1970-01-01T08:00:00.000Z"
             stop_time:
               type: string
               format: date-time
-              example: '1970-01-01T19:00:00.000Z'
+              example: "1970-01-01T19:00:00.000Z"
             weekdays:
               type: array
               items:
-                $ref: '#/components/schemas/WeekdayEnum'
+                $ref: "#/components/schemas/WeekdayEnum"
     EnvironmentDeploymentRuleEditRequest:
       type: object
       required:
@@ -17969,22 +17991,22 @@ components:
         start_time:
           type: string
           format: date-time
-          example: '1970-01-01T08:00:00.000Z'
+          example: "1970-01-01T08:00:00.000Z"
         stop_time:
           type: string
           format: date-time
-          example: '1970-01-01T19:00:00.000Z'
+          example: "1970-01-01T19:00:00.000Z"
         weekdays:
           type: array
           items:
-            $ref: '#/components/schemas/WeekdayEnum'
+            $ref: "#/components/schemas/WeekdayEnum"
     EnvironmentEditRequest:
       type: object
       properties:
         name:
           type: string
         mode:
-          $ref: '#/components/schemas/CreateEnvironmentModeEnum'
+          $ref: "#/components/schemas/CreateEnvironmentModeEnum"
     EnvironmentLog:
       type: object
       required:
@@ -18004,14 +18026,14 @@ components:
           type: object
           properties:
             type:
-              $ref: '#/components/schemas/EnvironmentLogTypeEnum'
+              $ref: "#/components/schemas/EnvironmentLogTypeEnum"
             name:
               type: string
             id:
               type: string
               format: uuid
         state:
-          $ref: '#/components/schemas/StatusKindEnum'
+          $ref: "#/components/schemas/StatusKindEnum"
         message:
           type: string
           nullable: true
@@ -18101,11 +18123,11 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/EnvironmentLog'
+            $ref: "#/components/schemas/EnvironmentLog"
     EnvironmentLogsResponseList:
       type: array
       items:
-        $ref: '#/components/schemas/EnvironmentLogs'
+        $ref: "#/components/schemas/EnvironmentLogs"
     EnvironmentLogTypeEnum:
       type: string
       enum:
@@ -18139,11 +18161,11 @@ components:
           type: string
           format: uuid
         mode:
-          $ref: '#/components/schemas/CreateEnvironmentModeEnum'
+          $ref: "#/components/schemas/CreateEnvironmentModeEnum"
     EnvironmentStats:
       allOf:
-        - $ref: '#/components/schemas/ReferenceObject'
-        - $ref: '#/components/schemas/ServiceTotalNumber'
+        - $ref: "#/components/schemas/ReferenceObject"
+        - $ref: "#/components/schemas/ServiceTotalNumber"
     EnvironmentStatus:
       type: object
       required:
@@ -18155,13 +18177,13 @@ components:
           type: string
           format: uuid
         state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         last_deployment_date:
           type: string
           format: date-time
           nullable: true
         last_deployment_state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         last_deployment_id:
           type: string
           nullable: true
@@ -18169,12 +18191,12 @@ components:
           type: integer
           nullable: true
         origin:
-          $ref: '#/components/schemas/EnvironmentStatusEventOriginEnum'
+          $ref: "#/components/schemas/EnvironmentStatusEventOriginEnum"
         triggered_by:
           type: string
           nullable: true
         deployment_status:
-          $ref: '#/components/schemas/EnvironmentDeploymentStatusEnum'
+          $ref: "#/components/schemas/EnvironmentDeploymentStatusEnum"
         deployment_request_id:
           type: string
           format: uuid
@@ -18183,14 +18205,14 @@ components:
           type: array
           nullable: true
           items:
-            $ref: '#/components/schemas/StageStepMetrics'
+            $ref: "#/components/schemas/StageStepMetrics"
     EnvironmentStatsResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/EnvironmentStats'
+            $ref: "#/components/schemas/EnvironmentStats"
     EnvironmentStatuses:
       type: object
       required:
@@ -18203,31 +18225,31 @@ components:
         - terraforms
       properties:
         environment:
-          $ref: '#/components/schemas/EnvironmentStatus'
+          $ref: "#/components/schemas/EnvironmentStatus"
         applications:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         containers:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         jobs:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         databases:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         helms:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         terraforms:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
     EnvironmentStatusEventOriginEnum:
       type: string
       nullable: true
@@ -18244,18 +18266,18 @@ components:
       type: object
       properties:
         environment:
-          $ref: '#/components/schemas/EnvironmentStatus'
+          $ref: "#/components/schemas/EnvironmentStatus"
         stages:
           type: array
           items:
-            $ref: '#/components/schemas/DeploymentStageWithServicesStatuses'
+            $ref: "#/components/schemas/DeploymentStageWithServicesStatuses"
         pre_check_stage:
           type: object
           x-stoplight:
             id: l9y5i1bt4jmsk
           properties:
             status:
-              $ref: '#/components/schemas/StepMetricStatusEnum'
+              $ref: "#/components/schemas/StepMetricStatusEnum"
             total_duration_sec:
               type: integer
               x-stoplight:
@@ -18266,7 +18288,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/EnvironmentStatus'
+            $ref: "#/components/schemas/EnvironmentStatus"
     EnvironmentTotalNumber:
       type: object
       required:
@@ -18276,31 +18298,31 @@ components:
           type: number
     EnvironmentVariable:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/EnvironmentVariableRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/EnvironmentVariableRequest"
         - type: object
           required:
             - scope
             - variable_type
           properties:
             overridden_variable:
-              $ref: '#/components/schemas/EnvironmentVariableOverride'
+              $ref: "#/components/schemas/EnvironmentVariableOverride"
             aliased_variable:
-              $ref: '#/components/schemas/EnvironmentVariableAlias'
+              $ref: "#/components/schemas/EnvironmentVariableAlias"
             scope:
-              $ref: '#/components/schemas/APIVariableScopeEnum'
+              $ref: "#/components/schemas/APIVariableScopeEnum"
             variable_type:
-              $ref: '#/components/schemas/APIVariableTypeEnum'
+              $ref: "#/components/schemas/APIVariableTypeEnum"
             service_id:
               type: string
               format: uuid
             service_name:
               type: string
             service_type:
-              $ref: '#/components/schemas/LinkedServiceTypeEnum'
+              $ref: "#/components/schemas/LinkedServiceTypeEnum"
             owned_by:
               type: string
-              description: 'Entity that created/own the variable (i.e: Qovery, Doppler)'
+              description: "Entity that created/own the variable (i.e: Qovery, Doppler)"
     EnvironmentVariableAlias:
       type: object
       required:
@@ -18322,9 +18344,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_type:
-          $ref: '#/components/schemas/APIVariableTypeEnum'
+          $ref: "#/components/schemas/APIVariableTypeEnum"
     EnvironmentVariableOverride:
       type: object
       required:
@@ -18345,9 +18367,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_type:
-          $ref: '#/components/schemas/APIVariableTypeEnum'
+          $ref: "#/components/schemas/APIVariableTypeEnum"
     EnvironmentVariableEditRequest:
       type: object
       required:
@@ -18410,7 +18432,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/EnvironmentVariable'
+            $ref: "#/components/schemas/EnvironmentVariable"
     EnvironmentServiceIdsAllRequest:
       type: object
       properties:
@@ -18494,7 +18516,7 @@ components:
           type: integer
           example: 3600
         cost:
-          $ref: '#/components/schemas/Cost'
+          $ref: "#/components/schemas/Cost"
     GitAuthProvider:
       type: object
       required:
@@ -18517,7 +18539,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/GitAuthProvider'
+            $ref: "#/components/schemas/GitAuthProvider"
     GitProviderEnum:
       type: string
       enum:
@@ -18538,7 +18560,7 @@ components:
           example: simple-node-app
         url:
           type: string
-          example: 'https://github.com/Qovery/simple-node-app'
+          example: "https://github.com/Qovery/simple-node-app"
         default_branch:
           type: string
           example: master
@@ -18558,14 +18580,14 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/GitRepositoryBranch'
+            $ref: "#/components/schemas/GitRepositoryBranch"
     GitRepositoryResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/GitRepository'
+            $ref: "#/components/schemas/GitRepository"
     GitTokenAssociatedServiceType:
       type: string
       enum:
@@ -18601,14 +18623,14 @@ components:
         service_name:
           type: string
         service_type:
-          $ref: '#/components/schemas/GitTokenAssociatedServiceType'
+          $ref: "#/components/schemas/GitTokenAssociatedServiceType"
     GitTokenAssociatedServicesResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/GitTokenAssociatedServiceResponse'
+            $ref: "#/components/schemas/GitTokenAssociatedServiceResponse"
     GitTokenRequest:
       type: object
       required:
@@ -18621,13 +18643,13 @@ components:
         description:
           type: string
         type:
-          $ref: '#/components/schemas/GitProviderEnum'
+          $ref: "#/components/schemas/GitProviderEnum"
         token:
           type: string
           description: The token from your git provider side
         workspace:
           type: string
-          description: 'Mandatory only for BITBUCKET git provider, to allow us to fetch repositories at creation/edition of a service'
+          description: "Mandatory only for BITBUCKET git provider, to allow us to fetch repositories at creation/edition of a service"
         git_api_url:
           type: string
           x-stoplight:
@@ -18638,7 +18660,7 @@ components:
             I.e: Self-hosted version of Gitlab
     GitTokenResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -18651,7 +18673,7 @@ components:
             description:
               type: string
             type:
-              $ref: '#/components/schemas/GitProviderEnum'
+              $ref: "#/components/schemas/GitProviderEnum"
             expired_at:
               type: string
               format: date
@@ -18672,18 +18694,18 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/GitTokenResponse'
+            $ref: "#/components/schemas/GitTokenResponse"
     Healthcheck:
       type: object
       nullable: false
       properties:
         readiness_probe:
-          $ref: '#/components/schemas/Probe'
+          $ref: "#/components/schemas/Probe"
         liveness_probe:
-          $ref: '#/components/schemas/Probe'
+          $ref: "#/components/schemas/Probe"
     InviteMember:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - email
@@ -18696,12 +18718,12 @@ components:
               type: string
               format: email
             role:
-              $ref: '#/components/schemas/InviteMemberRoleEnum'
+              $ref: "#/components/schemas/InviteMemberRoleEnum"
             invitation_link:
               type: string
               format: uri
             invitation_status:
-              $ref: '#/components/schemas/InviteStatusEnum'
+              $ref: "#/components/schemas/InviteStatusEnum"
             organization_name:
               type: string
             inviter:
@@ -18722,7 +18744,7 @@ components:
         email:
           type: string
         role:
-          $ref: '#/components/schemas/InviteMemberRoleEnum'
+          $ref: "#/components/schemas/InviteMemberRoleEnum"
         role_id:
           type: string
           format: uuid
@@ -18733,7 +18755,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/InviteMember'
+            $ref: "#/components/schemas/InviteMember"
     InviteMemberRoleEnum:
       type: string
       description: deprecated
@@ -18749,7 +18771,7 @@ components:
         - PENDING
     Invoice:
       allOf:
-        - $ref: '#/components/schemas/Cost'
+        - $ref: "#/components/schemas/Cost"
         - type: object
           required:
             - id
@@ -18766,14 +18788,14 @@ components:
               type: string
               format: date-time
             status:
-              $ref: '#/components/schemas/InvoiceStatusEnum'
+              $ref: "#/components/schemas/InvoiceStatusEnum"
     InvoiceResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Invoice'
+            $ref: "#/components/schemas/Invoice"
     InvoiceStatusEnum:
       type: string
       enum:
@@ -18798,13 +18820,13 @@ components:
           description: free test describing this stage
     DeploymentStageResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - environment
           properties:
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             name:
               type: string
               description: name is case insensitive
@@ -18815,21 +18837,21 @@ components:
               description: Position of the deployment stage within the environment
               example: 1
             services:
-              $ref: '#/components/schemas/DeploymentStageServiceResponseList'
+              $ref: "#/components/schemas/DeploymentStageServiceResponseList"
     DeploymentStageResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/DeploymentStageResponse'
+            $ref: "#/components/schemas/DeploymentStageResponse"
     DeploymentStageServiceResponseList:
       type: array
       items:
-        $ref: '#/components/schemas/DeploymentStageServiceResponse'
+        $ref: "#/components/schemas/DeploymentStageServiceResponse"
     DeploymentStageServiceResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             service_id:
@@ -18838,7 +18860,7 @@ components:
               description: id of the service attached to the stage
             service_type:
               type: string
-              description: 'type of the service (i.e APPLICATION, JOB, DATABASE, ...)'
+              description: "type of the service (i.e APPLICATION, JOB, DATABASE, ...)"
             is_skipped:
               type: boolean
               description: whether the service is excluded from environment-level deployments
@@ -18848,29 +18870,29 @@ components:
         applications:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         containers:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         jobs:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         databases:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         helms:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         terraforms:
           type: array
           items:
-            $ref: '#/components/schemas/Status'
+            $ref: "#/components/schemas/Status"
         stage:
-          $ref: '#/components/schemas/Stage'
+          $ref: "#/components/schemas/Stage"
     DockerfileCheckRequest:
       type: object
       required:
@@ -18878,7 +18900,7 @@ components:
         - dockerfile_path
       properties:
         git_repository:
-          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
         dockerfile_path:
           type: string
           description: path of the dockerfile with root_path as base path
@@ -18907,7 +18929,7 @@ components:
         - files
       properties:
         git_repository:
-          $ref: '#/components/schemas/HelmGitRepositoryRequest'
+          $ref: "#/components/schemas/HelmGitRepositoryRequest"
         files:
           type: array
           items:
@@ -18920,7 +18942,7 @@ components:
         - git_repository
       properties:
         git_repository:
-          $ref: '#/components/schemas/HelmGitRepositoryRequest'
+          $ref: "#/components/schemas/HelmGitRepositoryRequest"
     HelmCheckResponse:
       type: object
     ContainerImageCheckRequest:
@@ -19017,7 +19039,7 @@ components:
                   nullable: true
                   properties:
                     git_repository:
-                      $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+                      $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
                     dockerfile_path:
                       type: string
                       description: The path of the associated Dockerfile. Only if you are using build_mode = DOCKER
@@ -19035,7 +19057,7 @@ components:
                       description: The target build stage in the Dockerfile to build
                       nullable: true
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             schedule:
               type: object
               description: |
@@ -19097,7 +19119,7 @@ components:
                         See https://crontab.guru/ to WISIWIG interface.  
                         Timezone is UTC
                 lifecycle_type:
-                  $ref: '#/components/schemas/JobLifecycleTypeEnum'
+                  $ref: "#/components/schemas/JobLifecycleTypeEnum"
             auto_deploy:
               type: boolean
               description: |
@@ -19105,9 +19127,9 @@ components:
                 The new image tag shall be communicated via the "Auto Deploy job" endpoint https://api-doc.qovery.com/#tag/Jobs/operation/autoDeployJobEnvironments
               nullable: true
             annotations_groups:
-              $ref: '#/components/schemas/ServiceAnnotationsRequestList'
+              $ref: "#/components/schemas/ServiceAnnotationsRequestList"
             labels_groups:
-              $ref: '#/components/schemas/ServiceLabelsRequestList'
+              $ref: "#/components/schemas/ServiceLabelsRequestList"
             icon_uri:
               type: string
               format: uri
@@ -19117,20 +19139,20 @@ components:
       type: object
     JobResponse:
       oneOf:
-        - $ref: '#/components/schemas/LifecycleJobResponse'
-        - $ref: '#/components/schemas/CronJobResponse'
+        - $ref: "#/components/schemas/LifecycleJobResponse"
+        - $ref: "#/components/schemas/CronJobResponse"
       discriminator:
         propertyName: job_type
         mapping:
-          LIFECYCLE: '#/components/schemas/LifecycleJobResponse'
-          CRON: '#/components/schemas/CronJobResponse'
+          LIFECYCLE: "#/components/schemas/LifecycleJobResponse"
+          CRON: "#/components/schemas/CronJobResponse"
     JobResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/JobResponse'
+            $ref: "#/components/schemas/JobResponse"
     JobAdvancedSettings:
       type: object
       properties:
@@ -19196,24 +19218,24 @@ components:
         - value
       properties:
         mode:
-          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
         type:
-          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
         value:
           type: string
-          description: 'For `PATH` restrictions, the value must not start with `/`'
+          description: "For `PATH` restrictions, the value must not start with `/`"
           example: job1/src/
     JobDeploymentRestrictionResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/JobDeploymentRestrictionRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/JobDeploymentRestrictionRequest"
     JobDeploymentRestrictionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/JobDeploymentRestrictionResponse'
+            $ref: "#/components/schemas/JobDeploymentRestrictionResponse"
     JobScheduleEvent:
       type: string
       enum:
@@ -19236,25 +19258,25 @@ components:
         - CRON
     DeploymentHistoryJobResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
               description: name of the job
             status:
-              $ref: '#/components/schemas/StateEnum'
+              $ref: "#/components/schemas/StateEnum"
             image_name:
               type: string
             tag:
               type: string
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             schedule:
               type: object
               properties:
                 event:
-                  $ref: '#/components/schemas/JobScheduleEvent'
+                  $ref: "#/components/schemas/JobScheduleEvent"
                 schedule_at:
                   type: string
                   format: cron
@@ -19273,7 +19295,7 @@ components:
               type: string
     HelmRequest:
       allOf:
-        - $ref: '#/components/schemas/HelmPortRequest'
+        - $ref: "#/components/schemas/HelmPortRequest"
         - type: object
           required:
             - name
@@ -19309,7 +19331,7 @@ components:
                 - type: object
                   properties:
                     git_repository:
-                      $ref: '#/components/schemas/HelmGitRepositoryRequest'
+                      $ref: "#/components/schemas/HelmGitRepositoryRequest"
                 - type: object
                   properties:
                     helm_repository:
@@ -19343,11 +19365,11 @@ components:
                 Specify helm values you want to set or override
               properties:
                 set:
-                  $ref: '#/components/schemas/HelmKeyValues'
+                  $ref: "#/components/schemas/HelmKeyValues"
                 set_string:
-                  $ref: '#/components/schemas/HelmKeyValues'
+                  $ref: "#/components/schemas/HelmKeyValues"
                 set_json:
-                  $ref: '#/components/schemas/HelmKeyValues'
+                  $ref: "#/components/schemas/HelmKeyValues"
                 file:
                   type: object
                   nullable: true
@@ -19360,7 +19382,7 @@ components:
                         - paths
                       properties:
                         git_repository:
-                          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+                          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
                         paths:
                           type: array
                           description: List of path inside your git repository to locate values file. Must start by a /
@@ -19389,7 +19411,7 @@ components:
                 id: 117p5u95nwx2p
     HelmResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - environment
@@ -19404,7 +19426,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             name:
               type: string
               description: name is case insensitive
@@ -19430,13 +19452,13 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/HelmPortResponseWithServiceName'
-                  - $ref: '#/components/schemas/HelmPortResponseWithServiceSelectors'
+                  - $ref: "#/components/schemas/HelmPortResponseWithServiceName"
+                  - $ref: "#/components/schemas/HelmPortResponseWithServiceSelectors"
                 discriminator:
                   propertyName: port_type
                   mapping:
-                    SERVICE_NAME: '#/components/schemas/HelmPortResponseWithServiceName'
-                    SERVICE_SELECTORS: '#/components/schemas/HelmPortResponseWithServiceSelectors'
+                    SERVICE_NAME: "#/components/schemas/HelmPortResponseWithServiceName"
+                    SERVICE_SELECTORS: "#/components/schemas/HelmPortResponseWithServiceSelectors"
             source:
               nullable: false
               oneOf:
@@ -19444,7 +19466,7 @@ components:
                     - git
                   properties:
                     git:
-                      $ref: '#/components/schemas/HelmSourceGitResponse'
+                      $ref: "#/components/schemas/HelmSourceGitResponse"
                   type: object
                 - x-stoplight:
                     id: 0prdehm6z8pua
@@ -19452,7 +19474,7 @@ components:
                     - repository
                   properties:
                     repository:
-                      $ref: '#/components/schemas/HelmSourceRepositoryResponse'
+                      $ref: "#/components/schemas/HelmSourceRepositoryResponse"
                   type: object
             arguments:
               type: array
@@ -19471,11 +19493,11 @@ components:
                 Specify helm values you want to set or override
               properties:
                 set:
-                  $ref: '#/components/schemas/HelmKeyValues'
+                  $ref: "#/components/schemas/HelmKeyValues"
                 set_string:
-                  $ref: '#/components/schemas/HelmKeyValues'
+                  $ref: "#/components/schemas/HelmKeyValues"
                 set_json:
-                  $ref: '#/components/schemas/HelmKeyValues'
+                  $ref: "#/components/schemas/HelmKeyValues"
                 file:
                   type: object
                   nullable: true
@@ -19508,7 +19530,7 @@ components:
                         - paths
                       properties:
                         git_repository:
-                          $ref: '#/components/schemas/ApplicationGitRepository'
+                          $ref: "#/components/schemas/ApplicationGitRepository"
                         paths:
                           type: array
                           description: List of path inside your git repository to locate values file. Must start by a /
@@ -19521,7 +19543,7 @@ components:
               x-stoplight:
                 id: i2pvbugqsldhe
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
     HelmPortResponseBase:
       type: object
       required:
@@ -19548,13 +19570,13 @@ components:
         namespace:
           type: string
         protocol:
-          $ref: '#/components/schemas/HelmPortProtocolEnum'
+          $ref: "#/components/schemas/HelmPortProtocolEnum"
         is_default:
           type: boolean
           description: is the default port to use for domain
     HelmPortResponseWithServiceName:
       allOf:
-        - $ref: '#/components/schemas/HelmPortResponseBase'
+        - $ref: "#/components/schemas/HelmPortResponseBase"
         - type: object
           required:
             - service_name
@@ -19563,7 +19585,7 @@ components:
               type: string
     HelmPortResponseWithServiceSelectors:
       allOf:
-        - $ref: '#/components/schemas/HelmPortResponseBase'
+        - $ref: "#/components/schemas/HelmPortResponseBase"
         - type: object
           required:
             - service_selectors
@@ -19571,14 +19593,14 @@ components:
             service_selectors:
               type: array
               items:
-                $ref: '#/components/schemas/KubernetesSelector'
+                $ref: "#/components/schemas/KubernetesSelector"
     HelmResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/HelmResponse'
+            $ref: "#/components/schemas/HelmResponse"
     HelmAdvancedSettings:
       type: object
       properties:
@@ -19591,7 +19613,7 @@ components:
           type: boolean
           x-stoplight:
             id: 6tcwjiqqo99ii
-          description: 'When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available'
+          description: "When using SSL offloading outside of cluster, you can enforce a redirect to HTTPS even when there is no TLS certificate available"
         network.ingress.enable_cors:
           type: boolean
         network.ingress.cors_allow_origin:
@@ -19694,24 +19716,24 @@ components:
         - value
       properties:
         mode:
-          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
         type:
-          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
         value:
           type: string
-          description: 'For `PATH` restrictions, the value must not start with `/`'
+          description: "For `PATH` restrictions, the value must not start with `/`"
           example: helm1/src/
     HelmDeploymentRestrictionResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/HelmDeploymentRestrictionRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/HelmDeploymentRestrictionRequest"
     HelmDeploymentRestrictionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/HelmDeploymentRestrictionResponse'
+            $ref: "#/components/schemas/HelmDeploymentRestrictionResponse"
     HelmPortRequest:
       type: object
       properties:
@@ -19736,7 +19758,7 @@ components:
                   namespace:
                     type: string
                   protocol:
-                    $ref: '#/components/schemas/HelmPortProtocolEnum'
+                    $ref: "#/components/schemas/HelmPortProtocolEnum"
                   is_default:
                     type: boolean
                     description: is the default port to use for domain
@@ -19746,7 +19768,7 @@ components:
                       service_selectors:
                         type: array
                         items:
-                          $ref: '#/components/schemas/KubernetesSelector'
+                          $ref: "#/components/schemas/KubernetesSelector"
                   - type: object
                     properties:
                       service_name:
@@ -19757,20 +19779,20 @@ components:
         - DIFF
     DeploymentHistoryHelmResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
               type: string
               description: name of the helm
             status:
-              $ref: '#/components/schemas/StateEnum'
+              $ref: "#/components/schemas/StateEnum"
             commit:
-              $ref: '#/components/schemas/Commit'
+              $ref: "#/components/schemas/Commit"
             repository:
               type: object
               nullable: true
-              description: 'If the chart source if from a repository, the chart name and its version'
+              description: "If the chart source if from a repository, the chart name and its version"
               properties:
                 chart_name:
                   type: string
@@ -19793,7 +19815,7 @@ components:
                 - type: object
                   properties:
                     git_repository:
-                      $ref: '#/components/schemas/HelmGitRepositoryRequest'
+                      $ref: "#/components/schemas/HelmGitRepositoryRequest"
                 - type: object
                   properties:
                     helm_repository:
@@ -19853,7 +19875,7 @@ components:
           format: uuid
           description: ID of the associated service
         service_type:
-          $ref: '#/components/schemas/ServiceTypeEnum'
+          $ref: "#/components/schemas/ServiceTypeEnum"
         url:
           type: string
           description: URL to access the service
@@ -19862,10 +19884,10 @@ components:
           description: The port from which the service is reachable from within the cluster
         external_port:
           type: integer
-          description: 'The port from which the service is reachable from externally (i.e: 443 for HTTPS)'
+          description: "The port from which the service is reachable from externally (i.e: 443 for HTTPS)"
         is_qovery_domain:
           type: boolean
-          description: 'True if the domain is managed by Qovery, false if it belongs to the user'
+          description: "True if the domain is managed by Qovery, false if it belongs to the user"
         is_default:
           type: boolean
           description: |
@@ -19881,10 +19903,10 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Link'
+            $ref: "#/components/schemas/Link"
     LinkedServiceTypeEnum:
       type: string
-      description: 'type of the service (application, database, job, gateway...)'
+      description: "type of the service (application, database, job, gateway...)"
       enum:
         - APPLICATION
         - CONTAINER
@@ -19906,7 +19928,7 @@ components:
         created_at:
           type: string
           format: date-time
-          example: '2022-04-19T15:36:12.024Z'
+          example: "2022-04-19T15:36:12.024Z"
         message:
           type: string
         pod_name:
@@ -19921,7 +19943,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Log'
+            $ref: "#/components/schemas/Log"
     ManagedDatabaseTypeResponse:
       type: object
       required:
@@ -19936,7 +19958,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ManagedDatabaseTypeResponse'
+            $ref: "#/components/schemas/ManagedDatabaseTypeResponse"
     ManagedDatabaseInstanceTypeResponse:
       type: object
       required:
@@ -19951,10 +19973,10 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ManagedDatabaseInstanceTypeResponse'
+            $ref: "#/components/schemas/ManagedDatabaseInstanceTypeResponse"
     Member:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - email
@@ -19974,7 +19996,7 @@ components:
               format: date-time
               description: last time the user was connected
             role:
-              $ref: '#/components/schemas/InviteMemberRoleEnum'
+              $ref: "#/components/schemas/InviteMemberRoleEnum"
             role_name:
               type: string
               description: the role linked to the user
@@ -19987,7 +20009,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Member'
+            $ref: "#/components/schemas/Member"
     MemberRoleUpdateRequest:
       type: object
       required:
@@ -20002,8 +20024,8 @@ components:
           format: uuid
     Organization:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/OrganizationRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/OrganizationRequest"
         - type: object
           properties:
             owner:
@@ -20026,13 +20048,13 @@ components:
               type: object
               properties:
                 plan:
-                  $ref: '#/components/schemas/PlanEnum'
+                  $ref: "#/components/schemas/PlanEnum"
                 audit_logs_retention_in_days:
                   type: number
                   description: audit logs maximum period available in days
     OrganizationApiToken:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
@@ -20046,7 +20068,7 @@ components:
               format: uuid
     OrganizationApiTokenCreate:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             name:
@@ -20072,7 +20094,7 @@ components:
         description:
           type: string
         scope:
-          $ref: '#/components/schemas/OrganizationApiTokenScope'
+          $ref: "#/components/schemas/OrganizationApiTokenScope"
         role_id:
           type: string
           format: uuid
@@ -20084,7 +20106,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationApiToken'
+            $ref: "#/components/schemas/OrganizationApiToken"
     OrganizationApiTokenScope:
       type: string
       nullable: true
@@ -20108,7 +20130,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationAvailableRole'
+            $ref: "#/components/schemas/OrganizationAvailableRole"
     OrganizationChangePlanRequest:
       type: object
       properties:
@@ -20139,7 +20161,7 @@ components:
           type: string
     OrganizationCurrentCost:
       allOf:
-        - $ref: '#/components/schemas/CurrentCost'
+        - $ref: "#/components/schemas/CurrentCost"
         - type: object
     OrganizationCustomRoleCreateRequest:
       type: object
@@ -20171,7 +20193,7 @@ components:
                 type: string
                 format: uuid
               permission:
-                $ref: '#/components/schemas/OrganizationCustomRoleClusterPermission'
+                $ref: "#/components/schemas/OrganizationCustomRoleClusterPermission"
         project_permissions:
           description: Should contain an entry for every existing project
           type: array
@@ -20204,9 +20226,9 @@ components:
                   type: object
                   properties:
                     environment_type:
-                      $ref: '#/components/schemas/EnvironmentModeEnum'
+                      $ref: "#/components/schemas/EnvironmentModeEnum"
                     permission:
-                      $ref: '#/components/schemas/OrganizationCustomRoleProjectPermission'
+                      $ref: "#/components/schemas/OrganizationCustomRoleProjectPermission"
     OrganizationCustomRole:
       type: object
       properties:
@@ -20227,7 +20249,7 @@ components:
               cluster_name:
                 type: string
               permission:
-                $ref: '#/components/schemas/OrganizationCustomRoleClusterPermission'
+                $ref: "#/components/schemas/OrganizationCustomRoleClusterPermission"
         project_permissions:
           type: array
           items:
@@ -20254,16 +20276,16 @@ components:
                   type: object
                   properties:
                     environment_type:
-                      $ref: '#/components/schemas/EnvironmentModeEnum'
+                      $ref: "#/components/schemas/EnvironmentModeEnum"
                     permission:
-                      $ref: '#/components/schemas/OrganizationCustomRoleProjectPermission'
+                      $ref: "#/components/schemas/OrganizationCustomRoleProjectPermission"
     OrganizationCustomRoleList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationCustomRole'
+            $ref: "#/components/schemas/OrganizationCustomRole"
     OrganizationCustomRoleProjectPermission:
       type: string
       description: |
@@ -20341,7 +20363,7 @@ components:
           type: string
           nullable: true
         plan:
-          $ref: '#/components/schemas/PlanEnum'
+          $ref: "#/components/schemas/PlanEnum"
         website_url:
           type: string
           nullable: true
@@ -20365,7 +20387,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Organization'
+            $ref: "#/components/schemas/Organization"
     OrganizationEventResponse:
       type: object
       properties:
@@ -20376,7 +20398,7 @@ components:
           type: string
           format: date-time
         event_type:
-          $ref: '#/components/schemas/OrganizationEventType'
+          $ref: "#/components/schemas/OrganizationEventType"
         target_id:
           type: string
           format: uuid
@@ -20384,13 +20406,13 @@ components:
         target_name:
           type: string
         target_type:
-          $ref: '#/components/schemas/OrganizationEventTargetType'
+          $ref: "#/components/schemas/OrganizationEventTargetType"
         sub_target_type:
-          $ref: '#/components/schemas/OrganizationEventSubTargetType'
+          $ref: "#/components/schemas/OrganizationEventSubTargetType"
         change:
           type: string
         origin:
-          $ref: '#/components/schemas/OrganizationEventOrigin'
+          $ref: "#/components/schemas/OrganizationEventOrigin"
         triggered_by:
           type: string
         project_id:
@@ -20411,8 +20433,8 @@ components:
         original_change:
           type: string
           nullable: true
-      description: ''
-      title: ''
+      description: ""
+      title: ""
     OrganizationEventResponseList:
       type: object
       properties:
@@ -20431,7 +20453,7 @@ components:
         events:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationEventResponse'
+            $ref: "#/components/schemas/OrganizationEventResponse"
     OrganizationEventTargetResponseList:
       type: object
       properties:
@@ -20519,7 +20541,7 @@ components:
         - WEBHOOK
         - TERRAFORM
       example: APPLICATION
-      title: ''
+      title: ""
     OrganizationEventType:
       type: string
       description: Type of the organization event
@@ -20597,9 +20619,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_type:
-          $ref: '#/components/schemas/APIVariableTypeEnum'
+          $ref: "#/components/schemas/APIVariableTypeEnum"
         description:
           type: string
           x-stoplight:
@@ -20620,7 +20642,7 @@ components:
         - events
       properties:
         kind:
-          $ref: '#/components/schemas/OrganizationWebhookKindEnum'
+          $ref: "#/components/schemas/OrganizationWebhookKindEnum"
         target_url:
           type: string
           description: |
@@ -20639,7 +20661,7 @@ components:
         events:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationWebhookEventEnum'
+            $ref: "#/components/schemas/OrganizationWebhookEventEnum"
         project_names_filter:
           type: array
           description: |
@@ -20654,14 +20676,14 @@ components:
             Specify the environment modes you want to filter to.
             This webhook will be triggered only if the event is coming from an environment with the specified mode.
           items:
-            $ref: '#/components/schemas/EnvironmentModeEnum'
+            $ref: "#/components/schemas/EnvironmentModeEnum"
     OrganizationWebhookCreateResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             kind:
-              $ref: '#/components/schemas/OrganizationWebhookKindEnum'
+              $ref: "#/components/schemas/OrganizationWebhookKindEnum"
             target_url:
               type: string
               description: |
@@ -20677,7 +20699,7 @@ components:
             events:
               type: array
               items:
-                $ref: '#/components/schemas/OrganizationWebhookEventEnum'
+                $ref: "#/components/schemas/OrganizationWebhookEventEnum"
             project_names_filter:
               type: array
               description: |
@@ -20692,7 +20714,7 @@ components:
                 Specify the environment modes you want to filter to.
                 This webhook will be triggered only if the event is coming from an environment with the specified mode.
               items:
-                $ref: '#/components/schemas/EnvironmentModeEnum'
+                $ref: "#/components/schemas/EnvironmentModeEnum"
     OrganizationWebhookEventEnum:
       type: string
       description: |
@@ -20733,9 +20755,9 @@ components:
           format: date-time
           description: Timestamp when the webhook event was created
         kind:
-          $ref: '#/components/schemas/OrganizationWebhookKindEnum'
+          $ref: "#/components/schemas/OrganizationWebhookKindEnum"
         matched_event:
-          $ref: '#/components/schemas/OrganizationWebhookEventEnum'
+          $ref: "#/components/schemas/OrganizationWebhookEventEnum"
         target_url_used:
           type: string
           format: uri
@@ -20754,11 +20776,11 @@ components:
           description: Response body from the webhook target
     OrganizationWebhookResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           properties:
             kind:
-              $ref: '#/components/schemas/OrganizationWebhookKindEnum'
+              $ref: "#/components/schemas/OrganizationWebhookKindEnum"
             target_url:
               type: string
               description: |
@@ -20774,7 +20796,7 @@ components:
             events:
               type: array
               items:
-                $ref: '#/components/schemas/OrganizationWebhookEventEnum'
+                $ref: "#/components/schemas/OrganizationWebhookEventEnum"
             project_names_filter:
               type: array
               description: |
@@ -20789,21 +20811,21 @@ components:
                 Specify the environment modes you want to filter to.
                 This webhook will be triggered only if the event is coming from an environment with the specified mode.
               items:
-                $ref: '#/components/schemas/EnvironmentModeEnum'
+                $ref: "#/components/schemas/EnvironmentModeEnum"
     OrganizationWebhookResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationWebhookResponse'
+            $ref: "#/components/schemas/OrganizationWebhookResponse"
     WebhookEventResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/WebhookEventResponse'
+            $ref: "#/components/schemas/WebhookEventResponse"
     GitWebhookStatusResponse:
       type: object
       required:
@@ -20848,18 +20870,18 @@ components:
         annotations:
           type: array
           items:
-            $ref: '#/components/schemas/Annotation'
+            $ref: "#/components/schemas/Annotation"
         scopes:
           type: array
           items:
-            $ref: '#/components/schemas/OrganizationAnnotationsGroupScopeEnum'
+            $ref: "#/components/schemas/OrganizationAnnotationsGroupScopeEnum"
     OrganizationAnnotationsGroupResponseList:
       type: array
       items:
-        $ref: '#/components/schemas/OrganizationAnnotationsGroupResponse'
+        $ref: "#/components/schemas/OrganizationAnnotationsGroupResponse"
     OrganizationAnnotationsGroupResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -20871,11 +20893,11 @@ components:
             annotations:
               type: array
               items:
-                $ref: '#/components/schemas/Annotation'
+                $ref: "#/components/schemas/Annotation"
             scopes:
               type: array
               items:
-                $ref: '#/components/schemas/OrganizationAnnotationsGroupScopeEnum'
+                $ref: "#/components/schemas/OrganizationAnnotationsGroupScopeEnum"
     OrganizationAnnotationsGroupScopeEnum:
       type: string
       description: Annotations Group Scope
@@ -20922,7 +20944,7 @@ components:
               item_name:
                 type: string
               item_type:
-                $ref: '#/components/schemas/AnnotationsGroupAssociatedItemType'
+                $ref: "#/components/schemas/AnnotationsGroupAssociatedItemType"
     AnnotationsGroupAssociatedItemType:
       type: string
       description: Annotations Group Associated Item Type
@@ -20956,15 +20978,15 @@ components:
         labels:
           type: array
           items:
-            $ref: '#/components/schemas/Label'
+            $ref: "#/components/schemas/Label"
     OrganizationLabelsGroupResponseList:
       type: array
       items:
-        $ref: '#/components/schemas/OrganizationLabelsGroupResponse'
-      title: ''
+        $ref: "#/components/schemas/OrganizationLabelsGroupResponse"
+      title: ""
     OrganizationLabelsGroupResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -20975,8 +20997,8 @@ components:
             labels:
               type: array
               items:
-                $ref: '#/components/schemas/Label'
-      title: ''
+                $ref: "#/components/schemas/Label"
+      title: ""
     OrganizationLabelsGroupAssociatedItemsResponseList:
       type: object
       properties:
@@ -21010,7 +21032,7 @@ components:
               item_name:
                 type: string
               item_type:
-                $ref: '#/components/schemas/LabelsGroupAssociatedItemType'
+                $ref: "#/components/schemas/LabelsGroupAssociatedItemType"
     LabelsGroupAssociatedItemType:
       type: string
       description: Labels Group Associated Item Type
@@ -21049,7 +21071,7 @@ components:
           example: 20
     PlanEnum:
       type: string
-      description: 'FREE, BUSINESS & PROFESSIONAL are deprecated. 2025 plans are the new plans available.'
+      description: "FREE, BUSINESS & PROFESSIONAL are deprecated. 2025 plans are the new plans available."
       enum:
         - FREE
         - TEAM
@@ -21106,7 +21128,7 @@ components:
               properties:
                 command:
                   type: array
-                  description: "Command to execute inside the container, specified as an array of strings. The first element is the executable, followed by its arguments. Example: [\"sh\", \"-c\", \"test -f /tmp/healthy\"]"
+                  description: 'Command to execute inside the container, specified as an array of strings. The first element is the executable, followed by its arguments. Example: ["sh", "-c", "test -f /tmp/healthy"]'
                   example: ["sh", "-c", "test -f /tmp/healthy"]
                   items:
                     type: string
@@ -21138,7 +21160,7 @@ components:
           default: 9
     Project:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -21152,27 +21174,27 @@ components:
             associated_environments_count:
               type: integer
             organization:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
     ProjectCurrentCost:
       allOf:
-        - $ref: '#/components/schemas/GenericObjectCurrentCost'
+        - $ref: "#/components/schemas/GenericObjectCurrentCost"
         - type: object
           properties:
             environments:
               type: array
               items:
-                $ref: '#/components/schemas/GenericObjectCurrentCost'
+                $ref: "#/components/schemas/GenericObjectCurrentCost"
     ProjectCurrentCostResponseList:
       type: object
       properties:
         projects:
           type: array
           items:
-            $ref: '#/components/schemas/ProjectCurrentCost'
+            $ref: "#/components/schemas/ProjectCurrentCost"
     ProjectDeploymentRule:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/ProjectDeploymentRuleRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/ProjectDeploymentRuleRequest"
         - type: object
           properties:
             priority_index:
@@ -21200,7 +21222,7 @@ components:
           nullable: true
           example: description project rule
         mode:
-          $ref: '#/components/schemas/EnvironmentModeEnum'
+          $ref: "#/components/schemas/EnvironmentModeEnum"
         cluster_id:
           type: string
           format: uuid
@@ -21213,18 +21235,18 @@ components:
         start_time:
           type: string
           format: date-time
-          example: '1970-01-01T08:00:00.000Z'
+          example: "1970-01-01T08:00:00.000Z"
         stop_time:
           type: string
           format: date-time
-          example: '1970-01-01T19:00:00.000Z'
+          example: "1970-01-01T19:00:00.000Z"
         weekdays:
           type: array
           items:
-            $ref: '#/components/schemas/WeekdayEnum'
+            $ref: "#/components/schemas/WeekdayEnum"
         wildcard:
           type: string
-          default: ''
+          default: ""
           description: wildcard pattern composed of '?' and/or '*' used to target new created environments
     ProjectDeploymentRuleResponseList:
       type: object
@@ -21232,7 +21254,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ProjectDeploymentRule'
+            $ref: "#/components/schemas/ProjectDeploymentRule"
     ProjectDeploymentRulesPriorityOrderRequest:
       type: object
       properties:
@@ -21258,19 +21280,19 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Project'
+            $ref: "#/components/schemas/Project"
     ProjectStats:
       allOf:
-        - $ref: '#/components/schemas/ReferenceObject'
-        - $ref: '#/components/schemas/ServiceTotalNumber'
-        - $ref: '#/components/schemas/EnvironmentTotalNumber'
+        - $ref: "#/components/schemas/ReferenceObject"
+        - $ref: "#/components/schemas/ServiceTotalNumber"
+        - $ref: "#/components/schemas/EnvironmentTotalNumber"
     ProjectStatsResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ProjectStats'
+            $ref: "#/components/schemas/ProjectStats"
     RebootServicesRequest:
       type: object
       properties:
@@ -21300,15 +21322,15 @@ components:
           readOnly: true
     ReferenceObjectStatus:
       allOf:
-        - $ref: '#/components/schemas/ReferenceObject'
-        - $ref: '#/components/schemas/Status'
+        - $ref: "#/components/schemas/ReferenceObject"
+        - $ref: "#/components/schemas/Status"
     ReferenceObjectStatusResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ReferenceObjectStatus'
+            $ref: "#/components/schemas/ReferenceObjectStatus"
     Referral:
       type: object
       properties:
@@ -21317,7 +21339,7 @@ components:
           example: 2
         invitation_link:
           type: string
-          example: 'https://join.qovery.com/xDowkWEl'
+          example: "https://join.qovery.com/xDowkWEl"
     RewardClaim:
       type: object
       properties:
@@ -21349,7 +21371,7 @@ components:
           type: string
     Secret:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - key
@@ -21359,23 +21381,23 @@ components:
               type: string
               description: key is case sensitive
             overridden_secret:
-              $ref: '#/components/schemas/SecretOverride'
+              $ref: "#/components/schemas/SecretOverride"
             aliased_secret:
-              $ref: '#/components/schemas/SecretAlias'
+              $ref: "#/components/schemas/SecretAlias"
             scope:
-              $ref: '#/components/schemas/APIVariableScopeEnum'
+              $ref: "#/components/schemas/APIVariableScopeEnum"
             variable_type:
-              $ref: '#/components/schemas/APIVariableTypeEnum'
+              $ref: "#/components/schemas/APIVariableTypeEnum"
             service_id:
               type: string
               format: uuid
             service_name:
               type: string
             service_type:
-              $ref: '#/components/schemas/LinkedServiceTypeEnum'
+              $ref: "#/components/schemas/LinkedServiceTypeEnum"
             owned_by:
               type: string
-              description: 'Entity that created/own the variable (i.e: Qovery, Doppler)'
+              description: "Entity that created/own the variable (i.e: Qovery, Doppler)"
             description:
               type: string
               x-stoplight:
@@ -21443,22 +21465,22 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Secret'
+            $ref: "#/components/schemas/Secret"
     Service:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - id
           properties:
             type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
             name:
               type: string
               description: name of the service
             id:
               type: string
-              description: 'uuid of the associated service (application, database, job, gateway...)'
+              description: "uuid of the associated service (application, database, job, gateway...)"
               format: uuid
             deployed_commit_id:
               type: string
@@ -21473,7 +21495,7 @@ components:
             service_typology:
               type: string
               example: container
-              description: 'describes the typology of service (container, postgresl, redis...)'
+              description: "describes the typology of service (container, postgresl, redis...)"
             service_version:
               type: string
               description: for databases this field exposes the database version
@@ -21497,7 +21519,7 @@ components:
       type: string
       x-stoplight:
         id: d66063cd29913
-      description: 'type of the service (application, database, job, ...)'
+      description: "type of the service (application, database, job, ...)"
       enum:
         - APPLICATION
         - DATABASE
@@ -21507,8 +21529,8 @@ components:
         - TERRAFORM
     SignUp:
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/SignUpRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/SignUpRequest"
     SignUpRequest:
       type: object
       required:
@@ -21525,14 +21547,14 @@ components:
         user_email:
           type: string
         type_of_use:
-          $ref: '#/components/schemas/TypeOfUseEnum'
+          $ref: "#/components/schemas/TypeOfUseEnum"
         qovery_usage:
           type: string
         company_name:
           type: string
           nullable: true
         company_size:
-          $ref: '#/components/schemas/CompanySizeEnum'
+          $ref: "#/components/schemas/CompanySizeEnum"
         user_role:
           type: string
           nullable: true
@@ -21665,22 +21687,22 @@ components:
           type: string
           format: uuid
         state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         service_deployment_status:
-          $ref: '#/components/schemas/ServiceDeploymentStatusEnum'
+          $ref: "#/components/schemas/ServiceDeploymentStatusEnum"
         last_deployment_date:
           type: string
           format: date-time
         is_part_last_deployment:
           type: boolean
         steps:
-          $ref: '#/components/schemas/ServiceStepMetrics'
+          $ref: "#/components/schemas/ServiceStepMetrics"
         execution_id:
           type: string
           x-stoplight:
             id: 3o9tz4272s2ct
         status_details:
-          $ref: '#/components/schemas/StatusDetails'
+          $ref: "#/components/schemas/StatusDetails"
         deployment_request_id:
           type: string
           x-stoplight:
@@ -21699,11 +21721,11 @@ components:
         - sub_action
       properties:
         action:
-          $ref: '#/components/schemas/ServiceActionEnum'
+          $ref: "#/components/schemas/ServiceActionEnum"
         status:
-          $ref: '#/components/schemas/ServiceActionStatusEnum'
+          $ref: "#/components/schemas/ServiceActionStatusEnum"
         sub_action:
-          $ref: '#/components/schemas/ServiceSubActionEnum'
+          $ref: "#/components/schemas/ServiceSubActionEnum"
     Stage:
       type: object
       required:
@@ -21718,13 +21740,13 @@ components:
           type: string
           description: stage name
         steps:
-          $ref: '#/components/schemas/StageStepMetrics'
+          $ref: "#/components/schemas/StageStepMetrics"
         description:
           type: string
           x-stoplight:
             id: gwpra9face692
         status:
-          $ref: '#/components/schemas/StageStatusEnum'
+          $ref: "#/components/schemas/StageStatusEnum"
     StatusKindEnum:
       type: string
       enum:
@@ -21790,7 +21812,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
     Value:
       type: object
       title: EnvironmentVariableOverrideRequest
@@ -21832,7 +21854,7 @@ components:
                 type: string
                 description: Optional if the variable is secret
               scope:
-                $ref: '#/components/schemas/APIVariableScopeEnum'
+                $ref: "#/components/schemas/APIVariableScopeEnum"
               is_secret:
                 type: boolean
     VariableImportRequest:
@@ -21859,7 +21881,7 @@ components:
               value:
                 type: string
               scope:
-                $ref: '#/components/schemas/APIVariableScopeEnum'
+                $ref: "#/components/schemas/APIVariableScopeEnum"
               is_secret:
                 type: boolean
     Version:
@@ -21869,14 +21891,14 @@ components:
       properties:
         name:
           type: string
-          example: '10.1'
+          example: "10.1"
     VersionResponseList:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Version'
+            $ref: "#/components/schemas/Version"
     WeekdayEnum:
       type: string
       enum:
@@ -21899,7 +21921,7 @@ components:
           type: string
           description: the value to be used as Alias of the targeted environment variable.
         alias_scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         alias_parent_id:
           type: string
           format: uuid
@@ -21927,7 +21949,7 @@ components:
           type: string
           description: the value to be used as Override of the targeted environment variable.
         override_scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         override_parent_id:
           type: string
           format: uuid
@@ -21965,13 +21987,13 @@ components:
           nullable: true
         is_secret:
           type: boolean
-          description: 'if true, the variable will be considered as a secret and will not be accessible after its creation. Only your applications will be able to access its value at build and run time.'
+          description: "if true, the variable will be considered as a secret and will not be accessible after its creation. Only your applications will be able to access its value at build and run time."
         variable_scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_parent_id:
           type: string
           format: uuid
-          description: 'based on the selected scope, it contains the ID of the service, environment or project where the variable is attached'
+          description: "based on the selected scope, it contains the ID of the service, environment or project where the variable is attached"
         description:
           type: string
           x-stoplight:
@@ -22008,7 +22030,7 @@ components:
           nullable: true
     VariableResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - key
@@ -22026,13 +22048,13 @@ components:
               type: string
               nullable: true
             overridden_variable:
-              $ref: '#/components/schemas/VariableOverride'
+              $ref: "#/components/schemas/VariableOverride"
             aliased_variable:
-              $ref: '#/components/schemas/VariableAlias'
+              $ref: "#/components/schemas/VariableAlias"
             scope:
-              $ref: '#/components/schemas/APIVariableScopeEnum'
+              $ref: "#/components/schemas/APIVariableScopeEnum"
             variable_type:
-              $ref: '#/components/schemas/APIVariableTypeEnum'
+              $ref: "#/components/schemas/APIVariableTypeEnum"
             service_id:
               type: string
               format: uuid
@@ -22041,10 +22063,10 @@ components:
               type: string
               description: The name of the service referenced by this variable.
             service_type:
-              $ref: '#/components/schemas/LinkedServiceTypeEnum'
+              $ref: "#/components/schemas/LinkedServiceTypeEnum"
             owned_by:
               type: string
-              description: 'Entity that created/own the variable (i.e: Qovery, Doppler)'
+              description: "Entity that created/own the variable (i.e: Qovery, Doppler)"
             is_secret:
               type: boolean
             description:
@@ -22061,7 +22083,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/VariableResponse'
+            $ref: "#/components/schemas/VariableResponse"
     VariableAlias:
       type: object
       required:
@@ -22083,9 +22105,9 @@ components:
         mount_path:
           type: string
         scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_type:
-          $ref: '#/components/schemas/APIVariableTypeEnum'
+          $ref: "#/components/schemas/APIVariableTypeEnum"
     VariableOverride:
       type: object
       required:
@@ -22110,9 +22132,9 @@ components:
           type: string
           description: The mounth path of the overriden variable (only if environment variable type is 'file')
         scope:
-          $ref: '#/components/schemas/APIVariableScopeEnum'
+          $ref: "#/components/schemas/APIVariableScopeEnum"
         variable_type:
-          $ref: '#/components/schemas/APIVariableTypeEnum'
+          $ref: "#/components/schemas/APIVariableTypeEnum"
     ClusterDeploymentStatusEnum:
       type: string
       enum:
@@ -22123,9 +22145,9 @@ components:
       type: object
       properties:
         step_name:
-          $ref: '#/components/schemas/ServiceStepMetricNameEnum'
+          $ref: "#/components/schemas/ServiceStepMetricNameEnum"
         status:
-          $ref: '#/components/schemas/StepMetricStatusEnum'
+          $ref: "#/components/schemas/StepMetricStatusEnum"
         duration_sec:
           description: The duration of the step in seconds.
           type: integer
@@ -22143,7 +22165,7 @@ components:
           description: A list of metrics for deployment steps of the stage.
           type: array
           items:
-            $ref: '#/components/schemas/StageStepMetric'
+            $ref: "#/components/schemas/StageStepMetric"
     ServiceStepMetrics:
       type: object
       required:
@@ -22162,7 +22184,7 @@ components:
           description: A list of metrics for deployment steps of the service.
           type: array
           items:
-            $ref: '#/components/schemas/ServiceStepMetric'
+            $ref: "#/components/schemas/ServiceStepMetric"
     StageStepMetric:
       type: object
       properties:
@@ -22170,9 +22192,9 @@ components:
           type: string
           format: uuid
         step_name:
-          $ref: '#/components/schemas/StageStepMetricNameEnum'
+          $ref: "#/components/schemas/StageStepMetricNameEnum"
         status:
-          $ref: '#/components/schemas/StepMetricStatusEnum'
+          $ref: "#/components/schemas/StepMetricStatusEnum"
         duration_sec:
           description: The duration of the step in seconds.
           type: integer
@@ -22259,14 +22281,14 @@ components:
         - CRON
     LifecycleJobResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseJobResponse'
+        - $ref: "#/components/schemas/BaseJobResponse"
         - type: object
           required:
             - job_type
             - schedule
           properties:
             job_type:
-              $ref: '#/components/schemas/JobTypeEnum'
+              $ref: "#/components/schemas/JobTypeEnum"
             schedule:
               type: object
               properties:
@@ -22301,22 +22323,22 @@ components:
                       type: string
                       description: optional entrypoint when launching container
                 lifecycle_type:
-                  $ref: '#/components/schemas/JobLifecycleTypeEnum'
+                  $ref: "#/components/schemas/JobLifecycleTypeEnum"
             annotations_groups:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
             labels_groups:
-              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
-      title: ''
+              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
+      title: ""
     CronJobResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseJobResponse'
+        - $ref: "#/components/schemas/BaseJobResponse"
         - type: object
           required:
             - job_type
             - schedule
           properties:
             job_type:
-              $ref: '#/components/schemas/JobTypeEnum'
+              $ref: "#/components/schemas/JobTypeEnum"
             schedule:
               type: object
               required:
@@ -22348,12 +22370,12 @@ components:
                         See https://crontab.guru/ to WISIWIG interface.  
                         Timezone is UT
             annotations_groups:
-              $ref: '#/components/schemas/OrganizationAnnotationsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationAnnotationsGroupResponseList"
             labels_groups:
-              $ref: '#/components/schemas/OrganizationLabelsGroupResponseList'
+              $ref: "#/components/schemas/OrganizationLabelsGroupResponseList"
     BaseJobResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - environment
@@ -22371,7 +22393,7 @@ components:
             - service_type
           properties:
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             maximum_cpu:
               type: integer
               description: Maximum cpu that can be allocated to the job based on organization cluster configuration. unit is millicores (m). 1000m = 1 cpu
@@ -22438,16 +22460,16 @@ components:
                     - image
                   properties:
                     image:
-                      $ref: '#/components/schemas/ContainerSource'
+                      $ref: "#/components/schemas/ContainerSource"
                   type: object
                 - required:
                     - docker
                   properties:
                     docker:
-                      $ref: '#/components/schemas/JobSourceDockerResponse'
+                      $ref: "#/components/schemas/JobSourceDockerResponse"
                   type: object
             healthchecks:
-              $ref: '#/components/schemas/Healthcheck'
+              $ref: "#/components/schemas/Healthcheck"
             auto_deploy:
               type: boolean
               description: |
@@ -22460,7 +22482,7 @@ components:
               x-stoplight:
                 id: p1secr7kxozsd
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
     HelmGitRepositoryRequest:
       type: object
       required:
@@ -22472,7 +22494,7 @@ components:
         url:
           type: string
           description: application git repository URL
-          example: 'https://github.com/Qovery/simple-node-app'
+          example: "https://github.com/Qovery/simple-node-app"
         branch:
           type: string
           description: |
@@ -22488,10 +22510,10 @@ components:
           format: uuid
           description: The git token id on Qovery side
           nullable: true
-      title: ''
+      title: ""
     HelmKeyValues:
       type: array
-      description: 'The input is in json array format: [ [$KEY,$VALUE], [...] ]'
+      description: "The input is in json array format: [ [$KEY,$VALUE], [...] ]"
       items:
         type: array
         items:
@@ -22507,12 +22529,12 @@ components:
           description: The start date of the report
           type: string
           format: date-time
-          example: '2020-01-01T00:00:00.000Z'
+          example: "2020-01-01T00:00:00.000Z"
         to:
           description: The end date of the report
           type: string
           format: date-time
-          example: '2020-01-31T23:59:59.000Z'
+          example: "2020-01-31T23:59:59.000Z"
         report_expiration_in_seconds:
           description: The number of seconds the report will be publicly available
           type: integer
@@ -22566,13 +22588,13 @@ components:
         id: 2tbiuqncqaqaw
       type: array
       items:
-        $ref: '#/components/schemas/OrganizationAnnotationsGroupEnrichedResponse'
+        $ref: "#/components/schemas/OrganizationAnnotationsGroupEnrichedResponse"
     OrganizationAnnotationsGroupEnrichedResponse:
       title: OrganizationAnnotationsGroupEnrichedResponse
       x-stoplight:
         id: edjpmiyq8n5nt
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           x-stoplight:
             id: 2auhw8xgz67rj
@@ -22590,13 +22612,13 @@ components:
               x-stoplight:
                 id: 4yn29zdqeb0og
               items:
-                $ref: '#/components/schemas/Annotation'
+                $ref: "#/components/schemas/Annotation"
             scopes:
               x-stoplight:
                 id: h8qu8e8yp5dh3
               type: array
               items:
-                $ref: '#/components/schemas/OrganizationAnnotationsGroupScopeEnum'
+                $ref: "#/components/schemas/OrganizationAnnotationsGroupScopeEnum"
             associated_items_count:
               type: integer
               x-stoplight:
@@ -22605,11 +22627,11 @@ components:
       title: OrganizationLabelsGroupEnrichedResponseList
       type: array
       items:
-        $ref: '#/components/schemas/OrganizationLabelsGroupEnrichedResponse'
+        $ref: "#/components/schemas/OrganizationLabelsGroupEnrichedResponse"
     OrganizationLabelsGroupEnrichedResponse:
       title: OrganizationLabelsGroupEnrichedResponse
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -22620,7 +22642,7 @@ components:
             labels:
               type: array
               items:
-                $ref: '#/components/schemas/Label'
+                $ref: "#/components/schemas/Label"
             associated_items_count:
               type: integer
     JobSourceDockerResponse:
@@ -22630,7 +22652,7 @@ components:
       type: object
       properties:
         git_repository:
-          $ref: '#/components/schemas/ApplicationGitRepository'
+          $ref: "#/components/schemas/ApplicationGitRepository"
         dockerfile_path:
           type: string
           x-stoplight:
@@ -22699,7 +22721,7 @@ components:
         - git_repository
       properties:
         git_repository:
-          $ref: '#/components/schemas/ApplicationGitRepository'
+          $ref: "#/components/schemas/ApplicationGitRepository"
     CpuArchitectureEnum:
       title: CpuArchitectureEnum
       x-stoplight:
@@ -22717,9 +22739,9 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/ClusterFeatureResponseTypeEnum'
+          $ref: "#/components/schemas/ClusterFeatureResponseTypeEnum"
         value:
-          $ref: '#/components/schemas/ClusterFeatureKarpenterParameters'
+          $ref: "#/components/schemas/ClusterFeatureKarpenterParameters"
     ClusterFeatureKarpenterParameters:
       title: ClusterFeatureKarpenterParameters
       x-stoplight:
@@ -22752,9 +22774,9 @@ components:
           example: 255
           description: Unit is in MB/s. The disk throughput to be used for the node configuration
         default_service_architecture:
-          $ref: '#/components/schemas/CpuArchitectureEnum'
+          $ref: "#/components/schemas/CpuArchitectureEnum"
         qovery_node_pools:
-          $ref: '#/components/schemas/KarpenterNodePool'
+          $ref: "#/components/schemas/KarpenterNodePool"
     JobLifecycleTypeEnum:
       title: JobLifecycleTypeEnum
       x-stoplight:
@@ -22835,7 +22857,7 @@ components:
           format: uri
           description: location of the template
         cloud_provider:
-          $ref: '#/components/schemas/CloudProviderEnum'
+          $ref: "#/components/schemas/CloudProviderEnum"
         events:
           type: array
           x-stoplight:
@@ -22926,7 +22948,7 @@ components:
                 type: object
                 x-stoplight:
                   id: 71mpuvnx5g4gm
-                description: 'If present, the variable should be a file instead of a raw value'
+                description: "If present, the variable should be a file instead of a raw value"
                 required:
                   - path
                 properties:
@@ -22954,7 +22976,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/ContainerRegistryAssociatedServicesResponse'
+            $ref: "#/components/schemas/ContainerRegistryAssociatedServicesResponse"
     CheckedCustomDomainsResponse:
       title: CheckedCustomDomainsResponse
       type: object
@@ -22964,7 +22986,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/CheckedCustomDomainResponse'
+            $ref: "#/components/schemas/CheckedCustomDomainResponse"
     CheckedCustomDomainStatus:
       type: string
       enum:
@@ -22993,7 +23015,7 @@ components:
           description: domain name checked
           example: my.domain.tld
         status:
-          $ref: '#/components/schemas/CheckedCustomDomainStatus'
+          $ref: "#/components/schemas/CheckedCustomDomainStatus"
         error_details:
           type: string
           nullable: true
@@ -23040,7 +23062,7 @@ components:
           x-stoplight:
             id: ga0yqhtmi4nl6
         service_type:
-          $ref: '#/components/schemas/ContainerRegistryAssociatedServiceType'
+          $ref: "#/components/schemas/ContainerRegistryAssociatedServiceType"
     ContainerRegistryAssociatedServiceType:
       title: ContainerRegistryAssociatedServiceType
       x-stoplight:
@@ -23097,7 +23119,7 @@ components:
           x-stoplight:
             id: rb0g9ev15frmu
         service_type:
-          $ref: '#/components/schemas/HelmRepositoryAssociatedServiceType'
+          $ref: "#/components/schemas/HelmRepositoryAssociatedServiceType"
     HelmRepositoryAssociatedServicesResponseList:
       title: HelmRepositoryAssociatedServicesResponseList
       x-stoplight:
@@ -23109,7 +23131,7 @@ components:
           x-stoplight:
             id: 00sn35cw5lnb4
           items:
-            $ref: '#/components/schemas/HelmRepositoryAssociatedServicesResponse'
+            $ref: "#/components/schemas/HelmRepositoryAssociatedServicesResponse"
     KubernetesServiceResponseList:
       title: KubernetesServiceResponseList
       x-stoplight:
@@ -23119,7 +23141,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/KubernetesService'
+            $ref: "#/components/schemas/KubernetesService"
     KubernetesService:
       title: KubernetesService
       x-stoplight:
@@ -23130,9 +23152,9 @@ components:
         - service_spec
       properties:
         metadata:
-          $ref: '#/components/schemas/KubernetesMetadata'
+          $ref: "#/components/schemas/KubernetesMetadata"
         service_spec:
-          $ref: '#/components/schemas/KubernetesServiceSpec'
+          $ref: "#/components/schemas/KubernetesServiceSpec"
     KubernetesMetadata:
       title: KubernetesMetadata
       x-stoplight:
@@ -23158,13 +23180,13 @@ components:
           x-stoplight:
             id: xaa6ow6ugihju
           items:
-            $ref: '#/components/schemas/KubernetesServicePort'
+            $ref: "#/components/schemas/KubernetesServicePort"
         selectors:
           type: array
           x-stoplight:
             id: snld7nhiy088w
           items:
-            $ref: '#/components/schemas/KubernetesSelector'
+            $ref: "#/components/schemas/KubernetesSelector"
     KubernetesServicePort:
       title: KubernetesServicePort
       x-stoplight:
@@ -23268,13 +23290,13 @@ components:
             id: pkowctfxv7q77
           type: array
           items:
-            $ref: '#/components/schemas/KarpenterNodePoolRequirement'
+            $ref: "#/components/schemas/KarpenterNodePoolRequirement"
         stable_override:
-          $ref: '#/components/schemas/KarpenterStableNodePoolOverride'
+          $ref: "#/components/schemas/KarpenterStableNodePoolOverride"
         default_override:
-          $ref: '#/components/schemas/KarpenterDefaultNodePoolOverride'
+          $ref: "#/components/schemas/KarpenterDefaultNodePoolOverride"
         gpu_override:
-          $ref: '#/components/schemas/KarpenterGpuNodePoolOverride'
+          $ref: "#/components/schemas/KarpenterGpuNodePoolOverride"
     KarpenterNodePoolRequirementKey:
       title: KarpenterNodePoolRequirementKey
       x-stoplight:
@@ -23302,9 +23324,9 @@ components:
         - values
       properties:
         key:
-          $ref: '#/components/schemas/KarpenterNodePoolRequirementKey'
+          $ref: "#/components/schemas/KarpenterNodePoolRequirementKey"
         operator:
-          $ref: '#/components/schemas/KarpenterNodePoolRequirementOperator'
+          $ref: "#/components/schemas/KarpenterNodePoolRequirementOperator"
         values:
           type: array
           x-stoplight:
@@ -23318,13 +23340,13 @@ components:
       type: object
       properties:
         consolidation:
-          $ref: '#/components/schemas/KarpenterNodePoolConsolidation'
+          $ref: "#/components/schemas/KarpenterNodePoolConsolidation"
         limits:
-          $ref: '#/components/schemas/KarpenterNodePoolLimits'
+          $ref: "#/components/schemas/KarpenterNodePoolLimits"
         consolidate_after:
           type: string
-          description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
-          example: '30s'
+          description: "Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h"
+          example: "30s"
           pattern: '^\d+(s|m|h)$'
     KarpenterGpuNodePoolOverride:
       title: KarpenterGpuNodePoolOverride
@@ -23333,15 +23355,15 @@ components:
       type: object
       properties:
         consolidation:
-          $ref: '#/components/schemas/KarpenterNodePoolConsolidation'
+          $ref: "#/components/schemas/KarpenterNodePoolConsolidation"
         limits:
-          $ref: '#/components/schemas/KarpenterNodePoolLimits'
+          $ref: "#/components/schemas/KarpenterNodePoolLimits"
         requirements:
           type: array
           x-stoplight:
             id: 38pdri17ozql9
           items:
-            $ref: '#/components/schemas/KarpenterNodePoolRequirement'
+            $ref: "#/components/schemas/KarpenterNodePoolRequirement"
         disk_size_in_gib:
           type: integer
           x-stoplight:
@@ -23372,19 +23394,19 @@ components:
           default: false
         consolidate_after:
           type: string
-          description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
-          example: '30s'
+          description: "Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h"
+          example: "30s"
           pattern: '^\d+(s|m|h)$'
     KarpenterDefaultNodePoolOverride:
       title: KarpenterDefaultNodePoolOverride
       type: object
       properties:
         limits:
-          $ref: '#/components/schemas/KarpenterNodePoolLimits'
+          $ref: "#/components/schemas/KarpenterNodePoolLimits"
         consolidate_after:
           type: string
-          description: 'Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h'
-          example: '1m'
+          description: "Time to wait before consolidating empty or underutilized nodes (e.g., 1m, 10m, 1h). Maximum: 24h"
+          example: "1m"
           pattern: '^\d+(s|m|h)$'
     KarpenterNodePoolConsolidation:
       title: KarpenterNodePoolConsolidation
@@ -23403,13 +23425,13 @@ components:
           type: array
           nullable: false
           items:
-            $ref: '#/components/schemas/WeekdayEnum'
+            $ref: "#/components/schemas/WeekdayEnum"
         start_time:
           description: |
             The start date of the consolidation.
             The format should follow ISO-8601 convention: "PThh:mm"
           type: string
-          example: 'PT22:30'
+          example: "PT22:30"
           nullable: false
         duration:
           description: |
@@ -23441,10 +23463,10 @@ components:
           nullable: false
         max_cpu_in_vcpu:
           type: integer
-          description: 'CPU limit that will be applied for the node pool (in vCPU unit: 1 vCPU = 1000 millicores)'
+          description: "CPU limit that will be applied for the node pool (in vCPU unit: 1 vCPU = 1000 millicores)"
         max_memory_in_gibibytes:
           type: integer
-          description: 'Memory limit that will be applied for the node pool (in Gibibytes unit: 1Gi = 1024 mebibytes)'
+          description: "Memory limit that will be applied for the node pool (in Gibibytes unit: 1Gi = 1024 mebibytes)"
         max_gpu:
           type: integer
           x-stoplight:
@@ -23513,7 +23535,7 @@ components:
           x-stoplight:
             id: xpi2ooy1zclay
           items:
-            $ref: '#/components/schemas/ClusterLock'
+            $ref: "#/components/schemas/ClusterLock"
     EnvDeploymentStatus:
       title: EnvDeploymentStatus
       x-stoplight:
@@ -23531,7 +23553,7 @@ components:
             id: t6sa9u90dayva
           format: uuid
         status:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
     DeploymentHistoryActionStatus:
       title: DeploymentHistoryActionStatus
       x-stoplight:
@@ -23585,9 +23607,9 @@ components:
               x-stoplight:
                 id: hfi1kibghpsc3
             origin:
-              $ref: '#/components/schemas/OrganizationEventOrigin'
+              $ref: "#/components/schemas/OrganizationEventOrigin"
         trigger_action:
-          $ref: '#/components/schemas/DeploymentHistoryTriggerAction'
+          $ref: "#/components/schemas/DeploymentHistoryTriggerAction"
         stages:
           type: array
           x-stoplight:
@@ -23606,7 +23628,7 @@ components:
                 x-stoplight:
                   id: 7p40i9fzfddii
               status:
-                $ref: '#/components/schemas/StageStatusEnum'
+                $ref: "#/components/schemas/StageStatusEnum"
               services:
                 type: array
                 x-stoplight:
@@ -23634,13 +23656,13 @@ components:
                             id: ixyztl7bo1e7r
                           format: uuid
                         service_type:
-                          $ref: '#/components/schemas/ServiceTypeEnum'
+                          $ref: "#/components/schemas/ServiceTypeEnum"
                         name:
                           type: string
                           x-stoplight:
                             id: rqj252xn7e17p
                     status:
-                      $ref: '#/components/schemas/StageStatusEnum'
+                      $ref: "#/components/schemas/StageStatusEnum"
                     icon_uri:
                       type: string
                       x-stoplight:
@@ -23691,7 +23713,7 @@ components:
                 id: 0l33zc2pd2ie0
               format: uuid
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
             name:
               type: string
               x-stoplight:
@@ -23704,9 +23726,9 @@ components:
             triggered_by:
               type: string
             origin:
-              $ref: '#/components/schemas/OrganizationEventOrigin'
+              $ref: "#/components/schemas/OrganizationEventOrigin"
         status_details:
-          $ref: '#/components/schemas/StatusDetails'
+          $ref: "#/components/schemas/StatusDetails"
         icon_uri:
           type: string
           x-stoplight:
@@ -23747,7 +23769,7 @@ components:
           x-stoplight:
             id: k6zs0jdg7k95f
         service_type:
-          $ref: '#/components/schemas/ServiceTypeEnum'
+          $ref: "#/components/schemas/ServiceTypeEnum"
         project_id:
           type: string
           x-stoplight:
@@ -23779,7 +23801,7 @@ components:
             - LIFECYCLE
     OrganizationEnvironmentResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -23791,11 +23813,11 @@ components:
               type: string
               description: name is case insensitive
             organization:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             project:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             mode:
-              $ref: '#/components/schemas/EnvironmentModeEnum'
+              $ref: "#/components/schemas/EnvironmentModeEnum"
     ClusterMetricsResponse:
       title: ClusterMetricsResponse
       x-stoplight:
@@ -23820,11 +23842,11 @@ components:
           x-stoplight:
             id: 1e9r2at0nxziv
           oneOf:
-            - $ref: '#/components/schemas/MetricsConfigurationManagedByQovery'
+            - $ref: "#/components/schemas/MetricsConfigurationManagedByQovery"
           discriminator:
             propertyName: kind
             mapping:
-              MANAGED_BY_QOVERY: '#/components/schemas/MetricsConfigurationManagedByQovery'
+              MANAGED_BY_QOVERY: "#/components/schemas/MetricsConfigurationManagedByQovery"
     MetricsConfigurationManagedByQovery:
       title: MetricsConfigurationManagedByQovery
       x-stoplight:
@@ -23837,17 +23859,17 @@ components:
           enum:
             - MANAGED_BY_QOVERY
         resource_profile:
-          $ref: '#/components/schemas/ObservabilityResourceProfile'
+          $ref: "#/components/schemas/ObservabilityResourceProfile"
         cloud_watch_export_config:
-          $ref: '#/components/schemas/CloudWatchExportConfig'
+          $ref: "#/components/schemas/CloudWatchExportConfig"
         high_availability:
           type: boolean
           x-stoplight:
             id: zs2zhdd1p5e6q
         internal_network_monitoring:
-          $ref: '#/components/schemas/InternalNetworkMonitoring'
+          $ref: "#/components/schemas/InternalNetworkMonitoring"
         alerting:
-          $ref: '#/components/schemas/AlertingConfig'
+          $ref: "#/components/schemas/AlertingConfig"
     InfrastructureOutputs:
       type: object
       required:
@@ -23855,15 +23877,15 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          AKS: '#/components/schemas/AksInfrastructureOutputs'
-          EKS: '#/components/schemas/EksInfrastructureOutputs'
-          GKE: '#/components/schemas/GkeInfrastructureOutputs'
-          SCW_KAPSULE: '#/components/schemas/KapsuleInfrastructureOutputs'
+          AKS: "#/components/schemas/AksInfrastructureOutputs"
+          EKS: "#/components/schemas/EksInfrastructureOutputs"
+          GKE: "#/components/schemas/GkeInfrastructureOutputs"
+          SCW_KAPSULE: "#/components/schemas/KapsuleInfrastructureOutputs"
       oneOf:
-        - $ref: '#/components/schemas/AksInfrastructureOutputs'
-        - $ref: '#/components/schemas/EksInfrastructureOutputs'
-        - $ref: '#/components/schemas/GkeInfrastructureOutputs'
-        - $ref: '#/components/schemas/KapsuleInfrastructureOutputs'
+        - $ref: "#/components/schemas/AksInfrastructureOutputs"
+        - $ref: "#/components/schemas/EksInfrastructureOutputs"
+        - $ref: "#/components/schemas/GkeInfrastructureOutputs"
+        - $ref: "#/components/schemas/KapsuleInfrastructureOutputs"
     AksInfrastructureOutputs:
       type: object
       required:
@@ -23935,7 +23957,7 @@ components:
             id: e507c0na5om2i
           format: uuid
         status:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
     GcpStaticClusterCredentials:
       title: GcpStaticClusterCredentials
       x-stoplight:
@@ -24055,15 +24077,15 @@ components:
             - type: object
               properties:
                 git_repository:
-                  $ref: '#/components/schemas/TerraformGitRepositoryRequest'
+                  $ref: "#/components/schemas/TerraformGitRepositoryRequest"
         terraform_variables_source:
-          $ref: '#/components/schemas/TerraformVariablesSourceRequest'
+          $ref: "#/components/schemas/TerraformVariablesSourceRequest"
         backend:
-          $ref: '#/components/schemas/TerraformBackend'
+          $ref: "#/components/schemas/TerraformBackend"
         engine:
-          $ref: '#/components/schemas/TerraformEngineEnum'
+          $ref: "#/components/schemas/TerraformEngineEnum"
         provider_version:
-          $ref: '#/components/schemas/TerraformProviderVersion'
+          $ref: "#/components/schemas/TerraformProviderVersion"
         timeout_sec:
           type: integer
           x-stoplight:
@@ -24074,7 +24096,7 @@ components:
             id: nem7zoh97kyzc
           format: uri
         job_resources:
-          $ref: '#/components/schemas/TerraformRequestJobResources'
+          $ref: "#/components/schemas/TerraformRequestJobResources"
         use_cluster_credentials:
           type: boolean
           x-stoplight:
@@ -24102,13 +24124,13 @@ components:
             Custom Dockerfile fragment to inject during build. Optional field.
             When null, no custom fragment is injected.
           oneOf:
-            - $ref: '#/components/schemas/DockerfileFragmentFile'
-            - $ref: '#/components/schemas/DockerfileFragmentInline'
+            - $ref: "#/components/schemas/DockerfileFragmentFile"
+            - $ref: "#/components/schemas/DockerfileFragmentInline"
           discriminator:
             propertyName: type
             mapping:
-              file: '#/components/schemas/DockerfileFragmentFile'
-              inline: '#/components/schemas/DockerfileFragmentInline'
+              file: "#/components/schemas/DockerfileFragmentFile"
+              inline: "#/components/schemas/DockerfileFragmentInline"
     TerraformResourceResponse:
       type: object
       title: Terraform Resource Response
@@ -24130,7 +24152,7 @@ components:
           example: 550e8400-e29b-41d4-a716-446655440000
         resource_type:
           type: string
-          description: 'Type of the Terraform resource (e.g., aws_instance, aws_s3_bucket)'
+          description: "Type of the Terraform resource (e.g., aws_instance, aws_s3_bucket)"
           example: aws_instance
         name:
           type: string
@@ -24138,11 +24160,11 @@ components:
           example: web_server
         address:
           type: string
-          description: 'Full address of the resource (e.g., aws_instance.web_server)'
+          description: "Full address of the resource (e.g., aws_instance.web_server)"
           example: aws_instance.web_server
         provider:
           type: string
-          description: 'Terraform provider name (e.g., aws, google, azurerm)'
+          description: "Terraform provider name (e.g., aws, google, azurerm)"
           example: aws
         mode:
           type: string
@@ -24164,7 +24186,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the resource was extracted from Terraform state
-          example: '2023-01-15T10:30:00Z'
+          example: "2023-01-15T10:30:00Z"
     TerraformResourcesResponse:
       type: object
       title: Terraform Resources List Response
@@ -24176,7 +24198,7 @@ components:
           type: array
           description: Array of Terraform resources
           items:
-            $ref: '#/components/schemas/TerraformResourceResponse'
+            $ref: "#/components/schemas/TerraformResourceResponse"
     TerraformResourcesRequest:
       type: object
       title: Terraform Resources Request
@@ -24205,7 +24227,7 @@ components:
           example: '[{"resource_type":"aws_instance","name":"web_server","provider":"aws","address":"aws_instance.web_server","mode":"managed","attributes":{"instance_id":"i-1234567890abcdef0","instance_type":"t2.micro"}}]'
     TerraformResponse:
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -24240,7 +24262,7 @@ components:
               x-stoplight:
                 id: abfhjb6q74upq
               oneOf:
-                - $ref: '#/components/schemas/TerraformFilesSource'
+                - $ref: "#/components/schemas/TerraformFilesSource"
             icon_uri:
               type: string
               format: uri
@@ -24248,19 +24270,19 @@ components:
               x-stoplight:
                 id: i2pvbugqsldhe
             service_type:
-              $ref: '#/components/schemas/ServiceTypeEnum'
+              $ref: "#/components/schemas/ServiceTypeEnum"
             terraform_variables_source:
-              $ref: '#/components/schemas/TerraformVariablesSourceResponse'
+              $ref: "#/components/schemas/TerraformVariablesSourceResponse"
             engine:
-              $ref: '#/components/schemas/TerraformEngineEnum'
+              $ref: "#/components/schemas/TerraformEngineEnum"
             backend:
-              $ref: '#/components/schemas/TerraformBackend'
+              $ref: "#/components/schemas/TerraformBackend"
             provider_version:
-              $ref: '#/components/schemas/TerraformProviderVersion'
+              $ref: "#/components/schemas/TerraformProviderVersion"
             job_resources:
-              $ref: '#/components/schemas/TerraformJobResourcesResponse'
+              $ref: "#/components/schemas/TerraformJobResourcesResponse"
             environment:
-              $ref: '#/components/schemas/ReferenceObject'
+              $ref: "#/components/schemas/ReferenceObject"
             use_cluster_credentials:
               type: boolean
               x-stoplight:
@@ -24288,13 +24310,13 @@ components:
                 Custom Dockerfile fragment to inject during build.
                 When null, no custom fragment is injected.
               oneOf:
-                - $ref: '#/components/schemas/DockerfileFragmentFile'
-                - $ref: '#/components/schemas/DockerfileFragmentInline'
+                - $ref: "#/components/schemas/DockerfileFragmentFile"
+                - $ref: "#/components/schemas/DockerfileFragmentInline"
               discriminator:
                 propertyName: type
                 mapping:
-                  file: '#/components/schemas/DockerfileFragmentFile'
-                  inline: '#/components/schemas/DockerfileFragmentInline'
+                  file: "#/components/schemas/DockerfileFragmentFile"
+                  inline: "#/components/schemas/DockerfileFragmentInline"
       description: A Terraform service
     TerraformRequestJobResources:
       title: TerraformRequestJobResources
@@ -24348,7 +24370,7 @@ components:
         - git_repository
       properties:
         git_repository:
-          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
     TerraformVariablesSourceRequest:
       title: TerraformVariablesSourceRequest
       x-stoplight:
@@ -24369,7 +24391,7 @@ components:
         tf_vars:
           type: array
           items:
-            $ref: '#/components/schemas/TerraformVarKeyValue'
+            $ref: "#/components/schemas/TerraformVarKeyValue"
     TerraformVarKeyValue:
       title: TerraformVarKeyValue
       type: object
@@ -24405,18 +24427,18 @@ components:
         nullable:
           type: boolean
           default: true
-          description: 'Whether the variable accepts null values. If false, the variable is required.'
+          description: "Whether the variable accepts null values. If false, the variable is required."
         default:
           type: string
           nullable: true
-          description: 'The default value of the variable, or null if no default is provided'
+          description: "The default value of the variable, or null if no default is provided"
         source:
           type: string
           description: The path inside your git repository where the variable is defined
         description:
           type: string
           nullable: true
-          description: 'The description of the variable, or null if no description is provided'
+          description: "The description of the variable, or null if no description is provided"
     TerraformFilesSourceRequest:
       title: TerraformFilesSourceRequest
       x-stoplight:
@@ -24428,26 +24450,26 @@ components:
           x-stoplight:
             id: vtpiblf7t37xq
     TerraformAutoDeployConfig:
-          title: TerraformAutoDeployConfig
-          type: object
-          required:
-            - auto_deploy
-            - terraform_action
-          properties:
-            auto_deploy:
-              type: boolean
-            terraform_action:
-              type: string
-              description: |
-                Action to force a specific Terraform behavior on autodeploy.
-                `DEFAULT`: The action is resolved based on the deployment type:
-                  - Start/Restart -> PLAN_AND_APPLY
-                  - Delete -> DESTROY
-                  - Pause -> PLAN_ONLY
-              enum:
-                - DEFAULT
-                - PLAN
-                - NOOP
+      title: TerraformAutoDeployConfig
+      type: object
+      required:
+        - auto_deploy
+        - terraform_action
+      properties:
+        auto_deploy:
+          type: boolean
+        terraform_action:
+          type: string
+          description: |
+            Action to force a specific Terraform behavior on autodeploy.
+            `DEFAULT`: The action is resolved based on the deployment type:
+              - Start/Restart -> PLAN_AND_APPLY
+              - Delete -> DESTROY
+              - Pause -> PLAN_ONLY
+          enum:
+            - DEFAULT
+            - PLAN
+            - NOOP
     TerraformGitRepositoryRequest:
       title: TerraformGitRepositoryRequest
       x-stoplight:
@@ -24492,7 +24514,7 @@ components:
         tf_vars:
           type: array
           items:
-            $ref: '#/components/schemas/TerraformVarKeyValue'
+            $ref: "#/components/schemas/TerraformVarKeyValue"
     TfVarsListRequest:
       title: TfVarsListRequest
       type: object
@@ -24502,20 +24524,20 @@ components:
         - mode
       properties:
         git_repository:
-          $ref: '#/components/schemas/ApplicationGitRepositoryRequest'
+          $ref: "#/components/schemas/ApplicationGitRepositoryRequest"
         mode:
-          $ref: '#/components/schemas/TfVarsDiscoveryMode'
+          $ref: "#/components/schemas/TfVarsDiscoveryMode"
     TfVarsDiscoveryMode:
       title: TfVarsDiscoveryMode
       description: Discovery mode for Terraform tfvars files - either auto-discover or specify paths
       oneOf:
-        - $ref: '#/components/schemas/TfVarsDiscoveryModeAutoDiscover'
-        - $ref: '#/components/schemas/TfVarsDiscoveryModeSpecificPaths'
+        - $ref: "#/components/schemas/TfVarsDiscoveryModeAutoDiscover"
+        - $ref: "#/components/schemas/TfVarsDiscoveryModeSpecificPaths"
       discriminator:
         propertyName: type
         mapping:
-          AutoDiscover: '#/components/schemas/TfVarsDiscoveryModeAutoDiscover'
-          SpecificPaths: '#/components/schemas/TfVarsDiscoveryModeSpecificPaths'
+          AutoDiscover: "#/components/schemas/TfVarsDiscoveryModeAutoDiscover"
+          SpecificPaths: "#/components/schemas/TfVarsDiscoveryModeSpecificPaths"
     TfVarsDiscoveryModeAutoDiscover:
       title: TfVarsDiscoveryModeAutoDiscover
       type: object
@@ -24644,7 +24666,7 @@ components:
           x-stoplight:
             id: mkzx2zfzysbnp
           items:
-            $ref: '#/components/schemas/TerraformResponse'
+            $ref: "#/components/schemas/TerraformResponse"
     TerraformVersionResponse:
       type: object
       required:
@@ -24652,7 +24674,7 @@ components:
         - version
       properties:
         engine:
-          $ref: '#/components/schemas/TerraformEngineEnum'
+          $ref: "#/components/schemas/TerraformEngineEnum"
         version:
           type: string
           description: Terraform version string
@@ -24662,7 +24684,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/TerraformVersionResponse'
+            $ref: "#/components/schemas/TerraformVersionResponse"
     TerraformAdvancedSettings:
       title: TerraformAdvancedSettings
       x-stoplight:
@@ -24726,21 +24748,21 @@ components:
         - value
       properties:
         mode:
-          $ref: '#/components/schemas/DeploymentRestrictionModeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionModeEnum"
         type:
-          $ref: '#/components/schemas/DeploymentRestrictionTypeEnum'
+          $ref: "#/components/schemas/DeploymentRestrictionTypeEnum"
         value:
           type: string
           x-stoplight:
             id: hsk8w0ydpuwm4
-          description: '‘For `PATH` restrictions, the value must not start with `/`’'
+          description: "‘For `PATH` restrictions, the value must not start with `/`’"
     TerraformDeploymentRestrictionResponse:
       title: TerraformDeploymentRestrictionResponse
       x-stoplight:
         id: 9t9zdouc9tao0
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/TerraformDeploymentRestrictionRequest'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/TerraformDeploymentRestrictionRequest"
     TerraformDeploymentRestrictionResponseList:
       title: TerraformDeploymentRestrictionResponseList
       x-stoplight:
@@ -24752,7 +24774,7 @@ components:
             id: iu0k7b7tkayre
           type: array
           items:
-            $ref: '#/components/schemas/TerraformDeploymentRestrictionResponse'
+            $ref: "#/components/schemas/TerraformDeploymentRestrictionResponse"
     OrganizationCrendentialsResponseList:
       title: OrganizationCrendentialsResponseList
       x-stoplight:
@@ -24769,13 +24791,13 @@ components:
             type: object
             properties:
               credential:
-                $ref: '#/components/schemas/ClusterCredentials'
+                $ref: "#/components/schemas/ClusterCredentials"
               clusters:
                 type: array
                 x-stoplight:
                   id: 7o7dzkbyt78bu
                 items:
-                  $ref: '#/components/schemas/CredentialCluster'
+                  $ref: "#/components/schemas/CredentialCluster"
     CredentialCluster:
       title: CredentialCluster
       x-stoplight:
@@ -24792,7 +24814,7 @@ components:
           x-stoplight:
             id: skztj7io7an31
         cloud_provider:
-          $ref: '#/components/schemas/CloudProviderEnum'
+          $ref: "#/components/schemas/CloudProviderEnum"
     TerraformFilesSource:
       title: TerraformFilesSource
       x-stoplight:
@@ -24805,7 +24827,7 @@ components:
           type: object
           properties:
             git_repository:
-              $ref: '#/components/schemas/ApplicationGitRepository'
+              $ref: "#/components/schemas/ApplicationGitRepository"
     ClusterLogsResponse:
       title: ClusterLogsResponse
       x-stoplight:
@@ -24820,13 +24842,13 @@ components:
       type: object
       properties:
         nginx_parameters:
-          $ref: '#/components/schemas/ClusterInfrastructureNginxChartParameters'
+          $ref: "#/components/schemas/ClusterInfrastructureNginxChartParameters"
         cert_manager_parameters:
-          $ref: '#/components/schemas/ClusterInfrastructureCertManagerChartParameters'
+          $ref: "#/components/schemas/ClusterInfrastructureCertManagerChartParameters"
         metal_lb_parameters:
-          $ref: '#/components/schemas/ClusterInfrastructureMetalLbChartParameters'
+          $ref: "#/components/schemas/ClusterInfrastructureMetalLbChartParameters"
         eks_anywhere_parameters:
-          $ref: '#/components/schemas/ClusterInfrastructureEksAnywhereParameters'
+          $ref: "#/components/schemas/ClusterInfrastructureEksAnywhereParameters"
     ClusterInfrastructureEksAnywhereParameters:
       type: object
       required:
@@ -24834,7 +24856,7 @@ components:
         - yaml_file_path
       properties:
         git_repository:
-          $ref: '#/components/schemas/ClusterEksAnywhereGitRepository'
+          $ref: "#/components/schemas/ClusterEksAnywhereGitRepository"
         yaml_file_path:
           type: string
           description: Path to the EKS Anywhere cluster YAML file in the git repository
@@ -24849,7 +24871,7 @@ components:
           type: string
           format: uri
           description: EKS Anywhere git repository URL
-          example: 'https://github.com/Qovery/eks-anywhere-config.git'
+          example: "https://github.com/Qovery/eks-anywhere-config.git"
         branch:
           type: string
           description: |
@@ -24861,7 +24883,7 @@ components:
           format: uuid
           description: Qovery git token id used to access the repository
         provider:
-          $ref: '#/components/schemas/GitProviderEnum'
+          $ref: "#/components/schemas/GitProviderEnum"
     ClusterInfrastructureNginxChartParameters:
       title: ClusterInfrastructureNginxChartParameters
       x-stoplight:
@@ -24920,7 +24942,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/EnterpriseConnectionDto'
+            $ref: "#/components/schemas/EnterpriseConnectionDto"
     EnterpriseConnectionDto:
       title: EnterpriseConnectionDto
       type: object
@@ -24966,13 +24988,13 @@ components:
         id: q1oj36zhkhmvp
       x-internal: false
       oneOf:
-        - $ref: '#/components/schemas/SlackAlertReceiverCreationRequest'
-        - $ref: '#/components/schemas/EmailAlertReceiverCreationRequest'
+        - $ref: "#/components/schemas/SlackAlertReceiverCreationRequest"
+        - $ref: "#/components/schemas/EmailAlertReceiverCreationRequest"
       discriminator:
         propertyName: type
         mapping:
-          SLACK: '#/components/schemas/SlackAlertReceiverCreationRequest'
-          EMAIL: '#/components/schemas/EmailAlertReceiverCreationRequest'
+          SLACK: "#/components/schemas/SlackAlertReceiverCreationRequest"
+          EMAIL: "#/components/schemas/EmailAlertReceiverCreationRequest"
     AlertReceiverCreationRequestBase:
       title: AlertReceiverCreationRequestBase
       type: object
@@ -24997,7 +25019,7 @@ components:
           x-stoplight:
             id: lrlxf8a34veta
         type:
-          $ref: '#/components/schemas/AlertReceiverType'
+          $ref: "#/components/schemas/AlertReceiverType"
         send_resolved:
           type: boolean
           x-stoplight:
@@ -25013,7 +25035,7 @@ components:
       x-stoplight:
         id: awuv9zidg4qxx
       allOf:
-        - $ref: '#/components/schemas/AlertReceiverCreationRequestBase'
+        - $ref: "#/components/schemas/AlertReceiverCreationRequestBase"
         - type: object
           required:
             - webhook_url
@@ -25026,7 +25048,7 @@ components:
     EmailAlertReceiverCreationRequest:
       title: EmailAlertReceiverCreationRequest
       allOf:
-        - $ref: '#/components/schemas/AlertReceiverCreationRequestBase'
+        - $ref: "#/components/schemas/AlertReceiverCreationRequestBase"
         - type: object
           required:
             - to
@@ -25045,8 +25067,8 @@ components:
               description: Sender email address
             smarthost:
               type: string
-              description: 'SMTP server in format ''host:port'''
-              example: 'smtp.example.com:587'
+              description: "SMTP server in format 'host:port'"
+              example: "smtp.example.com:587"
             auth_username:
               type: string
               nullable: true
@@ -25070,13 +25092,13 @@ components:
       x-stoplight:
         id: y2od6vkbmt7yr
       oneOf:
-        - $ref: '#/components/schemas/SlackAlertReceiverEditRequest'
-        - $ref: '#/components/schemas/EmailAlertReceiverEditRequest'
+        - $ref: "#/components/schemas/SlackAlertReceiverEditRequest"
+        - $ref: "#/components/schemas/EmailAlertReceiverEditRequest"
       discriminator:
         propertyName: type
         mapping:
-          SLACK: '#/components/schemas/SlackAlertReceiverEditRequest'
-          EMAIL: '#/components/schemas/EmailAlertReceiverEditRequest'
+          SLACK: "#/components/schemas/SlackAlertReceiverEditRequest"
+          EMAIL: "#/components/schemas/EmailAlertReceiverEditRequest"
     AlertReceiverEditRequestBase:
       title: AlertReceiverEditRequestBase
       type: object
@@ -25095,7 +25117,7 @@ components:
           x-stoplight:
             id: 0l6xifjl3s4e2
         type:
-          $ref: '#/components/schemas/AlertReceiverType'
+          $ref: "#/components/schemas/AlertReceiverType"
         send_resolved:
           type: boolean
           x-stoplight:
@@ -25111,20 +25133,20 @@ components:
       x-stoplight:
         id: hcxf6sxx1jrv9
       allOf:
-        - $ref: '#/components/schemas/AlertReceiverEditRequestBase'
+        - $ref: "#/components/schemas/AlertReceiverEditRequestBase"
         - type: object
           properties:
             webhook_url:
               type: string
               format: uri
               nullable: true
-              description: 'Update webhook URL. If null, keeps existing value.'
+              description: "Update webhook URL. If null, keeps existing value."
               x-stoplight:
                 id: 8c5ze7hwv90q2
     EmailAlertReceiverEditRequest:
       title: EmailAlertReceiverEditRequest
       allOf:
-        - $ref: '#/components/schemas/AlertReceiverEditRequestBase'
+        - $ref: "#/components/schemas/AlertReceiverEditRequestBase"
         - type: object
           required:
             - to
@@ -25140,7 +25162,7 @@ components:
               format: email
             smarthost:
               type: string
-              description: 'SMTP server in format ''host:port'''
+              description: "SMTP server in format 'host:port'"
             auth_username:
               type: string
               nullable: true
@@ -25148,7 +25170,7 @@ components:
               type: string
               format: password
               nullable: true
-              description: 'SMTP password. If null, keeps existing password.'
+              description: "SMTP password. If null, keeps existing password."
             require_tls:
               type: boolean
     AlertReceiverResponse:
@@ -25156,17 +25178,17 @@ components:
       x-stoplight:
         id: qyrx61cvx84cz
       oneOf:
-        - $ref: '#/components/schemas/SlackAlertReceiverResponse'
-        - $ref: '#/components/schemas/EmailAlertReceiverResponse'
+        - $ref: "#/components/schemas/SlackAlertReceiverResponse"
+        - $ref: "#/components/schemas/EmailAlertReceiverResponse"
       discriminator:
         propertyName: type
         mapping:
-          SLACK: '#/components/schemas/SlackAlertReceiverResponse'
-          EMAIL: '#/components/schemas/EmailAlertReceiverResponse'
+          SLACK: "#/components/schemas/SlackAlertReceiverResponse"
+          EMAIL: "#/components/schemas/EmailAlertReceiverResponse"
     SlackAlertReceiverResponse:
       title: SlackAlertReceiverResponse
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -25183,7 +25205,7 @@ components:
               x-stoplight:
                 id: aja5apvg882lo
             type:
-              $ref: '#/components/schemas/AlertReceiverType'
+              $ref: "#/components/schemas/AlertReceiverType"
             send_resolved:
               type: boolean
               x-stoplight:
@@ -25197,7 +25219,7 @@ components:
     EmailAlertReceiverResponse:
       title: EmailAlertReceiverResponse
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           required:
             - name
@@ -25215,7 +25237,7 @@ components:
             description:
               type: string
             type:
-              $ref: '#/components/schemas/AlertReceiverType'
+              $ref: "#/components/schemas/AlertReceiverType"
             send_resolved:
               type: boolean
             to:
@@ -25250,7 +25272,7 @@ components:
             id: e8a6xqrax75d5
           type: array
           items:
-            $ref: '#/components/schemas/AlertReceiverResponse'
+            $ref: "#/components/schemas/AlertReceiverResponse"
     AlertPresentation:
       title: AlertPresentation
       x-stoplight:
@@ -25299,7 +25321,7 @@ components:
           x-stoplight:
             id: luojx47y8mgl1
           format: uuid
-          description: ' Cluster identifier where the rule will be deployed'
+          description: " Cluster identifier where the rule will be deployed"
         name:
           type: string
           x-stoplight:
@@ -25316,7 +25338,7 @@ components:
           x-stoplight:
             id: eaisshdmo1xgi
         condition:
-          $ref: '#/components/schemas/AlertRuleCondition'
+          $ref: "#/components/schemas/AlertRuleCondition"
         for_duration:
           type: string
           x-stoplight:
@@ -25324,9 +25346,9 @@ components:
           description: Duration the condition must be true before firing (ISO-8601 duration format)
           format: duration
         severity:
-          $ref: '#/components/schemas/AlertSeverity'
+          $ref: "#/components/schemas/AlertSeverity"
         presentation:
-          $ref: '#/components/schemas/AlertPresentation'
+          $ref: "#/components/schemas/AlertPresentation"
         enabled:
           type: boolean
           x-stoplight:
@@ -25344,7 +25366,7 @@ components:
             type: string
             format: uuid
         target:
-          $ref: '#/components/schemas/AlertTarget'
+          $ref: "#/components/schemas/AlertTarget"
     AlertSeverity:
       title: AlertSeverity
       x-stoplight:
@@ -25391,7 +25413,7 @@ components:
           x-stoplight:
             id: p754eq1nh7gqp
         condition:
-          $ref: '#/components/schemas/AlertRuleCondition'
+          $ref: "#/components/schemas/AlertRuleCondition"
         for_duration:
           type: string
           x-stoplight:
@@ -25399,7 +25421,7 @@ components:
           format: duration
           description: Duration the condition must be true before firing (ISO-8601 duration format)
         severity:
-          $ref: '#/components/schemas/AlertSeverity'
+          $ref: "#/components/schemas/AlertSeverity"
         enabled:
           type: boolean
           x-stoplight:
@@ -25417,7 +25439,7 @@ components:
             type: string
             format: uuid
         presentation:
-          $ref: '#/components/schemas/AlertPresentation'
+          $ref: "#/components/schemas/AlertPresentation"
     AlertPresentationResponse:
       title: AlertPresentationResponse
       x-stoplight:
@@ -25428,7 +25450,7 @@ components:
           type: string
           x-stoplight:
             id: z5t89ub093022
-          description: ' Alert summary template'
+          description: " Alert summary template"
           nullable: true
         runbook_url:
           type: string
@@ -25460,26 +25482,26 @@ components:
         - state
       properties:
         source:
-          $ref: '#/components/schemas/AlertRuleSource'
+          $ref: "#/components/schemas/AlertRuleSource"
         name:
           type: string
           x-stoplight:
             id: base_name_prop
           description: Name of the alert rule
         state:
-          $ref: '#/components/schemas/AlertRuleState'
+          $ref: "#/components/schemas/AlertRuleState"
       discriminator:
         propertyName: source
         mapping:
-          MANAGED: '#/components/schemas/AlertRuleResponse'
-          GHOST: '#/components/schemas/GhostAlertRuleResponse'
+          MANAGED: "#/components/schemas/AlertRuleResponse"
+          GHOST: "#/components/schemas/GhostAlertRuleResponse"
     AlertRuleResponse:
       title: AlertRuleResponse
       x-stoplight:
         id: jsi9jy70651hv
       allOf:
-        - $ref: '#/components/schemas/Base'
-        - $ref: '#/components/schemas/AlertRuleResponseBase'
+        - $ref: "#/components/schemas/Base"
+        - $ref: "#/components/schemas/AlertRuleResponseBase"
         - type: object
           required:
             - organization_id
@@ -25505,7 +25527,7 @@ components:
               type: string
               x-stoplight:
                 id: nd3oz9h1qpa6w
-              description: ' Cluster identifier'
+              description: " Cluster identifier"
               format: uuid
             description:
               type: string
@@ -25517,7 +25539,7 @@ components:
               x-stoplight:
                 id: kloew25gqdxqt
             condition:
-              $ref: '#/components/schemas/AlertRuleCondition'
+              $ref: "#/components/schemas/AlertRuleCondition"
             for_duration:
               type: string
               x-stoplight:
@@ -25525,7 +25547,7 @@ components:
               format: duration
               description: Duration the condition must be true before firing (ISO-8601 duration format)
             severity:
-              $ref: '#/components/schemas/AlertSeverity'
+              $ref: "#/components/schemas/AlertSeverity"
             enabled:
               type: boolean
               x-stoplight:
@@ -25542,9 +25564,9 @@ components:
                 type: string
                 format: uuid
             presentation:
-              $ref: '#/components/schemas/AlertPresentationResponse'
+              $ref: "#/components/schemas/AlertPresentationResponse"
             target:
-              $ref: '#/components/schemas/AlertTarget'
+              $ref: "#/components/schemas/AlertTarget"
             is_up_to_date:
               type: boolean
               x-stoplight:
@@ -25564,12 +25586,12 @@ components:
         id: ghost_alert_rule_response
       description: Response for ghost alerts that exist in Prometheus but have been deleted from the database
       allOf:
-        - $ref: '#/components/schemas/AlertRuleResponseBase'
+        - $ref: "#/components/schemas/AlertRuleResponseBase"
         - type: object
           properties:
             target:
               allOf:
-                - $ref: '#/components/schemas/AlertTarget'
+                - $ref: "#/components/schemas/AlertTarget"
                 - nullable: true
               description: May be null if target info couldn't be extracted from Prometheus
             starts_at:
@@ -25584,7 +25606,7 @@ components:
       x-stoplight:
         id: y45ivkwhr7wb4
       enum:
-        - ' CLUSTER'
+        - " CLUSTER"
         - ENVIRONMENT
         - APPLICATION
         - CONTAINER
@@ -25603,15 +25625,15 @@ components:
         - target_id
       properties:
         target_type:
-          $ref: '#/components/schemas/AlertTargetType'
+          $ref: "#/components/schemas/AlertTargetType"
         target_id:
           type: string
           x-stoplight:
             id: 8begp36fsknxq
           format: uuid
         service:
-          $ref: '#/components/schemas/ServiceLightResponse'
-          description: 'Service details when target_type is APPLICATION, CONTAINER, JOB, CRONJOB, HELM or TERRAFORM'
+          $ref: "#/components/schemas/ServiceLightResponse"
+          description: "Service details when target_type is APPLICATION, CONTAINER, JOB, CRONJOB, HELM or TERRAFORM"
     AlertRuleState:
       title: AlertRuleState
       x-stoplight:
@@ -25638,13 +25660,13 @@ components:
             id: nsk4tfkil7yuf
           items:
             oneOf:
-              - $ref: '#/components/schemas/AlertRuleResponse'
-              - $ref: '#/components/schemas/GhostAlertRuleResponse'
+              - $ref: "#/components/schemas/AlertRuleResponse"
+              - $ref: "#/components/schemas/GhostAlertRuleResponse"
             discriminator:
               propertyName: source
               mapping:
-                MANAGED: '#/components/schemas/AlertRuleResponse'
-                GHOST: '#/components/schemas/GhostAlertRuleResponse'
+                MANAGED: "#/components/schemas/AlertRuleResponse"
+                GHOST: "#/components/schemas/GhostAlertRuleResponse"
     ObservabilityResourceProfile:
       title: ObservabilityResourceProfile
       x-stoplight:
@@ -25720,15 +25742,15 @@ components:
         - promql
       properties:
         kind:
-          $ref: '#/components/schemas/AlertRuleConditionKind'
+          $ref: "#/components/schemas/AlertRuleConditionKind"
         operator:
-          $ref: '#/components/schemas/AlertRuleConditionOperator'
+          $ref: "#/components/schemas/AlertRuleConditionOperator"
         threshold:
           type: number
           x-stoplight:
             id: ua0w1t89vrl0b
         function:
-          $ref: '#/components/schemas/AlertRuleConditionFunction'
+          $ref: "#/components/schemas/AlertRuleConditionFunction"
         promql:
           type: string
           x-stoplight:
@@ -25781,7 +25803,7 @@ components:
         - alert_receiver
       properties:
         alert_receiver:
-          $ref: '#/components/schemas/AlertReceiverCreationRequest'
+          $ref: "#/components/schemas/AlertReceiverCreationRequest"
         message:
           type: string
           x-stoplight:
@@ -25803,11 +25825,11 @@ components:
       x-stoplight:
         id: ylgyx3ozik2hf
       oneOf:
-        - $ref: '#/components/schemas/KedaAutoscalingRequest'
+        - $ref: "#/components/schemas/KedaAutoscalingRequest"
       discriminator:
         propertyName: mode
         mapping:
-          KEDA: '#/components/schemas/KedaAutoscalingRequest'
+          KEDA: "#/components/schemas/KedaAutoscalingRequest"
     AutoscalingMode:
       title: AutoscalingMode
       x-stoplight:
@@ -25825,7 +25847,7 @@ components:
         - scalers
       properties:
         mode:
-          $ref: '#/components/schemas/AutoscalingMode'
+          $ref: "#/components/schemas/AutoscalingMode"
         polling_interval_seconds:
           type: integer
           x-stoplight:
@@ -25842,7 +25864,7 @@ components:
             id: 6oh134v1tqb28
           minItems: 1
           items:
-            $ref: '#/components/schemas/KedaScalerRequest'
+            $ref: "#/components/schemas/KedaScalerRequest"
     KedaScalerRole:
       title: KedaScalerRole
       x-stoplight:
@@ -25856,7 +25878,7 @@ components:
       x-stoplight:
         id: dgcb902szizvv
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           x-stoplight:
             id: zjlwqohiiyuwf
@@ -25873,7 +25895,7 @@ components:
                 id: j9bxhtiyyl0iv
               format: uuid
             mode:
-              $ref: '#/components/schemas/AutoscalingMode'
+              $ref: "#/components/schemas/AutoscalingMode"
             polling_interval_seconds:
               type: integer
               x-stoplight:
@@ -25890,8 +25912,8 @@ components:
                 id: oyhxgvwg36ixz
               minItems: 1
               items:
-                $ref: '#/components/schemas/KedaScalerResponse'
-      description: ''
+                $ref: "#/components/schemas/KedaScalerResponse"
+      description: ""
     KedaTriggerAuthenticationRequest:
       title: KedaTriggerAuthenticationRequest
       x-stoplight:
@@ -25914,7 +25936,7 @@ components:
       x-stoplight:
         id: 7mm4a4sk9jhz3
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           x-stoplight:
             id: ssejnexbsra11
@@ -25934,7 +25956,7 @@ components:
               type: string
               x-stoplight:
                 id: r5lmrzakyk9o6
-              description: ' Optional raw KEDA TriggerAuthentication YAML configuration.'
+              description: " Optional raw KEDA TriggerAuthentication YAML configuration."
     KedaTriggerAuthenticationResponseList:
       title: KedaTriggerAuthenticationResponseList
       x-stoplight:
@@ -25946,7 +25968,7 @@ components:
           x-stoplight:
             id: md92njfinutyy
           items:
-            $ref: '#/components/schemas/KedaTriggerAuthenticationResponse'
+            $ref: "#/components/schemas/KedaTriggerAuthenticationResponse"
     KedaScalerRequest:
       title: KedaScalerRequest
       x-stoplight:
@@ -25965,7 +25987,7 @@ components:
           x-stoplight:
             id: 9m67trg9m0ioz
         role:
-          $ref: '#/components/schemas/KedaScalerRole'
+          $ref: "#/components/schemas/KedaScalerRole"
         config_json:
           type: object
           x-stoplight:
@@ -25975,13 +25997,13 @@ components:
           x-stoplight:
             id: 8c7vktd7svl30
         trigger_authentication:
-          $ref: '#/components/schemas/KedaTriggerAuthenticationRequest'
+          $ref: "#/components/schemas/KedaTriggerAuthenticationRequest"
     KedaScalerResponse:
       title: KedaScalerResponse
       x-stoplight:
         id: gaaqg32ivl48h
       allOf:
-        - $ref: '#/components/schemas/Base'
+        - $ref: "#/components/schemas/Base"
         - type: object
           x-stoplight:
             id: 74tt3hgf95nfe
@@ -25999,7 +26021,7 @@ components:
               x-stoplight:
                 id: 0dnjwnlkuj3kp
             role:
-              $ref: '#/components/schemas/KedaScalerRole'
+              $ref: "#/components/schemas/KedaScalerRole"
             config_json:
               type: object
               nullable: true
@@ -26007,17 +26029,17 @@ components:
               type: string
               nullable: true
             trigger_authentication:
-              $ref: '#/components/schemas/KedaTriggerAuthenticationResponse'
+              $ref: "#/components/schemas/KedaTriggerAuthenticationResponse"
     AutoscalingPolicyResponse:
       title: AutoscalingPolicyResponse
       x-stoplight:
         id: mjawsx6obi237
       oneOf:
-        - $ref: '#/components/schemas/KedaAutoscalingResponse'
+        - $ref: "#/components/schemas/KedaAutoscalingResponse"
       discriminator:
         propertyName: mode
         mapping:
-          KEDA: '#/components/schemas/KedaAutoscalingResponse'
+          KEDA: "#/components/schemas/KedaAutoscalingResponse"
     ClusterLabelsGroup:
       title: ClusterLabelsGroup
       x-stoplight:
@@ -26035,17 +26057,17 @@ components:
         id: imn8c9l4fab56
       type: array
       items:
-        $ref: '#/components/schemas/ClusterLabelsGroup'
+        $ref: "#/components/schemas/ClusterLabelsGroup"
   responses:
-    '204':
+    "204":
       description: no content
-    '400':
+    "400":
       description: Bad request
-    '401':
+    "401":
       description: Access token is missing or invalid
-    '403':
+    "403":
       description: Access forbidden
-    '404':
+    "404":
       description: Resource not found
     204-deletion:
       description: The resource was deleted successfully

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -8,8 +8,7 @@ description: "Fine-tune your Qovery services with advanced configuration options
 Service Advanced Settings allow you to fine-tune infrastructure and deployment parameters for your Qovery services. These settings provide granular control over build processes, networking, security, and resource allocation without requiring direct Kubernetes configuration.
 
 <Info>
-  Advanced settings are available for **Applications**, **Containers**,
-  **Cronjobs**, **Jobs**, and **Helm charts**.
+Advanced settings are available for **Applications**, **Containers**, **Cronjobs**, **Jobs**, and **Helm charts**.
 </Info>
 
 ## Accessing Advanced Settings
@@ -19,26 +18,25 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
     Open your service (Application, Container, Cronjob, Job, or Helm) in Qovery Console
   </Step>
 
-<Step title="Open Settings">Click on the **Settings** tab</Step>
+  <Step title="Open Settings">
+    Click on the **Settings** tab
+  </Step>
 
   <Step title="Access Advanced Settings">
     Scroll to the **Advanced Settings** section
 
     ![Advanced Settings Location](/images/configuration/advanced-settings/settings.png)
-
   </Step>
 
   <Step title="Configure Settings">
     Click on a setting to modify its value. You can toggle to show only overridden settings.
 
     ![Advanced Settings Interface](/images/configuration/advanced-settings/advanced_settings.png)
-
   </Step>
 </Steps>
 
 <Tip>
-  Use the **Show only overridden** toggle to view only settings that differ from
-  defaults.
+Use the **Show only overridden** toggle to view only settings that differ from defaults.
 </Tip>
 
 ---
@@ -49,8 +47,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### build.timeout_max_sec
 
-<span class="badge-app">Application</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -62,8 +59,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### build.cpu_max_in_milli
 
-<span class="badge-app">Application</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -75,8 +71,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### build.ram_max_in_gib
 
-<span class="badge-app">Application</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -88,8 +83,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### build.ephemeral_storage_in_gib
 
-<span class="badge-app">Application</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -101,8 +95,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### build.disable_buildkit_cache
 
-<span class="badge-app">Application</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `boolean`
 
@@ -120,9 +113,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.termination_grace_period_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -131,9 +122,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Use Case:** Increase this value for services that need extra time to drain connections, finish background jobs, or flush data to disk. Keep it low for stateless workers that can restart quickly.
 
 <Warning>
-  This value must be **greater than** the time your
-  `deployment.lifecycle.pre_stop_exec_command` takes to complete. Otherwise
-  Kubernetes will kill the pod before the pre-stop hook finishes.
+This value must be **greater than** the time your `deployment.lifecycle.pre_stop_exec_command` takes to complete. Otherwise Kubernetes will kill the pod before the pre-stop hook finishes.
 </Warning>
 
 **Default Value:** `60`
@@ -142,9 +131,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.affinity.node.required
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `Map<String, String>`
 
@@ -164,7 +151,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
       "karpenter.sh/nodepool": "stable"
     }
     ```
-
   </Tab>
   <Tab title="AWS — Graviton (ARM64)">
     Schedule on ARM64 Graviton instances for better price/performance:
@@ -174,7 +160,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
       "kubernetes.io/arch": "arm64"
     }
     ```
-
   </Tab>
   <Tab title="GCP Autopilot — ARM64 Performance">
     Run on ARM64 nodes with the GCP Autopilot `Performance` compute class:
@@ -185,22 +170,18 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
       "cloud.google.com/compute-class": "Performance"
     }
     ```
-
   </Tab>
 </Tabs>
 
 <Warning>
-  If no node matches the required labels, your pods will stay in `Pending`
-  state. Make sure the target node pool or nodes exist before applying this
-  setting.
+If no node matches the required labels, your pods will stay in `Pending` state. Make sure the target node pool or nodes exist before applying this setting.
 </Warning>
 
 <a id="deployment-antiaffinity-pod"></a>
 
 ### deployment.antiaffinity.pod
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -209,8 +190,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Use Case:** Use `Required` to guarantee that no two replicas of the same service land on the same node — critical for high-availability setups where a single node failure must not take down the entire service. Use `Preferred` (default) when you want Kubernetes to spread pods across nodes on a best-effort basis without blocking scheduling if not enough nodes are available.
 
 <Info>
-  With `Required`, you need **at least as many nodes as replicas**. If your
-  cluster doesn't have enough nodes, excess pods will stay `Pending`.
+With `Required`, you need **at least as many nodes as replicas**. If your cluster doesn't have enough nodes, excess pods will stay `Pending`.
 </Info>
 
 **Default Value:** `Preferred`
@@ -219,8 +199,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.topology_spread.zone
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -234,15 +213,13 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.update_strategy.type
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `string`
 
 **Description:** Allows you to specify the deployment update strategy type. Options are `RollingUpdate` or `Recreate`.
 
 **Use Case:**
-
 - **`RollingUpdate`** (default) — gradually replaces pods for zero-downtime deployments. Best for stateless services.
 - **`Recreate`** — terminates all existing pods before creating new ones. Use this when:
   - Your service uses a **ReadWriteOnce (RWO) volume** that cannot be mounted by two pods simultaneously.
@@ -255,8 +232,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.update_strategy.rolling_update.max_unavailable_percent
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -270,8 +246,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.update_strategy.rolling_update.max_surge_percent
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -285,8 +260,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.lifecycle.post_start_exec_command
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -297,12 +271,10 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `""`
 
 **Examples:**
-
 ```json
 // Warm the application cache at startup
 ["/bin/sh", "-c", "curl -s http://localhost:8080/warmup || true"]
 ```
-
 ```json
 // Write a marker file for a readiness probe
 ["/bin/sh", "-c", "touch /tmp/ready"]
@@ -312,8 +284,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### deployment.lifecycle.pre_stop_exec_command
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -322,21 +293,16 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Use Case:** Use this to give your service time to drain in-flight requests, close database connections, or deregister from a load balancer before the pod disappears.
 
 <Info>
-  The default `sleep 15` gives Kubernetes networking time to remove the pod from
-  service endpoints before the process exits. If your service handles its own
-  graceful shutdown, you may still want a short sleep to avoid receiving traffic
-  after `SIGTERM`.
+The default `sleep 15` gives Kubernetes networking time to remove the pod from service endpoints before the process exits. If your service handles its own graceful shutdown, you may still want a short sleep to avoid receiving traffic after `SIGTERM`.
 </Info>
 
 **Default Value:** `["/bin/sh", "-c", "sleep 15"]`
 
 **Examples:**
-
 ```json
 // Notify the app to drain, then wait for connections to close
 ["/bin/sh", "-c", "curl -s http://localhost:8080/drain && sleep 20"]
 ```
-
 ```json
 // Simple sleep to let LB deregister the pod
 ["/bin/sh", "-c", "sleep 30"]
@@ -350,9 +316,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.enable_cors
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -364,9 +328,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.cors_allow_origin
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -378,9 +340,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.cors_allow_methods
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -392,9 +352,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.cors_allow_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -406,9 +364,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.force_ssl_redirect
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -422,9 +378,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_body_size_mb
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -438,9 +392,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_buffer_size_kb
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -454,9 +406,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_connect_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -468,9 +418,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_read_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -484,9 +432,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_send_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -498,9 +444,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_buffering
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -514,9 +458,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_request_buffering
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -530,9 +472,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.proxy_set_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `Map<String, String>`
 
@@ -544,9 +484,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.add_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -557,18 +495,15 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `{}`
 
 **Example:**
-
 ```json
-{ "X-Frame-Options": "DENY", "X-Content-Type-Options": "nosniff" }
+{"X-Frame-Options":"DENY","X-Content-Type-Options":"nosniff"}
 ```
 
 <a id="network-ingress-whitelist-source-range"></a>
 
 ### network.ingress.whitelist_source_range
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -582,9 +517,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.denylist_source_range
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -596,9 +529,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.basic_auth_env_var
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -612,9 +543,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.enable_sticky_session
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -628,9 +557,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.keepalive_time_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -644,9 +571,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.keepalive_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -658,9 +583,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.send_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -674,9 +597,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.grpc_send_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -688,9 +609,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.grpc_read_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -702,9 +621,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_controller_configuration_snippet
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -718,9 +635,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_controller_server_snippet
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -734,9 +649,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_limit_burst_multiplier
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -750,9 +663,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_limit_connections
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -766,9 +677,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_limit_rpm
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -780,9 +689,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_limit_rps
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -794,9 +701,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.ingress.nginx_custom_http_errors
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -807,7 +712,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null`
 
 **Example:**
-
 ```json
 "404,503"
 ```
@@ -816,9 +720,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.enable_sticky_session
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -832,9 +734,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.force_ssl_redirect
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -848,9 +748,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.enable_cors
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -864,9 +762,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.cors_allow_origin
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -875,7 +771,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `"*"` (allows all origins)
 
 **Example:**
-
 ```json
 "https://example.com, https://app.example.com"
 ```
@@ -884,9 +779,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.cors_allow_methods
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -898,9 +791,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.cors_allow_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -912,9 +803,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.whitelist_source_range
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -925,7 +814,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `"0.0.0.0/0, ::/0"` (allows all IPv4 and IPv6 addresses)
 
 **Example:**
-
 ```json
 "10.0.0.0/8, 192.168.1.0/24"
 ```
@@ -934,9 +822,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.denylist_source_range
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -947,7 +833,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `""` (no IPs are blocked)
 
 **Example:**
-
 ```json
 "203.0.113.0/24, 198.51.100.0/24"
 ```
@@ -956,9 +841,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.basic_auth_env_var
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -969,7 +852,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `""` (Basic Auth disabled)
 
 **Example:**
-
 ```json
 "BASIC_AUTH_CREDENTIALS"
 ```
@@ -978,9 +860,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.route_limit_rpm
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -991,7 +871,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (no limit)
 
 **Example:**
-
 ```json
 1000
 ```
@@ -1000,9 +879,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.route_limit_rps
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1013,7 +890,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (no limit)
 
 **Example:**
-
 ```json
 100
 ```
@@ -1022,9 +898,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.route_limit_source_cidrs
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -1035,7 +909,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `""` (rate limiting applies to all sources)
 
 **Example:**
-
 ```json
 "0.0.0.0/0, ::/0"
 ```
@@ -1044,9 +917,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.route_limit_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -1057,7 +928,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `""` (rate limiting is per source IP)
 
 **Example:**
-
 ```json
 "X-API-Key, X-User-ID"
 ```
@@ -1066,9 +936,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.add_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `map<string, string>`
 
@@ -1079,7 +947,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `{}` (no headers added)
 
 **Example:**
-
 ```json
 {
   "X-Custom-Header": "custom-value",
@@ -1091,9 +958,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.proxy_set_headers
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `map<string, string>`
 
@@ -1104,7 +969,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `{}` (no headers modified)
 
 **Example:**
-
 ```json
 {
   "X-Forwarded-Proto": "https",
@@ -1116,9 +980,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.custom_http_errors
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -1129,24 +991,19 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (no custom error pages)
 
 **Example:**
-
 ```json
 "404,503,502"
 ```
 
 <Info>
-  The hardcoded error pages cannot be customized at this time. If you need to
-  customize error pages for your use case, please contact us and we can extend
-  this feature.
+The hardcoded error pages cannot be customized at this time. If you need to customize error pages for your use case, please contact us and we can extend this feature.
 </Info>
 
 <a id="network-gateway-api-circuit-breaker-max-connections"></a>
 
 ### network.gateway_api.circuit_breaker.max_connections
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1157,7 +1014,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (no limit)
 
 **Example:**
-
 ```json
 1024
 ```
@@ -1166,9 +1022,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.circuit_breaker.max_pending_requests
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1179,7 +1033,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (no limit)
 
 **Example:**
-
 ```json
 1024
 ```
@@ -1188,9 +1041,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.circuit_breaker.max_parallel_requests
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1201,7 +1052,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (no limit)
 
 **Example:**
-
 ```json
 2048
 ```
@@ -1210,9 +1060,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.tcp_keepalive_idle_time_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1223,7 +1071,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
-
 ```json
 7200
 ```
@@ -1232,9 +1079,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.tcp_keepalive_interval_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1245,7 +1090,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
-
 ```json
 120
 ```
@@ -1254,9 +1098,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.http_request_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1267,7 +1109,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
-
 ```json
 90
 ```
@@ -1276,9 +1117,7 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.gateway_api.http_connection_idle_timeout_seconds
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1289,7 +1128,6 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
-
 ```json
 120
 ```
@@ -1298,16 +1136,13 @@ Service Advanced Settings allow you to fine-tune infrastructure and deployment p
 
 ### network.dns.ndots
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer` (unsigned)
 
 **Description:** Configures the DNS `ndots` threshold that determines when Kubernetes appends search domain suffixes to hostnames during DNS resolution.
 
 **Use Case:** When your service queries an external domain like `api.example.com` (2 dots) with the default `ndots=5`, Kubernetes attempts **6 DNS queries** before resolving:
-
 1. `api.example.com.default.svc.cluster.local` ❌ (fails)
 2. `api.example.com.svc.cluster.local` ❌ (fails)
 3. `api.example.com.cluster.local` ❌ (fails)
@@ -1320,7 +1155,6 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 **Default Value:** `null` (uses Kubernetes default of `5`)
 
 **Example:**
-
 ```json
 2
 ```
@@ -1335,8 +1169,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### hpa.cpu.average_utilization_percent
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -1350,8 +1183,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### hpa.memory.average_utilization_percent
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -1425,9 +1257,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### resources.override.limit.cpu_in_milli
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -1441,9 +1271,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### resources.override.limit.ram_in_mib
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -1461,9 +1289,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### security.service_account_name
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `string`
 
@@ -1477,9 +1303,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### security.automount_service_account_token
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `boolean`
 
@@ -1493,9 +1317,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### security.read_only_root_filesystem
 
-<span class="badge-app">Application</span>
-<span class="badge-container">Container</span>
-<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `boolean`
 
@@ -1510,32 +1332,16 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card
-    title="Cluster Advanced Settings"
-    icon="server"
-    href="/configuration/cluster-advanced-settings"
-  >
+  <Card title="Cluster Advanced Settings" icon="server" href="/configuration/cluster-advanced-settings">
     Configure cluster-level advanced settings
   </Card>
-  <Card
-    title="Environment Variables"
-    icon="code"
-    href="/configuration/environment-variables"
-  >
+  <Card title="Environment Variables" icon="code" href="/configuration/environment-variables">
     Manage environment variables and secrets
   </Card>
-  <Card
-    title="Qovery API Reference"
-    icon="brackets-curly"
-    href="/api-reference/introduction"
-  >
+  <Card title="Qovery API Reference" icon="brackets-curly" href="/api-reference/introduction">
     Explore the full Qovery API
   </Card>
-  <Card
-    title="Terraform Provider"
-    icon="/images/logos/terraform-icon.svg"
-    href="/terraform-provider/overview"
-  >
+  <Card title="Terraform Provider" icon="/images/logos/terraform-icon.svg" href="/terraform-provider/overview">
     Manage infrastructure as code
   </Card>
 </CardGroup>

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -8,7 +8,8 @@ description: "Fine-tune your Qovery services with advanced configuration options
 Service Advanced Settings allow you to fine-tune infrastructure and deployment parameters for your Qovery services. These settings provide granular control over build processes, networking, security, and resource allocation without requiring direct Kubernetes configuration.
 
 <Info>
-Advanced settings are available for **Applications**, **Containers**, **Cronjobs**, **Jobs**, and **Helm charts**.
+  Advanced settings are available for **Applications**, **Containers**,
+  **Cronjobs**, **Jobs**, and **Helm charts**.
 </Info>
 
 ## Accessing Advanced Settings
@@ -18,25 +19,26 @@ Advanced settings are available for **Applications**, **Containers**, **Cronjobs
     Open your service (Application, Container, Cronjob, Job, or Helm) in Qovery Console
   </Step>
 
-  <Step title="Open Settings">
-    Click on the **Settings** tab
-  </Step>
+<Step title="Open Settings">Click on the **Settings** tab</Step>
 
   <Step title="Access Advanced Settings">
     Scroll to the **Advanced Settings** section
 
     ![Advanced Settings Location](/images/configuration/advanced-settings/settings.png)
+
   </Step>
 
   <Step title="Configure Settings">
     Click on a setting to modify its value. You can toggle to show only overridden settings.
 
     ![Advanced Settings Interface](/images/configuration/advanced-settings/advanced_settings.png)
+
   </Step>
 </Steps>
 
 <Tip>
-Use the **Show only overridden** toggle to view only settings that differ from defaults.
+  Use the **Show only overridden** toggle to view only settings that differ from
+  defaults.
 </Tip>
 
 ---
@@ -47,7 +49,8 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 ### build.timeout_max_sec
 
-<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -59,7 +62,8 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 ### build.cpu_max_in_milli
 
-<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -71,7 +75,8 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 ### build.ram_max_in_gib
 
-<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -83,7 +88,8 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 ### build.ephemeral_storage_in_gib
 
-<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -95,7 +101,8 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 ### build.disable_buildkit_cache
 
-<span class="badge-app">Application</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `boolean`
 
@@ -113,7 +120,9 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 
 ### deployment.termination_grace_period_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -122,7 +131,9 @@ Use the **Show only overridden** toggle to view only settings that differ from d
 **Use Case:** Increase this value for services that need extra time to drain connections, finish background jobs, or flush data to disk. Keep it low for stateless workers that can restart quickly.
 
 <Warning>
-This value must be **greater than** the time your `deployment.lifecycle.pre_stop_exec_command` takes to complete. Otherwise Kubernetes will kill the pod before the pre-stop hook finishes.
+  This value must be **greater than** the time your
+  `deployment.lifecycle.pre_stop_exec_command` takes to complete. Otherwise
+  Kubernetes will kill the pod before the pre-stop hook finishes.
 </Warning>
 
 **Default Value:** `60`
@@ -131,7 +142,9 @@ This value must be **greater than** the time your `deployment.lifecycle.pre_stop
 
 ### deployment.affinity.node.required
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `Map<String, String>`
 
@@ -151,6 +164,7 @@ This value must be **greater than** the time your `deployment.lifecycle.pre_stop
       "karpenter.sh/nodepool": "stable"
     }
     ```
+
   </Tab>
   <Tab title="AWS — Graviton (ARM64)">
     Schedule on ARM64 Graviton instances for better price/performance:
@@ -160,6 +174,7 @@ This value must be **greater than** the time your `deployment.lifecycle.pre_stop
       "kubernetes.io/arch": "arm64"
     }
     ```
+
   </Tab>
   <Tab title="GCP Autopilot — ARM64 Performance">
     Run on ARM64 nodes with the GCP Autopilot `Performance` compute class:
@@ -170,18 +185,22 @@ This value must be **greater than** the time your `deployment.lifecycle.pre_stop
       "cloud.google.com/compute-class": "Performance"
     }
     ```
+
   </Tab>
 </Tabs>
 
 <Warning>
-If no node matches the required labels, your pods will stay in `Pending` state. Make sure the target node pool or nodes exist before applying this setting.
+  If no node matches the required labels, your pods will stay in `Pending`
+  state. Make sure the target node pool or nodes exist before applying this
+  setting.
 </Warning>
 
 <a id="deployment-antiaffinity-pod"></a>
 
 ### deployment.antiaffinity.pod
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -190,22 +209,40 @@ If no node matches the required labels, your pods will stay in `Pending` state. 
 **Use Case:** Use `Required` to guarantee that no two replicas of the same service land on the same node — critical for high-availability setups where a single node failure must not take down the entire service. Use `Preferred` (default) when you want Kubernetes to spread pods across nodes on a best-effort basis without blocking scheduling if not enough nodes are available.
 
 <Info>
-With `Required`, you need **at least as many nodes as replicas**. If your cluster doesn't have enough nodes, excess pods will stay `Pending`.
+  With `Required`, you need **at least as many nodes as replicas**. If your
+  cluster doesn't have enough nodes, excess pods will stay `Pending`.
 </Info>
 
 **Default Value:** `Preferred`
+
+<a id="deployment-topology-spread-zone"></a>
+
+### deployment.topology_spread.zone
+
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+
+**Type:** `string`
+
+**Description:** Controls how pods are spread across availability zones using Kubernetes `topologySpreadConstraints`. Options are `Disabled`, `ScheduleAnyway`, or `DoNotSchedule`.
+
+**Use Case:** Use `DoNotSchedule` to enforce even distribution of pods across availability zones with a `maxSkew` of 1 (hard constraint). Use `ScheduleAnyway` for best-effort spreading. This is a prerequisite for properly leveraging multi-AZ clusters for high availability.
+
+**Default Value:** `Disabled`
 
 <a id="deployment-update-strategy-type"></a>
 
 ### deployment.update_strategy.type
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `string`
 
 **Description:** Allows you to specify the deployment update strategy type. Options are `RollingUpdate` or `Recreate`.
 
 **Use Case:**
+
 - **`RollingUpdate`** (default) — gradually replaces pods for zero-downtime deployments. Best for stateless services.
 - **`Recreate`** — terminates all existing pods before creating new ones. Use this when:
   - Your service uses a **ReadWriteOnce (RWO) volume** that cannot be mounted by two pods simultaneously.
@@ -218,7 +255,8 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 
 ### deployment.update_strategy.rolling_update.max_unavailable_percent
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -232,7 +270,8 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 
 ### deployment.update_strategy.rolling_update.max_surge_percent
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -246,7 +285,8 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 
 ### deployment.lifecycle.post_start_exec_command
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -257,10 +297,12 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 **Default Value:** `""`
 
 **Examples:**
+
 ```json
 // Warm the application cache at startup
 ["/bin/sh", "-c", "curl -s http://localhost:8080/warmup || true"]
 ```
+
 ```json
 // Write a marker file for a readiness probe
 ["/bin/sh", "-c", "touch /tmp/ready"]
@@ -270,7 +312,8 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 
 ### deployment.lifecycle.pre_stop_exec_command
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `string`
 
@@ -279,16 +322,21 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 **Use Case:** Use this to give your service time to drain in-flight requests, close database connections, or deregister from a load balancer before the pod disappears.
 
 <Info>
-The default `sleep 15` gives Kubernetes networking time to remove the pod from service endpoints before the process exits. If your service handles its own graceful shutdown, you may still want a short sleep to avoid receiving traffic after `SIGTERM`.
+  The default `sleep 15` gives Kubernetes networking time to remove the pod from
+  service endpoints before the process exits. If your service handles its own
+  graceful shutdown, you may still want a short sleep to avoid receiving traffic
+  after `SIGTERM`.
 </Info>
 
 **Default Value:** `["/bin/sh", "-c", "sleep 15"]`
 
 **Examples:**
+
 ```json
 // Notify the app to drain, then wait for connections to close
 ["/bin/sh", "-c", "curl -s http://localhost:8080/drain && sleep 20"]
 ```
+
 ```json
 // Simple sleep to let LB deregister the pod
 ["/bin/sh", "-c", "sleep 30"]
@@ -302,7 +350,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.enable_cors
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -314,7 +364,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.cors_allow_origin
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -326,7 +378,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.cors_allow_methods
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -338,7 +392,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.cors_allow_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -350,7 +406,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.force_ssl_redirect
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -364,7 +422,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_body_size_mb
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -378,7 +438,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_buffer_size_kb
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -392,7 +454,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_connect_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -404,7 +468,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_read_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -418,7 +484,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_send_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -430,7 +498,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_buffering
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -444,7 +514,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_request_buffering
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -458,7 +530,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.proxy_set_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `Map<String, String>`
 
@@ -470,7 +544,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.add_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -481,15 +557,18 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `{}`
 
 **Example:**
+
 ```json
-{"X-Frame-Options":"DENY","X-Content-Type-Options":"nosniff"}
+{ "X-Frame-Options": "DENY", "X-Content-Type-Options": "nosniff" }
 ```
 
 <a id="network-ingress-whitelist-source-range"></a>
 
 ### network.ingress.whitelist_source_range
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -503,7 +582,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.denylist_source_range
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -515,7 +596,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.basic_auth_env_var
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -529,7 +612,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.enable_sticky_session
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -543,7 +628,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.keepalive_time_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -557,7 +644,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.keepalive_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -569,7 +658,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.send_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -583,7 +674,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.grpc_send_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -595,7 +688,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.grpc_read_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -607,7 +702,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_controller_configuration_snippet
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -621,7 +718,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_controller_server_snippet
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -635,7 +734,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_limit_burst_multiplier
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -649,7 +750,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_limit_connections
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer`
 
@@ -663,7 +766,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_limit_rpm
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -675,7 +780,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_limit_rps
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -687,7 +794,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.ingress.nginx_custom_http_errors
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -698,6 +807,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `null`
 
 **Example:**
+
 ```json
 "404,503"
 ```
@@ -706,7 +816,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.enable_sticky_session
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -720,7 +832,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.force_ssl_redirect
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -734,7 +848,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.enable_cors
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `boolean`
 
@@ -748,7 +864,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.cors_allow_origin
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -757,6 +875,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `"*"` (allows all origins)
 
 **Example:**
+
 ```json
 "https://example.com, https://app.example.com"
 ```
@@ -765,7 +884,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.cors_allow_methods
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -777,7 +898,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.cors_allow_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -789,7 +912,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.whitelist_source_range
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -800,6 +925,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `"0.0.0.0/0, ::/0"` (allows all IPv4 and IPv6 addresses)
 
 **Example:**
+
 ```json
 "10.0.0.0/8, 192.168.1.0/24"
 ```
@@ -808,7 +934,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.denylist_source_range
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -819,6 +947,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `""` (no IPs are blocked)
 
 **Example:**
+
 ```json
 "203.0.113.0/24, 198.51.100.0/24"
 ```
@@ -827,7 +956,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.basic_auth_env_var
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -838,6 +969,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `""` (Basic Auth disabled)
 
 **Example:**
+
 ```json
 "BASIC_AUTH_CREDENTIALS"
 ```
@@ -846,7 +978,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.route_limit_rpm
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -857,6 +991,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `null` (no limit)
 
 **Example:**
+
 ```json
 1000
 ```
@@ -865,7 +1000,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.route_limit_rps
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -876,6 +1013,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `null` (no limit)
 
 **Example:**
+
 ```json
 100
 ```
@@ -884,7 +1022,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.route_limit_source_cidrs
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -895,6 +1035,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `""` (rate limiting applies to all sources)
 
 **Example:**
+
 ```json
 "0.0.0.0/0, ::/0"
 ```
@@ -903,7 +1044,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.route_limit_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -914,6 +1057,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `""` (rate limiting is per source IP)
 
 **Example:**
+
 ```json
 "X-API-Key, X-User-ID"
 ```
@@ -922,7 +1066,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.add_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `map<string, string>`
 
@@ -933,6 +1079,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `{}` (no headers added)
 
 **Example:**
+
 ```json
 {
   "X-Custom-Header": "custom-value",
@@ -944,7 +1091,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.proxy_set_headers
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `map<string, string>`
 
@@ -955,6 +1104,7 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `{}` (no headers modified)
 
 **Example:**
+
 ```json
 {
   "X-Forwarded-Proto": "https",
@@ -966,7 +1116,9 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 
 ### network.gateway_api.custom_http_errors
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `string`
 
@@ -977,19 +1129,24 @@ The default `sleep 15` gives Kubernetes networking time to remove the pod from s
 **Default Value:** `null` (no custom error pages)
 
 **Example:**
+
 ```json
 "404,503,502"
 ```
 
 <Info>
-The hardcoded error pages cannot be customized at this time. If you need to customize error pages for your use case, please contact us and we can extend this feature.
+  The hardcoded error pages cannot be customized at this time. If you need to
+  customize error pages for your use case, please contact us and we can extend
+  this feature.
 </Info>
 
 <a id="network-gateway-api-circuit-breaker-max-connections"></a>
 
 ### network.gateway_api.circuit_breaker.max_connections
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1000,6 +1157,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (no limit)
 
 **Example:**
+
 ```json
 1024
 ```
@@ -1008,7 +1166,9 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.gateway_api.circuit_breaker.max_pending_requests
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1019,6 +1179,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (no limit)
 
 **Example:**
+
 ```json
 1024
 ```
@@ -1027,7 +1188,9 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.gateway_api.circuit_breaker.max_parallel_requests
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1038,6 +1201,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (no limit)
 
 **Example:**
+
 ```json
 2048
 ```
@@ -1046,7 +1210,9 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.gateway_api.tcp_keepalive_idle_time_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1057,6 +1223,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
+
 ```json
 7200
 ```
@@ -1065,7 +1232,9 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.gateway_api.tcp_keepalive_interval_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1076,6 +1245,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
+
 ```json
 120
 ```
@@ -1084,7 +1254,9 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.gateway_api.http_request_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1095,6 +1267,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
+
 ```json
 90
 ```
@@ -1103,7 +1276,9 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.gateway_api.http_connection_idle_timeout_seconds
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-helm">Helm</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-helm">Helm</span>
 
 **Type:** `integer` (unsigned)
 
@@ -1114,6 +1289,7 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 **Default Value:** `null` (uses Envoy Gateway default)
 
 **Example:**
+
 ```json
 120
 ```
@@ -1122,13 +1298,16 @@ The hardcoded error pages cannot be customized at this time. If you need to cust
 
 ### network.dns.ndots
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer` (unsigned)
 
 **Description:** Configures the DNS `ndots` threshold that determines when Kubernetes appends search domain suffixes to hostnames during DNS resolution.
 
 **Use Case:** When your service queries an external domain like `api.example.com` (2 dots) with the default `ndots=5`, Kubernetes attempts **6 DNS queries** before resolving:
+
 1. `api.example.com.default.svc.cluster.local` ❌ (fails)
 2. `api.example.com.svc.cluster.local` ❌ (fails)
 3. `api.example.com.cluster.local` ❌ (fails)
@@ -1141,6 +1320,7 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 **Default Value:** `null` (uses Kubernetes default of `5`)
 
 **Example:**
+
 ```json
 2
 ```
@@ -1155,7 +1335,8 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### hpa.cpu.average_utilization_percent
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -1169,7 +1350,8 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### hpa.memory.average_utilization_percent
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
 
 **Type:** `integer`
 
@@ -1243,7 +1425,9 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### resources.override.limit.cpu_in_milli
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -1257,7 +1441,9 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### resources.override.limit.ram_in_mib
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `integer`
 
@@ -1275,7 +1461,9 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### security.service_account_name
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `string`
 
@@ -1289,7 +1477,9 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### security.automount_service_account_token
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `boolean`
 
@@ -1303,7 +1493,9 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 ### security.read_only_root_filesystem
 
-<span class="badge-app">Application</span> <span class="badge-container">Container</span> <span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
+<span class="badge-app">Application</span>
+<span class="badge-container">Container</span>
+<span class="badge-cronjob">Cronjob</span> <span class="badge-job">Job</span>
 
 **Type:** `boolean`
 
@@ -1318,16 +1510,32 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Cluster Advanced Settings" icon="server" href="/configuration/cluster-advanced-settings">
+  <Card
+    title="Cluster Advanced Settings"
+    icon="server"
+    href="/configuration/cluster-advanced-settings"
+  >
     Configure cluster-level advanced settings
   </Card>
-  <Card title="Environment Variables" icon="code" href="/configuration/environment-variables">
+  <Card
+    title="Environment Variables"
+    icon="code"
+    href="/configuration/environment-variables"
+  >
     Manage environment variables and secrets
   </Card>
-  <Card title="Qovery API Reference" icon="brackets-curly" href="/api-reference/introduction">
+  <Card
+    title="Qovery API Reference"
+    icon="brackets-curly"
+    href="/api-reference/introduction"
+  >
     Explore the full Qovery API
   </Card>
-  <Card title="Terraform Provider" icon="/images/logos/terraform-icon.svg" href="/terraform-provider/overview">
+  <Card
+    title="Terraform Provider"
+    icon="/images/logos/terraform-icon.svg"
+    href="/terraform-provider/overview"
+  >
     Manage infrastructure as code
   </Card>
 </CardGroup>

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -213,7 +213,7 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 | `ScheduleAnyway` | Kubernetes **tries** to spread pods evenly across zones, but will still schedule them even if the distribution is not perfect. This is a soft constraint — pods are never left `Pending` due to zone imbalance. |
 | `DoNotSchedule` | Kubernetes **enforces** even distribution across zones. If the scheduler cannot place a pod without exceeding a `maxSkew` of 1, the pod stays `Pending` until a suitable node becomes available. |
 
-**Recommendation:** Use `ScheduleAnyway` for most workloads — it provides zone spreading on a best-effort basis without risking pods stuck in `Pending`. Reserve `DoNotSchedule` for critical services where strict zone distribution is mandatory and you are confident that your cluster has enough nodes in each zone to accommodate all replicas.
+**Recommendation:** Use `ScheduleAnyway` for most production workloads — it provides zone spreading on a best-effort basis without risking pods stuck in `Pending`. Reserve `DoNotSchedule` for critical services where strict zone distribution is mandatory and you are confident that your cluster has enough capacity in each zone. Keep `Disabled` for dev/staging environments or workloads where zone spreading adds no value (e.g., single-replica services, batch jobs).
 
 <Warning>
 With `DoNotSchedule`, if your cluster has an uneven number of nodes across zones or if a zone is temporarily unavailable, excess pods will remain in `Pending` state. Make sure you have sufficient capacity in each availability zone before enabling this mode.

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -203,9 +203,25 @@ With `Required`, you need **at least as many nodes as replicas**. If your cluste
 
 **Type:** `string`
 
-**Description:** Controls how pods are spread across availability zones using Kubernetes `topologySpreadConstraints`. Options are `Disabled`, `ScheduleAnyway`, or `DoNotSchedule`.
+**Description:** Controls how pods are spread across availability zones using Kubernetes [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/). This setting generates a constraint with `maxSkew: 1` and `topologyKey: topology.kubernetes.io/zone`.
 
-**Use Case:** Use `DoNotSchedule` to enforce even distribution of pods across availability zones with a `maxSkew` of 1 (hard constraint). Use `ScheduleAnyway` for best-effort spreading. This is a prerequisite for properly leveraging multi-AZ clusters for high availability.
+**Options:**
+
+| Value | Behavior |
+|---|---|
+| `Disabled` | No topology spread constraint is applied. Pods are scheduled without any zone-awareness. |
+| `ScheduleAnyway` | Kubernetes **tries** to spread pods evenly across zones, but will still schedule them even if the distribution is not perfect. This is a soft constraint — pods are never left `Pending` due to zone imbalance. |
+| `DoNotSchedule` | Kubernetes **enforces** even distribution across zones. If the scheduler cannot place a pod without exceeding a `maxSkew` of 1, the pod stays `Pending` until a suitable node becomes available. |
+
+**Recommendation:** Use `ScheduleAnyway` for most workloads — it provides zone spreading on a best-effort basis without risking pods stuck in `Pending`. Reserve `DoNotSchedule` for critical services where strict zone distribution is mandatory and you are confident that your cluster has enough nodes in each zone to accommodate all replicas.
+
+<Warning>
+With `DoNotSchedule`, if your cluster has an uneven number of nodes across zones or if a zone is temporarily unavailable, excess pods will remain in `Pending` state. Make sure you have sufficient capacity in each availability zone before enabling this mode.
+</Warning>
+
+<Info>
+This setting is a prerequisite for properly leveraging multi-AZ clusters for high availability. It complements `deployment.antiaffinity.pod` which spreads pods across **nodes** — this setting spreads pods across **zones**.
+</Info>
 
 **Default Value:** `Disabled`
 

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -225,6 +225,44 @@ This setting is a prerequisite for properly leveraging multi-AZ clusters for hig
 
 **Default Value:** `Disabled`
 
+#### Common patterns
+
+These settings work together to cover different high-availability strategies. Here are recommended combinations depending on your use case:
+
+<Tabs>
+  <Tab title="Critical production service">
+    Maximum resilience: pods pinned to stable on-demand nodes, strictly spread across zones, and never co-located on the same node.
+
+    | Setting | Value |
+    |---|---|
+    | `deployment.affinity.node.required` | `{"karpenter.sh/capacity-type": "on-demand"}` |
+    | `deployment.topology_spread.zone` | `DoNotSchedule` |
+    | `deployment.antiaffinity.pod` | `Required` |
+
+    <Warning>
+    Requires at least as many on-demand nodes as replicas, distributed across all availability zones. Otherwise pods will stay `Pending`.
+    </Warning>
+  </Tab>
+  <Tab title="Standard production service">
+    Best-effort zone and node spreading without any scheduling risk. Works well with spot instances and autoscaling.
+
+    | Setting | Value |
+    |---|---|
+    | `deployment.affinity.node.required` | `{}` |
+    | `deployment.topology_spread.zone` | `ScheduleAnyway` |
+    | `deployment.antiaffinity.pod` | `Preferred` |
+  </Tab>
+  <Tab title="Stateful with zone pinning">
+    Pin pods to a specific zone — useful for workloads that must be co-located with a zone-bound resource (e.g., EBS volume, RDS instance).
+
+    | Setting | Value |
+    |---|---|
+    | `deployment.affinity.node.required` | `{"topology.kubernetes.io/zone": "eu-west-1a"}` |
+    | `deployment.topology_spread.zone` | `Disabled` |
+    | `deployment.antiaffinity.pod` | `Preferred` |
+  </Tab>
+</Tabs>
+
 <a id="deployment-update-strategy-type"></a>
 
 ### deployment.update_strategy.type


### PR DESCRIPTION
## Summary
- Add `deployment.topology_spread.zone` documentation in `service-advanced-settings.mdx`
- Add setting to API reference `openapi.yaml` for `ApplicationAdvancedSettings` and `ContainerAdvancedSettings`
- Values: `Disabled` (default), `ScheduleAnyway`, `DoNotSchedule`

## Context
Customer request to support topology spread constraints as an advanced setting, prerequisite for multi-AZ cluster usage.