### PR TITLE
docs: add CLI binary checksum verification instructions

### DIFF
--- a/docs/snippets/install-qovery-cli.mdx
+++ b/docs/snippets/install-qovery-cli.mdx
@@ -7,6 +7,10 @@
         ```bash
         curl -s https://get.qovery.com | bash
         ```
+
+        <Warning>
+        The install script does not verify the binary's integrity. For security-sensitive environments, use the **Manual** tab to download a pinned release and verify its checksum against the official [checksums.txt](https://github.com/Qovery/qovery-cli/releases) published with each release.
+        </Warning>
       </Tab>
 
       <Tab title="Arch Linux">
@@ -18,7 +22,25 @@
       </Tab>
 
       <Tab title="Manual">
-        Install the Qovery CLI on Linux manually by downloading the [latest release](https://github.com/Qovery/qovery-cli/releases), and uncompress its content to a folder into your shell `PATH`.
+        Install the Qovery CLI on Linux manually from a [pinned release](https://github.com/Qovery/qovery-cli/releases) to ensure you control what version is installed.
+
+        Replace `X.Y.Z` with the version you want to install:
+
+        ```bash
+        # Download the binary and checksums for your platform
+        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/qovery_Linux_x86_64.tar.gz -o qovery.tar.gz
+        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/checksums.txt -o checksums.txt
+
+        # Verify the checksum (fails if the binary has been tampered with)
+        sha256sum --check --ignore-missing checksums.txt
+
+        # Extract and install
+        tar -xzf qovery.tar.gz
+        mv qovery /usr/local/bin/qovery
+        chmod +x /usr/local/bin/qovery
+        ```
+
+        For ARM64 (Apple Silicon-based Linux), replace `x86_64` with `arm64`.
       </Tab>
     </Tabs>
   </Tab>
@@ -43,10 +65,32 @@
         ```bash
         curl -s https://get.qovery.com | bash
         ```
+
+        <Warning>
+        The install script does not verify the binary's integrity. For security-sensitive environments, use the **Manual** tab to download a pinned release and verify its checksum against the official [checksums.txt](https://github.com/Qovery/qovery-cli/releases) published with each release.
+        </Warning>
       </Tab>
 
       <Tab title="Manual">
-        Install the Qovery CLI on Mac OS manually by downloading the [latest release](https://github.com/Qovery/qovery-cli/releases), and uncompress its content to a folder into your shell `PATH`.
+        Install the Qovery CLI on macOS manually from a [pinned release](https://github.com/Qovery/qovery-cli/releases) to ensure you control what version is installed.
+
+        Replace `X.Y.Z` with the version you want to install:
+
+        ```bash
+        # Download the binary and checksums for your platform
+        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/qovery_Darwin_x86_64.tar.gz -o qovery.tar.gz
+        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/checksums.txt -o checksums.txt
+
+        # Verify the checksum (fails if the binary has been tampered with)
+        shasum -a 256 --check checksums.txt
+
+        # Extract and install
+        tar -xzf qovery.tar.gz
+        mv qovery /usr/local/bin/qovery
+        chmod +x /usr/local/bin/qovery
+        ```
+
+        For Apple Silicon (M1/M2/M3), replace `Darwin_x86_64` with `Darwin_arm64`.
       </Tab>
     </Tabs>
   </Tab>

--- a/docs/snippets/install-qovery-cli.mdx
+++ b/docs/snippets/install-qovery-cli.mdx
@@ -27,8 +27,8 @@
         Replace `X.Y.Z` with the version you want to install:
 
         ```bash
-        VERSION=X.Y.Z
-        ARCH=amd64  # use arm64 for ARM64
+        VERSION=1.48.0  # version number without the 'v' prefix
+        ARCH=amd64      # use arm64 for ARM64
         ARCHIVE="qovery-cli_${VERSION}_linux_${ARCH}.tar.gz"
 
         # Download the binary and checksums for your platform
@@ -79,8 +79,8 @@
         Replace `X.Y.Z` with the version you want to install:
 
         ```bash
-        VERSION=X.Y.Z
-        ARCH=amd64  # use arm64 for Apple Silicon (M1/M2/M3)
+        VERSION=1.48.0  # version number without the 'v' prefix
+        ARCH=amd64      # use arm64 for Apple Silicon (M1/M2/M3)
         ARCHIVE="qovery-cli_${VERSION}_darwin_${ARCH}.tar.gz"
 
         # Download the binary and checksums for your platform

--- a/docs/snippets/install-qovery-cli.mdx
+++ b/docs/snippets/install-qovery-cli.mdx
@@ -29,16 +29,17 @@
         ```bash
         VERSION=X.Y.Z
         ARCH=amd64  # use arm64 for ARM64
+        ARCHIVE="qovery-cli_${VERSION}_linux_${ARCH}.tar.gz"
 
         # Download the binary and checksums for your platform
-        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/qovery-cli_${VERSION}_linux_${ARCH}.tar.gz" -o qovery.tar.gz
+        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/${ARCHIVE}" -o "${ARCHIVE}"
         curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
 
         # Verify the checksum of the downloaded file only (fails if tampered)
-        grep "qovery-cli_${VERSION}_linux_${ARCH}.tar.gz" checksums.txt | sha256sum --check
+        grep "${ARCHIVE}" checksums.txt | sha256sum --check
 
         # Extract and install
-        tar -xzf qovery.tar.gz
+        tar -xzf "${ARCHIVE}"
         mv qovery /usr/local/bin/qovery
         chmod +x /usr/local/bin/qovery
         ```
@@ -80,16 +81,17 @@
         ```bash
         VERSION=X.Y.Z
         ARCH=amd64  # use arm64 for Apple Silicon (M1/M2/M3)
+        ARCHIVE="qovery-cli_${VERSION}_darwin_${ARCH}.tar.gz"
 
         # Download the binary and checksums for your platform
-        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/qovery-cli_${VERSION}_darwin_${ARCH}.tar.gz" -o qovery.tar.gz
+        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/${ARCHIVE}" -o "${ARCHIVE}"
         curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
 
         # Verify the checksum of the downloaded file only (fails if tampered)
-        grep "qovery-cli_${VERSION}_darwin_${ARCH}.tar.gz" checksums.txt | shasum -a 256 --check
+        grep "${ARCHIVE}" checksums.txt | shasum -a 256 --check
 
         # Extract and install
-        tar -xzf qovery.tar.gz
+        tar -xzf "${ARCHIVE}"
         mv qovery /usr/local/bin/qovery
         chmod +x /usr/local/bin/qovery
         ```

--- a/docs/snippets/install-qovery-cli.mdx
+++ b/docs/snippets/install-qovery-cli.mdx
@@ -27,20 +27,21 @@
         Replace `X.Y.Z` with the version you want to install:
 
         ```bash
-        # Download the binary and checksums for your platform
-        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/qovery_Linux_x86_64.tar.gz -o qovery.tar.gz
-        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/checksums.txt -o checksums.txt
+        VERSION=X.Y.Z
+        ARCH=amd64  # use arm64 for ARM64
 
-        # Verify the checksum (fails if the binary has been tampered with)
-        sha256sum --check --ignore-missing checksums.txt
+        # Download the binary and checksums for your platform
+        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/qovery-cli_${VERSION}_linux_${ARCH}.tar.gz" -o qovery.tar.gz
+        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
+
+        # Verify the checksum of the downloaded file only (fails if tampered)
+        grep "qovery-cli_${VERSION}_linux_${ARCH}.tar.gz" checksums.txt | sha256sum --check
 
         # Extract and install
         tar -xzf qovery.tar.gz
         mv qovery /usr/local/bin/qovery
         chmod +x /usr/local/bin/qovery
         ```
-
-        For ARM64 (Apple Silicon-based Linux), replace `x86_64` with `arm64`.
       </Tab>
     </Tabs>
   </Tab>
@@ -77,20 +78,21 @@
         Replace `X.Y.Z` with the version you want to install:
 
         ```bash
-        # Download the binary and checksums for your platform
-        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/qovery_Darwin_x86_64.tar.gz -o qovery.tar.gz
-        curl -sL https://github.com/Qovery/qovery-cli/releases/download/vX.Y.Z/checksums.txt -o checksums.txt
+        VERSION=X.Y.Z
+        ARCH=amd64  # use arm64 for Apple Silicon (M1/M2/M3)
 
-        # Verify the checksum (fails if the binary has been tampered with)
-        shasum -a 256 --check checksums.txt
+        # Download the binary and checksums for your platform
+        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/qovery-cli_${VERSION}_darwin_${ARCH}.tar.gz" -o qovery.tar.gz
+        curl -sL "https://github.com/Qovery/qovery-cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
+
+        # Verify the checksum of the downloaded file only (fails if tampered)
+        grep "qovery-cli_${VERSION}_darwin_${ARCH}.tar.gz" checksums.txt | shasum -a 256 --check
 
         # Extract and install
         tar -xzf qovery.tar.gz
         mv qovery /usr/local/bin/qovery
         chmod +x /usr/local/bin/qovery
         ```
-
-        For Apple Silicon (M1/M2/M3), replace `Darwin_x86_64` with `Darwin_arm64`.
       </Tab>
     </Tabs>
   </Tab>


### PR DESCRIPTION
## Summary

- Adds a `<Warning>` callout on the Linux and macOS `curl | bash` install tabs pointing users to the Manual tab for integrity verification
- Expands the Linux and macOS `Manual` tabs with a full checksum verification workflow using the `checksums.txt` already published by GoReleaser on every GitHub release
- No changes to Windows, Homebrew, Scoop, or Docker tabs

## Context

Customer feedback ([internal thread](https://qovery.atlassian.net/)) flagged that the `curl -s https://get.qovery.com | bash` install method provides no way to verify binary integrity. GoReleaser already generates and publishes `checksums.txt` with every release — this PR simply documents it.

## Test plan

- [ ] Verify the MDX renders correctly on the Mintlify preview (Tabs/Warning components)
- [ ] Confirm the checksum download URLs follow the correct GitHub releases pattern (`/releases/download/vX.Y.Z/checksums.txt`)
- [ ] Check that the `sha256sum` and `shasum` commands shown are correct for Linux and macOS respectively