### PR TITLE
feat: Add AI Agent Skill documentation to Getting Started

### DIFF
--- a/docs/copilot/mcp-server.mdx
+++ b/docs/copilot/mcp-server.mdx
@@ -11,6 +11,10 @@ The Qovery MCP Server lets you interact with your Qovery infrastructure from any
 **What is MCP?** The Model Context Protocol is an open standard developed by Anthropic that allows AI assistants to interact with external tools and systems. [Learn more →](https://modelcontextprotocol.io)
 </Info>
 
+<Tip>
+**Want to deploy a new application from source code?** The MCP Server is for managing *existing* infrastructure. To deploy a new application from your codebase using an AI agent, install the [Qovery Agent Skill](/getting-started/quickstart/ai-agent) instead — it works with Claude Code, Cursor, OpenCode, and 30+ AI coding tools. The skill and MCP Server complement each other: use the skill to deploy, then the MCP Server to manage.
+</Tip>
+
 ## Prerequisites
 
 - **MCP-Compatible Client**: Any MCP-compatible application

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -65,6 +65,7 @@
                 "pages": [
                   "getting-started/quickstart/docker-desktop",
                   "getting-started/quickstart/cloud",
+                  "getting-started/quickstart/ai-agent",
                   {
                     "group": "Managed Cluster",
                     "pages": [

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -86,6 +86,11 @@ From provisioning infrastructure to deploying applications, monitoring performan
 
     Scheduled tasks, background workers, database migrations, seeding, pre/post-deployment hooks
   </Card>
+  <Card title="AI Agent Deployment" icon="wand-magic-sparkles" href="/getting-started/quickstart/ai-agent">
+    **Deploy with Claude Code, Cursor, OpenCode**
+
+    Install the Qovery skill, ask your AI agent to deploy. It analyzes your code, creates Dockerfiles, provisions databases, and deploys automatically
+  </Card>
 </CardGroup>
 
 ### Observe - Monitoring & Logging

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -88,6 +88,26 @@ Select the scenario that best matches your needs:
 
     → **Bring Your Own Cluster (BYOK)**
   </Card>
+
+  <Card title="Deploy with AI Agent" icon="wand-magic-sparkles" href="/getting-started/quickstart/ai-agent">
+    **Use Claude Code, Cursor, OpenCode, or any AI coding agent**
+
+    Perfect for:
+    - **Developers** who prefer working in their terminal or IDE
+    - **AI-first workflows** — describe what you want, the agent does the rest
+    - **Quick prototyping** — from source code to deployed in minutes
+    - **Zero Kubernetes knowledge** required
+
+    What the agent does for you:
+    - Analyzes your codebase and creates Dockerfiles if missing
+    - Provisions databases (container for dev, managed for production)
+    - Sets up environment variables, health checks, and deployment stages
+    - Deploys via CLI + API or Terraform and watches for failures
+
+    **Time:** ~10 minutes | **Tools:** Claude Code, Cursor, OpenCode, VS Code Copilot, Gemini CLI, 30+ more
+
+    → **Install the Qovery Skill**
+  </Card>
 </CardGroup>
 
 ---

--- a/docs/getting-started/quickstart/ai-agent.mdx
+++ b/docs/getting-started/quickstart/ai-agent.mdx
@@ -1,0 +1,170 @@
+---
+title: "Deploy with AI Agent"
+description: "Use Claude Code, Cursor, OpenCode, or any AI coding agent to deploy your application on Qovery with a single prompt."
+---
+
+Install the Qovery Agent Skill and let your AI coding agent deploy your application end-to-end — from analyzing your codebase to a running deployment on Kubernetes. No Kubernetes knowledge required.
+
+<Info>
+**Skill vs MCP Server — what's the difference?**
+
+- **Qovery Agent Skill** (this page) = **Forward engineering.** Takes your source code and deploys it on Qovery. The AI agent analyzes your project, creates Dockerfiles, provisions databases, sets up environment variables, and deploys everything.
+- **[Qovery MCP Server](/copilot/mcp-server)** = **Operations.** Manages existing infrastructure. Query environments, troubleshoot deployments, monitor services.
+
+Both can be used together: use the skill to deploy, then the MCP Server to manage.
+</Info>
+
+---
+
+## Install the Skill
+
+One command installs the skill globally for all your projects:
+
+<Steps>
+  <Step title="Run the installer">
+    ```bash
+    curl -fsSL https://skill.qovery.com/install.sh | bash
+    ```
+
+    This installs the skill to all compatible tool directories automatically. No manual configuration needed.
+  </Step>
+
+  <Step title="Open your AI coding tool">
+    Launch Claude Code, Cursor, OpenCode, VS Code Copilot, Gemini CLI, or any compatible tool.
+  </Step>
+
+  <Step title="Ask the agent to deploy">
+    ```
+    Deploy my application with Qovery
+    ```
+
+    The agent loads the skill automatically and guides you through the entire process.
+  </Step>
+</Steps>
+
+<Tip>
+To install for the current project only (instead of globally), run:
+```bash
+curl -fsSL https://skill.qovery.com/install.sh | bash -s -- --project
+```
+To update to the latest version, re-run the install command.
+</Tip>
+
+---
+
+## Compatible Tools
+
+The Qovery Agent Skill follows the [Agent Skills](https://agentskills.io) open standard and works with 30+ AI coding tools. The installer places the skill in all discovery paths automatically.
+
+| Tool | Supported |
+|------|-----------|
+| **Claude Code** | Yes |
+| **Cursor** | Yes |
+| **OpenCode** | Yes |
+| **VS Code Copilot** | Yes |
+| **Gemini CLI** | Yes |
+| Roo Code | Yes |
+| Goose | Yes |
+| Amp | Yes |
+| Kiro | Yes |
+| Junie (JetBrains) | Yes |
+| OpenHands | Yes |
+| OpenAI Codex | Yes |
+| Mistral Vibe | Yes |
+| TRAE | Yes |
+
+And any other tool that discovers skills from `.claude/skills/` or `.agents/skills/` directories.
+
+---
+
+## What the Skill Does
+
+When you tell your AI agent to deploy, the skill guides it through a complete deployment workflow:
+
+1. **Analyzes your codebase** — detects language, framework, ports, database needs, environment variables
+2. **Creates a Dockerfile** if one is missing — production-ready multi-stage templates for Node.js, Next.js, React, Vite, Python, Go, Java, Ruby, PHP, .NET
+3. **Asks the right questions** — dev vs production, database type, deployment method
+4. **Sets up infrastructure** — cluster creation from scratch if needed (AWS, GCP, Azure, Scaleway)
+5. **Deploys via CLI + API** (quick path) or **Terraform provider** (recommended for production)
+6. **Provisions databases** — container mode for dev/test, managed mode (e.g. AWS RDS) for production, or Terraform services for RDS Aurora
+7. **Sets up environment variables** using aliases, interpolation, and overrides — no duplication
+8. **Handles Helm charts, Terraform modules, lifecycle jobs, and cron jobs**
+9. **Watches deployments and auto-fixes failures** — diagnoses build errors, port mismatches, health check failures, missing env vars, and OOM issues. Fixes Qovery configuration automatically; asks for permission before modifying your code
+
+---
+
+## What You Need
+
+<Check>**Qovery account** — [Sign up at console.qovery.com](https://console.qovery.com) (free to start)</Check>
+<Check>**Git repository** connected to Qovery (GitHub, GitLab, or Bitbucket)</Check>
+
+That's it. The skill handles everything else:
+- **No API token needed upfront** — the skill generates one via the Qovery CLI
+- **No cluster needed upfront** — the skill guides you through cluster creation if you don't have one
+- **No Dockerfile needed** — the skill creates one if missing
+- **No Kubernetes knowledge needed** — the skill configures health checks, ports, deployment stages, and resource limits
+
+---
+
+## How It Compares
+
+| | Console (Manual) | AI Agent Skill | MCP Server |
+|---|---|---|---|
+| **Purpose** | Full control via web UI | Fastest path from code to deployed | Manage existing infrastructure |
+| **Creates Dockerfiles** | No | Yes, for 12+ frameworks | No |
+| **Provisions databases** | Manual configuration | Automatic (asks dev vs prod) | No |
+| **Sets up env vars** | Manual per variable | Automatic with aliases and overrides | No |
+| **Deployment method** | Console UI | CLI + API or Terraform | N/A |
+| **Monitors & fixes failures** | Manual log inspection | Automatic diagnosis and auto-fix | Query-based |
+| **Best for** | Experienced users, fine-tuning | Developers deploying from code | Day-2 operations |
+
+---
+
+## Supported Frameworks
+
+The skill includes production-ready Dockerfile templates for:
+
+| Language | Frameworks |
+|----------|-----------|
+| **Node.js** | Express, Fastify, NestJS |
+| **Next.js** | SSR with standalone output |
+| **React / Vite** | SPA served via nginx |
+| **Python** | Flask, Django, FastAPI |
+| **Go** | Any (net/http, Gin, Echo, Fiber, etc.) |
+| **Java** | Spring Boot (Maven and Gradle) |
+| **Ruby** | Rails |
+| **PHP** | Laravel |
+| **.NET** | ASP.NET Core |
+
+If your framework is not listed, the agent creates a custom Dockerfile based on your project structure.
+
+---
+
+## Example Prompts
+
+Once the skill is installed, try any of these prompts with your AI coding agent:
+
+- *"Deploy my application with Qovery"*
+- *"Set up Qovery for my project"*
+- *"Deploy this to Kubernetes with Qovery"*
+- *"Create a Qovery Terraform configuration for my app"*
+- *"I need a production deployment with a PostgreSQL database"*
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Qovery MCP Server" icon="robot" href="/copilot/mcp-server">
+    Manage deployed infrastructure from your AI agent
+  </Card>
+  <Card title="Terraform Provider" icon="code" href="/terraform-provider/overview">
+    Version-controlled infrastructure as code
+  </Card>
+  <Card title="CLI Reference" icon="terminal" href="/cli/overview">
+    Monitor, debug, and manage from the terminal
+  </Card>
+  <Card title="Skill Source Code" icon="github" href="https://github.com/Qovery/qovery-skills">
+    View, contribute, or fork on GitHub
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Adds a dedicated **"Deploy with AI Agent"** page to the Getting Started section, documenting how to use the [Qovery Agent Skill](https://github.com/Qovery/qovery-skills) with Claude Code, Cursor, OpenCode, VS Code Copilot, Gemini CLI, and 30+ compatible AI coding tools
- Positions AI agent deployment as a first-class entry path alongside Docker Desktop, Cloud, and BYOK
- Cross-references with the existing MCP Server documentation to clarify the distinction: Skill = forward engineering (code → deployed), MCP = operations (manage existing infra)

## Changes

| File | Change |
|---|---|
| `docs/getting-started/quickstart/ai-agent.mdx` | **New page** — Install instructions, compatible tools, what the skill does, comparison table, supported frameworks, example prompts |
| `docs/getting-started/quickstart.mdx` | Add "Deploy with AI Agent" card to the use case selector |
| `docs/getting-started/introduction.mdx` | Add "AI Agent Deployment" card in the Deploy section |
| `docs/copilot/mcp-server.mdx` | Add Tip callout clarifying Skill vs MCP Server |
| `docs/docs.json` | Add `getting-started/quickstart/ai-agent` nav entry under Installation |

## Context

The Qovery Agent Skill (`https://github.com/Qovery/qovery-skills`) follows the [Agent Skills](https://agentskills.io) open standard. It enables any compatible AI coding agent to deploy applications on Qovery end-to-end — from analyzing the codebase and creating Dockerfiles to provisioning databases, setting up environment variables, deploying via CLI+API or Terraform, and watching/auto-fixing deployment failures.

Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`