### PR TITLE
feat(QOV-1581): add QOVERY_KUBERNETES_CLUSTER_DOMAIN built-in env var

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -126,6 +126,7 @@ QOVERY_APPLICATION_NAME=my-api
 # Infrastructure
 QOVERY_CLOUD_PROVIDER=AWS
 QOVERY_CLOUD_PROVIDER_REGION=us-east-1
+QOVERY_KUBERNETES_CLUSTER_DOMAIN=<domain>
 ```
 
 ### Database Connection Variables


### PR DESCRIPTION
## Summary

- Documents the new `QOVERY_KUBERNETES_CLUSTER_DOMAIN` environment-scoped built-in variable in the System Variables section
- Available for all cluster kinds; value is the cluster's managed DNS domain

## Test plan

- [ ] Verify the variable appears in the Infrastructure section of the Built-in Variables docs

Closes QOV-1581