### PR TITLE
docs(QOV-794): document dedicated cronjob nodepool for AWS EKS

### DIFF
--- a/docs/configuration/cronjob.mdx
+++ b/docs/configuration/cronjob.mdx
@@ -18,11 +18,11 @@ Cron Jobs in Qovery are Kubernetes workloads that run on a regular schedule. The
 ## Dedicated Cronjob Node Pool
 
 <Info>
-On AWS EKS clusters with Karpenter, you can enable a dedicated **cronjob node pool**. When enabled, a Karpenter NodePool named `cronjob` is created with a `nodepool/cronjob: NoSchedule` taint. Cronjob pods automatically receive the appropriate tolerations and node affinity to schedule on this nodepool, isolating them from other services running on shared nodes. See [AWS EKS cluster resources](/configuration/integrations/kubernetes/eks/managed#resources) for details on enabling and configuring this nodepool.
+On AWS EKS clusters with Karpenter, you can enable a dedicated **cronjob node pool**. When enabled, a Karpenter NodePool named `cronjob` is created with a `nodepool/cronjob: NoSchedule` taint. Qovery cron jobs automatically receive the appropriate toleration and a preferred node affinity toward this node pool, so they are steered there when available. See [AWS EKS cluster resources](/configuration/integrations/kubernetes/eks/managed#resources) for details on enabling and configuring this nodepool.
 </Info>
 
 <Warning>
-After enabling or disabling the cronjob node pool, **we strongly recommend redeploying all your cron jobs** to ensure they pick up the updated scheduling configuration. While a fallback mechanism ensures that pods will not get stuck in `Pending` state if the nodepool is removed, redeploying guarantees that your cronjobs are running with the correct and expected node targeting.
+After enabling or disabling the cronjob node pool, **we strongly recommend redeploying all your cron jobs** to ensure they pick up the updated scheduling configuration. If the nodepool is removed before jobs are redeployed, existing cron jobs can fall back to the default nodepool instead of staying in `Pending`, but redeploying ensures they run with the latest intended scheduling behavior.
 </Warning>
 
 ## Deployment Sources

--- a/docs/configuration/cronjob.mdx
+++ b/docs/configuration/cronjob.mdx
@@ -15,6 +15,16 @@ Cron Jobs in Qovery are Kubernetes workloads that run on a regular schedule. The
 - Perform database backups
 - Run maintenance scripts
 
+## Dedicated Cronjob Node Pool
+
+<Info>
+On AWS EKS clusters with Karpenter, you can enable a dedicated **cronjob node pool**. When enabled, a Karpenter NodePool named `cronjob` is created with a `nodepool/cronjob: NoSchedule` taint. Cronjob pods automatically receive the appropriate tolerations and node affinity to schedule on this nodepool, isolating them from other services running on shared nodes. See [AWS EKS cluster resources](/configuration/integrations/kubernetes/eks/managed#resources) for details on enabling and configuring this nodepool.
+</Info>
+
+<Warning>
+After enabling or disabling the cronjob node pool, **we strongly recommend redeploying all your cron jobs** to ensure they pick up the updated scheduling configuration. While a fallback mechanism ensures that pods will not get stuck in `Pending` state if the nodepool is removed, redeploying guarantees that your cronjobs are running with the correct and expected node targeting.
+</Warning>
+
 ## Deployment Sources
 
 Qovery supports two deployment sources for Cron Jobs:

--- a/docs/configuration/integrations/kubernetes/eks/managed.mdx
+++ b/docs/configuration/integrations/kubernetes/eks/managed.mdx
@@ -166,7 +166,7 @@ You can read our [blog post](https://www.qovery.com/blog/save-up-to-60-on-aws-co
   </Step>
 
   <Step title="Update Daemonsets">
-    If you have deployed some daemonsets, you must update their definitions to enable them to run on every node of the future nodepools (stable & default). Everything is explained in [our guide](/getting-started/guides/advanced-tutorials/deploy-daemonset-karpenter)
+    If you have deployed some daemonsets, you must update their definitions to enable them to run on every node of the future nodepools (stable, default, and cronjob if enabled). Everything is explained in [our guide](/getting-started/guides/advanced-tutorials/deploy-daemonset-karpenter)
   </Step>
 </Steps>
 
@@ -252,14 +252,17 @@ Qovery deploys two node pools by default:
 - **Stable node pool**: Used for single instances and internal Qovery applications. For example, any containerized databases or application having the number of minimum instances set to 1, will be deployed on this nodepool. On this nodepool the consolidation is deactivated by default.
 - **Default node pool**: Designed to handle general workloads and serves as the foundation for deploying most applications.
 
-An additional GPU node pool can be present if you have enabled the GPU node pool configuration when creating your cluster (can be enabled afterwards).
+Additional optional node pools can be enabled:
+
+- **GPU node pool**: Can be enabled if you want to run GPU workloads on your cluster. You can select the GPU instance types you want to use on this nodepool.
+- **Cronjob node pool**: A dedicated node pool for cronjob workloads. When enabled, a Karpenter NodePool named `cronjob` is created with a `nodepool/cronjob: NoSchedule` taint. Cronjob pods automatically receive the appropriate tolerations and node affinity to schedule on this nodepool. This isolates cronjob workloads from other services, preventing them from impacting shared nodes. The cronjob nodepool supports consolidation scheduling and resource limits (same as the stable nodepool). After enabling or disabling this nodepool, **we strongly recommend redeploying all your cron jobs** to ensure they run with the correct node targeting. A fallback mechanism prevents pods from getting stuck if the nodepool is removed, but redeploying ensures optimal scheduling.
 
 #### Settings for nodepools:
 
 - **Instance types**: Define the list of instance types that can be used. (Shared for Stable and Default nodepools)
 - **Spot instances**: Enable or disable spot instances. (Shared across the three nodepools)
 - **Node disk size (GB)**: Specify the disk capacity allocated per worker node, determining the amount of data each node can store. (Shared for Stable and Default nodepools)
-- **Consolidation schedule** _(Stable nodepool only)_: Optimizes resource usage by consolidating workloads onto fewer nodes. This feature is not available for the default nodepool, as consolidation can happen at any time. We recommend enabling this option; otherwise, nodes will never be consolidated, leading to unnecessary infrastructure costs.
+- **Consolidation schedule** _(Stable and Cronjob nodepools only)_: Optimizes resource usage by consolidating workloads onto fewer nodes. This feature is not available for the default nodepool, as consolidation can happen at any time. We recommend enabling this option; otherwise, nodes will never be consolidated, leading to unnecessary infrastructure costs.
 - **Node pool limits**: Configure CPU and memory limits to ensure nodes stay within defined resource constraints, preventing excessive costs.
 
 <Warning>
@@ -315,7 +318,7 @@ For example, to assign a service to the t3a.xlarge instance type, manually set t
 
 ### Change the node pool of your service when using Helm
 
-When using Helm, you can update the `affinity` field in your `values.yaml` file to target a specific node pool for your service. For example you can switch from the `default` to `stable` nodepool:
+When using Helm, you can update the `affinity` field in your `values.yaml` file to target a specific node pool for your service. For example you can switch from the `default` to `stable` or `cronjob` nodepool:
 
 ```yaml
 affinity:

--- a/docs/configuration/integrations/kubernetes/eks/managed.mdx
+++ b/docs/configuration/integrations/kubernetes/eks/managed.mdx
@@ -255,7 +255,7 @@ Qovery deploys two node pools by default:
 Additional optional node pools can be enabled:
 
 - **GPU node pool**: Can be enabled if you want to run GPU workloads on your cluster. You can select the GPU instance types you want to use on this nodepool.
-- **Cronjob node pool**: A dedicated node pool for cronjob workloads. When enabled, a Karpenter NodePool named `cronjob` is created with a `nodepool/cronjob: NoSchedule` taint. Cronjob pods automatically receive the appropriate tolerations and node affinity to schedule on this nodepool. This isolates cronjob workloads from other services, preventing them from impacting shared nodes. The cronjob nodepool supports consolidation scheduling and resource limits (same as the stable nodepool). After enabling or disabling this nodepool, **we strongly recommend redeploying all your cron jobs** to ensure they run with the correct node targeting. A fallback mechanism prevents pods from getting stuck if the nodepool is removed, but redeploying ensures optimal scheduling.
+- **Cronjob node pool**: A dedicated node pool for Qovery cron jobs. When enabled, a Karpenter NodePool named `cronjob` is created with a `nodepool/cronjob: NoSchedule` taint. Qovery cron jobs automatically receive the appropriate toleration and a preferred node affinity toward this nodepool, so they are steered there when available. This helps isolate cronjob workloads from long-running services on shared nodes. The cronjob nodepool supports consolidation scheduling and resource limits (same as the stable nodepool). After enabling or disabling this nodepool, **we strongly recommend redeploying all your cron jobs** to ensure they run with the latest intended scheduling configuration. If the nodepool is removed before redeploy, existing jobs can fall back to the default nodepool instead of staying in `Pending`.
 
 #### Settings for nodepools:
 
@@ -318,7 +318,7 @@ For example, to assign a service to the t3a.xlarge instance type, manually set t
 
 ### Change the node pool of your service when using Helm
 
-When using Helm, you can update the `affinity` field in your `values.yaml` file to target a specific node pool for your service. For example you can switch from the `default` to `stable` or `cronjob` nodepool:
+When using Helm, you can update the `affinity` field in your `values.yaml` file to target a specific node pool for your service. For example you can switch from the `default` to the `stable` nodepool:
 
 ```yaml
 affinity:

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -161,6 +161,15 @@ This value must be **greater than** the time your `deployment.lifecycle.pre_stop
     }
     ```
   </Tab>
+  <Tab title="AWS — Dedicated Cronjob Pool">
+    Schedule pods onto the dedicated `cronjob` Karpenter NodePool (must be enabled on the cluster):
+
+    ```json
+    {
+      "karpenter.sh/nodepool": "cronjob"
+    }
+    ```
+  </Tab>
   <Tab title="GCP Autopilot — ARM64 Performance">
     Run on ARM64 nodes with the GCP Autopilot `Performance` compute class:
 

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -161,15 +161,6 @@ This value must be **greater than** the time your `deployment.lifecycle.pre_stop
     }
     ```
   </Tab>
-  <Tab title="AWS — Dedicated Cronjob Pool">
-    Schedule pods onto the dedicated `cronjob` Karpenter NodePool (must be enabled on the cluster):
-
-    ```json
-    {
-      "karpenter.sh/nodepool": "cronjob"
-    }
-    ```
-  </Tab>
   <Tab title="GCP Autopilot — ARM64 Performance">
     Run on ARM64 nodes with the GCP Autopilot `Performance` compute class:
 

--- a/docs/getting-started/guides/advanced-tutorials/deploy-daemonset-karpenter.mdx
+++ b/docs/getting-started/guides/advanced-tutorials/deploy-daemonset-karpenter.mdx
@@ -39,6 +39,8 @@ When you deploy Qovery, a PriorityClass named `qovery-standard-priority` is crea
 
 When you deploy Qovery, two nodepools are deployed by default: `default` and `stable`. The `stable` nodepool includes a taint with the key `nodepool/stable` on it. This taint restricts pod scheduling to only those pods that have the corresponding toleration.
 
+If the optional cronjob nodepool is enabled on your cluster, a third nodepool named `cronjob` is created with a taint `nodepool/cronjob: NoSchedule`. Your DaemonSet must also tolerate this taint to be scheduled on cronjob nodes.
+
 ### How to target every node
 
 To target all nodes and properly deploy your DaemonSet or Helm chart, add the following tolerations and affinity to your pods:


### PR DESCRIPTION
## Summary
- Add Dedicated Cronjob Node Pool section to cronjob.mdx
- Update EKS managed cluster docs with cronjob nodepool details in Resources section
- Add cronjob nodepool affinity example tab in service advanced settings
- Document nodepool/cronjob taint in DaemonSet Karpenter guide

## Test plan
- [ ] Verify all internal links resolve correctly
- [ ] Preview docs locally with Mintlify
- [ ] Check consistency of terminology across all changed pages