### PR TITLE
docs: add RDE getting started guide and rewrite cloud migration guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -128,6 +128,12 @@
                   "getting-started/guides/use-cases/preview-environments",
                   "getting-started/guides/use-cases/e2e-testing"
                 ]
+              },
+              {
+                "group": "Remote Development Environments",
+                "pages": [
+                  "getting-started/guides/use-cases/remote-development-environments"
+                ]
               }
             ]
           },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -129,12 +129,7 @@
                   "getting-started/guides/use-cases/e2e-testing"
                 ]
               },
-              {
-                "group": "Remote Development Environments",
-                "pages": [
-                  "getting-started/guides/use-cases/remote-development-environments"
-                ]
-              }
+              "getting-started/guides/use-cases/remote-development-environments"
             ]
           },
           {

--- a/docs/getting-started/guides/use-cases/cloud-migration-and-scaling.mdx
+++ b/docs/getting-started/guides/use-cases/cloud-migration-and-scaling.mdx
@@ -1,245 +1,310 @@
 ---
-title: "Migrate Your Application from Heroku to AWS"
-description: "Learn how to migrate your applications from Heroku to AWS using Qovery"
+title: "Migrate to Kubernetes"
+description: "Migrate your applications from Heroku, Render, or any platform to Kubernetes on your cloud provider - fully automated by AI"
 ---
 
-This tutorial will guide you through all required steps you need to take to deploy your application on AWS and transfer your data from Heroku Postgres to the database managed by AWS via Qovery.
+## Overview
+
+Migrating to Kubernetes is traditionally the hardest part of modernizing your infrastructure. It means months of planning, rewriting deployment configs, learning Helm charts, and re-architecting your stack. Most teams get stuck halfway.
+
+Qovery removes that complexity entirely. With Qovery AI skills, you can migrate your applications from any platform - Heroku, Render, OpenShift, legacy VMs - to Kubernetes running on **your own cloud account** (AWS, GCP, Azure, or Scaleway). The AI agent analyzes your codebase, generates Dockerfiles, provisions databases, sets up environment variables, and deploys everything. No Kubernetes expertise required.
 
 <Info>
-This guide also works for migrating your application from Heroku to GCP, Azure, Scaleway.
+For complex migrations (microservices architectures, stateful workloads, compliance requirements), Qovery provides **cloud architect assistance**. [Book a demo](https://www.qovery.com/book-a-demo) to get a personalized migration plan.
 </Info>
 
-## What you will do
+## Why Migrate with Qovery?
 
-1. Create your Dockerfile(s)
-2. Create resources on Qovery (applications and databases)
-3. Configure your Environment Variables and Secrets
-4. Copy your data from Heroku databases to AWS
-5. Deploy your apps
+<CardGroup cols={3}>
+  <Card title="AI-Powered Migration" icon="wand-magic-sparkles">
+    The `/qovery-deploy` AI skill analyzes your codebase, creates Dockerfiles, provisions databases, and deploys - all from a single prompt
+  </Card>
 
-## 1. Create Your Dockerfile
+  <Card title="No Kubernetes Expertise" icon="graduation-cap">
+    Qovery abstracts the complexity of Kubernetes. You deploy applications - Qovery handles pods, ingress, TLS, RBAC, and networking
+  </Card>
 
-### Find a Dockerfile template
+  <Card title="Your Cloud, Your Control" icon="cloud">
+    Everything runs on your own AWS, GCP, Azure, or Scaleway account. No vendor lock-in, no shared infrastructure
+  </Card>
 
-We provide Dockerfile templates for Rails, NodeJS, React, VueJS, NextJS, Golang, Flask, Django, Laravel, Symfony, Spring, Rust, and many more.
+  <Card title="Cloud Architect Assistance" icon="headset">
+    Qovery's team helps with complex migrations. [Book a demo](https://www.qovery.com/book-a-demo) to get a personalized migration plan
+  </Card>
 
-### Example: Rails application
+  <Card title="Compliance Ready" icon="shield-check">
+    SOC2 Type II, ISO 27001, DORA, HIPAA, GDPR compliant infrastructure from day one
+  </Card>
 
-```dockerfile
-# syntax=docker/dockerfile:1
+  <Card title="Cost Savings" icon="dollar-sign">
+    Right-sized from the start. No over-provisioning, no surprise bills. Customers report $200K+ annual savings vs. DIY Kubernetes
+  </Card>
+</CardGroup>
 
-FROM ruby:2.7
+## Migrate from Any Platform
 
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+<CardGroup cols={3}>
+  <Card title="Heroku" icon="h">
+    Dynos, add-ons, Heroku Postgres, Redis - all mapped to Kubernetes equivalents automatically
+  </Card>
 
-WORKDIR /myapp
+  <Card title="Render" icon="server">
+    Web services, background workers, cron jobs, managed databases - migrated with full parity
+  </Card>
 
-COPY Gemfile Gemfile
+  <Card title="OpenShift" icon="redhat">
+    DeploymentConfigs, Routes, BuildConfigs - converted to standard Kubernetes resources
+  </Card>
 
-COPY Gemfile.lock Gemfile.lock
+  <Card title="VMs / Bare Metal" icon="hard-drive">
+    Legacy applications running on EC2, DigitalOcean droplets, or bare metal servers
+  </Card>
 
-RUN bundle install
+  <Card title="Docker Compose" icon="docker">
+    Multi-container setups defined in docker-compose.yml - each service becomes a Qovery application
+  </Card>
 
-COPY . .
+  <Card title="Other PaaS" icon="cloud-arrow-up">
+    Fly.io, Railway, DigitalOcean App Platform, Google App Engine, Azure App Service, and more
+  </Card>
+</CardGroup>
 
-EXPOSE 3000
+## How It Works
 
-CMD ["rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+```mermaid
+flowchart LR
+    SRC[Your Current Platform] -->|AI analyzes| AGENT[Qovery AI Agent]
+    AGENT -->|generates| DOCKER[Dockerfiles]
+    AGENT -->|provisions| DB[Databases]
+    AGENT -->|configures| ENV[Env Vars & Secrets]
+    AGENT -->|deploys to| K8S[Kubernetes on Your Cloud]
 ```
 
-### Example: Rails Sidekiq worker
+1. **Install** the Qovery AI skill (one command)
+2. **Ask** the AI agent to migrate your project
+3. **AI analyzes** your codebase - detects languages, frameworks, databases, dependencies
+4. **AI generates** optimized Dockerfiles if missing
+5. **AI provisions** databases (PostgreSQL, Redis, MongoDB, MySQL) and configures environment variables
+6. **AI deploys** everything to Kubernetes on your cloud provider
+7. **You verify** and go live
 
-```dockerfile
-# syntax=docker/dockerfile:1
+## Getting Started
 
-FROM ruby:2.7
+### Option 1: AI-Powered Migration (Recommended)
 
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+The fastest path. The AI agent handles the entire migration end-to-end.
 
-WORKDIR /myapp
+<Steps>
+  <Step title="Install the Qovery AI Skill">
+    One command installs the skill globally for all your projects:
 
-COPY Gemfile Gemfile
+    ```bash
+    curl -fsSL https://skill.qovery.com/install.sh | bash
+    ```
+  </Step>
 
-COPY Gemfile.lock Gemfile.lock
+  <Step title="Open Your AI Coding Tool">
+    Launch [OpenCode](https://opencode.ai), Claude Code, Cursor, VS Code Copilot, or any compatible AI coding tool.
+  </Step>
 
-RUN bundle install
+  <Step title="Ask the Agent to Migrate">
+    ```
+    Migrate my project from Heroku to Kubernetes with Qovery
+    ```
 
-COPY . .
+    Or use the skill command directly:
 
-CMD ["bundle", "exec", "sidekiq"]
-```
+    ```
+    /qovery-deploy
+    ```
 
-### Test your Dockerfile
+    The agent will guide you through the entire process:
 
-Build your Dockerfile:
+    - **Analyze** your codebase and detect languages, frameworks, and databases
+    - **Create** optimized multi-stage Dockerfiles if your project doesn't have one
+    - **Provision** databases (PostgreSQL, Redis, MongoDB, MySQL) - managed or containerized
+    - **Set up** environment variables and secrets
+    - **Deploy** everything to Kubernetes on your cloud provider
+    - **Watch** the deployment and auto-fix any issues (up to 3 retries per service)
 
-```bash
-docker build -f Dockerfile.qovery .
-```
+    <Tip>
+    The AI agent supports Node.js, Python, Go, Java, Ruby, PHP, .NET, React, Vite, Next.js, Rails, Django, Spring, Laravel, and many more frameworks.
+    </Tip>
+  </Step>
 
-Then run your image:
+  <Step title="Migrate Environment Variables">
+    The AI agent handles environment variable migration as part of the deployment process.
 
-```bash
-docker run a0f90a6ec8bc4036a7b268479a0c0773ca324ba2de11fdef31309650743f4055
-```
+    For **Heroku** specifically, you can also export and import manually using the Qovery CLI:
 
-<Info>
-Once you successfully build your application with Docker, your app will run anywhere (not only on AWS with Qovery).
-</Info>
+    ```bash
+    qovery auth
+    qovery context set
+    heroku config --app <your_heroku_app_name> --json | \
+      qovery env parse --heroku-json > heroku.env && \
+      qovery env import heroku.env && \
+      rm heroku.env
+    ```
 
-### Environment variables at build time
+    <Warning>
+    Import sensitive data (API keys, credentials, tokens) as **Secrets**, not Environment Variables.
+    </Warning>
+  </Step>
 
-If your application needs environment variables at build time, you can use the `ARG` instruction in your Dockerfile:
+  <Step title="Verify and Go Live">
+    Once the deployment is complete:
 
-```dockerfile
-...
-ARG CONTENT_API_KEY
-ENV CONTENT_API_KEY $CONTENT_API_KEY
-...
-```
+    1. Check your application status in the [Qovery Console](https://console.qovery.com)
+    2. Test your endpoints using the auto-generated Qovery URL
+    3. [Configure your custom domain](/configuration/application#domains) when ready
+    4. Update your DNS records to point to Qovery
+  </Step>
+</Steps>
 
-### Add your Dockerfile to your Git repository
+### Option 2: Manual Migration
 
-```bash
-git add Dockerfile.qovery
-git commit -m "Add Qovery Dockerfile"
-git push origin
-```
+For teams that prefer full control over every step.
 
-## 2. Create Resources on Qovery
+<Steps>
+  <Step title="Create Your Dockerfile">
+    If your project doesn't have a Dockerfile, create one. Qovery provides templates for all major frameworks.
 
-### Create your application
+    Example for a Node.js application:
 
-1. Connect to the [Qovery Console](https://console.qovery.com)
-2. Create your Organization and Project
-3. Create your production Environment
-4. Create your application with the name of your repository
-5. Select your GitHub/GitLab/Bitbucket repository
-6. Select the branch you want to deploy
-7. Specify the port your application is listening on
-8. Click on create
+    ```dockerfile
+    FROM node:20-alpine AS builder
+    WORKDIR /app
+    COPY package*.json ./
+    RUN npm ci
+    COPY . .
+    RUN npm run build
 
-<Info>
-Your application is created but not deployed yet! You can configure the vCPU, Memory, Environment Variables... before deploying.
-</Info>
+    FROM node:20-alpine
+    WORKDIR /app
+    COPY --from=builder /app/dist ./dist
+    COPY --from=builder /app/node_modules ./node_modules
+    EXPOSE 3000
+    CMD ["node", "dist/index.js"]
+    ```
 
-### Create your database
+    <Tip>
+    Use multi-stage builds to keep your images small and secure. The AI agent generates these automatically when you use Option 1.
+    </Tip>
+  </Step>
 
-1. Go to your production Environment
-2. Click on "Add" and then "Database"
-3. Select your database type and version (PostgreSQL, MySQL, MongoDB, Redis)
-4. Select Managed or Container mode
-5. Select Public accessibility (or Private if you don't need to restore data from Heroku)
+  <Step title="Create Resources on Qovery">
+    1. Sign in to the [Qovery Console](https://console.qovery.com)
+    2. Create your Organization and Project
+    3. Create your production Environment
+    4. Add your application (select your Git repository, branch, and port)
+    5. Add your database (PostgreSQL, MySQL, MongoDB, or Redis - managed or containerized)
+  </Step>
 
-## 3. Configure Environment Variables and Secrets
+  <Step title="Configure Environment Variables">
+    1. Export your environment variables from your current platform
+    2. Import them into Qovery via the Console or [CLI](/cli/commands/env)
+    3. Create environment variable aliases to connect your services (e.g., link your app to your database using `DATABASE_URL`)
+  </Step>
 
-### Export your environment variables from Heroku
+  <Step title="Deploy">
+    Click "Deploy" in the Qovery Console or use the CLI:
 
-Use the Heroku CLI to export your environment variables:
+    ```bash
+    qovery deploy
+    ```
+  </Step>
+</Steps>
 
-```bash
-heroku config
-```
+### Need Help? Talk to a Cloud Architect
 
-Example output:
+<CardGroup cols={1}>
+  <Card title="Book a Migration Demo" icon="calendar" href="https://www.qovery.com/book-a-demo">
+    For complex migrations - microservices, stateful workloads, compliance requirements, or large-scale infrastructure - Qovery provides personalized cloud architect assistance. Get a migration plan tailored to your stack.
+  </Card>
+</CardGroup>
 
-```
-GREETINGS: hello world
-STRIPE_API_KEY: xxx-yyy-zzz
-IS_PRODUCTION: true
-```
+## What Gets Migrated?
 
-### Import your environment variables with Qovery CLI
+| Source | Qovery Equivalent | Handled by AI? |
+|--------|-------------------|----------------|
+| Web applications (any language/framework) | [Applications](/configuration/application) - containerized on Kubernetes | Yes |
+| Background workers (Sidekiq, Celery, etc.) | [Applications](/configuration/application) - separate services | Yes |
+| Cron jobs | [Cron Jobs](/configuration/cronjob) | Yes |
+| PostgreSQL, MySQL | [Managed Database](/configuration/database) (AWS RDS, GCP Cloud SQL, etc.) | Yes |
+| Redis, MongoDB | [Container Database](/configuration/database) or Managed | Yes |
+| Environment variables | [Environment Variables & Secrets](/configuration/environment-variable) | Yes |
+| Custom domains | [Custom Domains](/configuration/application#domains) | Manual DNS update required |
+| Add-ons (Memcached, Elasticsearch, etc.) | [Helm Charts](/configuration/helm) or container services | Partially |
+| Scheduled tasks | [Lifecycle Jobs](/configuration/lifecycle-job) | Yes |
 
-```bash
-qovery auth
-qovery context set
-heroku config --app <your_heroku_app_name> --json | \
-  qovery env parse --heroku-json > heroku.env && \
-  qovery env import heroku.env && \
-  rm heroku.env
-```
-
-<Warning>
-Import sensitive data (e.g., API keys, credentials...) as `Secret` and not `Environment Variable`.
-</Warning>
-
-### Connect your frontend to your backend
-
-Create environment variable aliases to connect your applications.
-
-### Connect your backend to your database
-
-Create environment variable alias on `_DATABASE_URL_INTERNAL` (not `_DATABASE_URL`).
-
-## 4. Copy Data from Heroku Databases to AWS
-
-Data migration support through Replibyte is coming soon.
-
-## 5. Deploy Your Apps
-
-After completing the configuration, you're ready to deploy through the Qovery console.
-
-## FAQ by Heroku Users
+## FAQ
 
 <AccordionGroup>
+  <Accordion title="How long does migration take?">
+    For most applications, less than a day. The AI agent handles Dockerfile creation, database provisioning, environment variable setup, and deployment in minutes. Complex multi-service architectures may take longer - [book a demo](https://www.qovery.com/book-a-demo) for a personalized timeline.
+  </Accordion>
+
+  <Accordion title="Do I need Kubernetes expertise?">
+    No. Qovery abstracts all Kubernetes complexity. You interact with applications, databases, and environment variables - not pods, deployments, or ingress controllers. The AI agent handles the Kubernetes-specific configuration automatically.
+  </Accordion>
+
+  <Accordion title="Which cloud providers are supported?">
+    AWS (EKS), Google Cloud (GKE), Azure (AKS), and Scaleway (Kapsule). You can also bring your own Kubernetes cluster (BYOK).
+  </Accordion>
+
+  <Accordion title="What about data migration?">
+    Database schema and application code are migrated automatically. For data transfer (copying production data), you'll need to handle the database dump/restore process. Qovery databases support standard import tools (pg_restore, mysql import, mongorestore).
+  </Accordion>
+
   <Accordion title="How to create a custom domain?">
     Check the [custom domain configuration documentation](/configuration/application#domains) for setup instructions.
   </Accordion>
 
   <Accordion title="How to monitor my apps?">
-    Qovery recommends using Datadog or comparable monitoring tools. See our [monitoring guide](/guides/qovery-101/observe).
+    Qovery provides built-in [observability](/getting-started/guides/qovery-101/observe) including logs, metrics, and alerts. You can also integrate with Datadog, New Relic, or other monitoring tools.
   </Accordion>
 
-  <Accordion title="Do you have Heroku 'Review App' equivalent?">
-    Yes, Qovery provides [Preview Environment](/configuration/environment#preview-environments) functionality.
+  <Accordion title="Do you have preview environments?">
+    Yes. Qovery provides [Preview Environments](/getting-started/guides/use-cases/preview-environments) that automatically create a clone of your environment on every pull request.
   </Accordion>
 
   <Accordion title="How to rollback?">
-    App rollback is available through the [deployment actions](/configuration/deployment/overview#rollback).
+    App rollback is available through the [deployment actions](/configuration/deployment/overview#rollback). You can roll back to any previous deployment in one click.
   </Accordion>
 
   <Accordion title="How does auto-scaling work?">
-    Auto-scaling is configured in the [application settings](/configuration/application#auto-scaling).
+    Auto-scaling is configured in the [application settings](/configuration/application#auto-scaling). Qovery supports horizontal pod autoscaling based on CPU/memory usage.
   </Accordion>
 
-  <Accordion title="How to manage database migration?">
-    Database migrations can be managed using [Lifecycle Jobs](/configuration/lifecycle-job).
+  <Accordion title="Can I use Terraform?">
+    Yes. Qovery has a [Terraform provider](/terraform/overview) for infrastructure-as-code deployment. The AI agent can also deploy via Terraform if you choose that option during setup.
   </Accordion>
 
-  <Accordion title="Is it possible to get a shell / connect to my app?">
-    Yes, via Qovery cloud shell button in the console interface, selecting pod and container. Also available through CLI with `qovery shell` command.
+  <Accordion title="Is it possible to get a shell into my app?">
+    Yes, via the cloud shell button in the Qovery Console or through the CLI with `qovery shell`.
   </Accordion>
 
-  <Accordion title="Can I use Terraform and Infrastructure as Code?">
-    Yes, Qovery has a [Terraform provider](/terraform/overview) available for infrastructure-as-code deployment.
-  </Accordion>
-
-  <Accordion title="How can I connect my app to MongoDB Atlas?">
-    Use [VPC peering](/integrations/networking/vpc-peering) for secure connection to MongoDB Atlas.
-  </Accordion>
-
-  <Accordion title="How can I connect my app to an AWS service not managed by Qovery?">
-    Use [VPC peering](/integrations/networking/vpc-peering) to connect to external AWS services.
+  <Accordion title="How to connect to external services (MongoDB Atlas, AWS services)?">
+    Use [VPC peering](/configuration/clusters#vpc-peering) for secure, private connectivity to external services in your cloud account.
   </Accordion>
 </AccordionGroup>
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Deploy Your First App" icon="rocket" href="/getting-started/guides/getting-started/deploy-your-first-application">
-    Complete the deployment process
+  <Card title="Deploy with AI Agent" icon="wand-magic-sparkles" href="/getting-started/quickstart/ai-agent">
+    Full guide on installing and using Qovery AI skills
   </Card>
 
   <Card title="Production Setup" icon="server" href="/getting-started/guides/use-cases/production-environment-management">
-    Set up a production-ready environment
+    Set up a production-ready environment with best practices
   </Card>
 
-  <Card title="Qovery CLI" icon="terminal" href="/cli/overview">
-    Learn about the Qovery CLI
+  <Card title="Preview Environments" icon="code-branch" href="/getting-started/guides/use-cases/preview-environments">
+    Automatically create environments for every pull request
   </Card>
 
-  <Card title="Changelog" icon="newspaper" href="https://www.qovery.com/changelog">
-    Read updates and announcements from the Qovery team
+  <Card title="Book a Demo" icon="calendar" href="https://www.qovery.com/book-a-demo">
+    Get cloud architect assistance for your migration
   </Card>
 </CardGroup>

--- a/docs/getting-started/guides/use-cases/remote-development-environments.mdx
+++ b/docs/getting-started/guides/use-cases/remote-development-environments.mdx
@@ -5,9 +5,9 @@ description: "Enable anyone in your organization to build and deploy application
 
 ## Overview
 
-Remote Development Environments (RDE) give every team member -- including non-technical builders -- the ability to build and ship software in a secure, cloud-based workspace. Platform engineers define the environment once as a **blueprint**, and Qovery clones it on demand for each builder with full isolation, RBAC, and cost controls.
+Remote Development Environments (RDE) give every team member - including non-technical builders - the ability to build and ship software in a secure, cloud-based workspace. Platform engineers define the environment once as a **blueprint**, and Qovery clones it on demand for each builder with full isolation, RBAC, and cost controls.
 
-The typical scenario: your organization has people who are technically curious -- they can build with AI-assisted coding tools, low-code platforms, or simple scripts -- but they are not infrastructure engineers. They need a safe, pre-configured environment where they can work autonomously without risking production systems or depending on the platform team for every deployment.
+The typical scenario: your organization has people who are technically curious - they can build with AI-assisted coding tools, low-code platforms, or simple scripts - but they are not infrastructure engineers. They need a safe, pre-configured environment where they can work autonomously without risking production systems or depending on the platform team for every deployment.
 
 RDE solves this by separating **who defines the environment** (platform engineers) from **who uses it** (builders), so both sides get what they need: control and autonomy.
 
@@ -23,7 +23,7 @@ RDE solves this by separating **who defines the environment** (platform engineer
   </Card>
 
   <Card title="Security & Compliance" icon="lock">
-    Builders work in sandboxed environments on your own infrastructure -- SOC2, ISO 27001, DORA compliant
+    Builders work in sandboxed environments on your own infrastructure - SOC2, ISO 27001, DORA compliant
   </Card>
 
   <Card title="Cost Efficiency" icon="dollar-sign">
@@ -35,7 +35,7 @@ RDE solves this by separating **who defines the environment** (platform engineer
   </Card>
 
   <Card title="Fast Onboarding" icon="rocket">
-    New team members are productive in minutes -- no local setup, no configuration drift
+    New team members are productive in minutes - no local setup, no configuration drift
   </Card>
 </CardGroup>
 
@@ -43,8 +43,8 @@ RDE solves this by separating **who defines the environment** (platform engineer
 
 RDE is built on a two-tier system:
 
-1. **Blueprints** -- Template projects and environments created by platform engineers. A blueprint contains everything a builder needs: workspace (VS Code, IDE), databases, services, environment variables, and configuration.
-2. **RDE Instances** -- Cloned from a blueprint for each builder. Each instance is an isolated environment with its own project, RBAC role, and workspace URL.
+1. **Blueprints** - Template projects and environments created by platform engineers. A blueprint contains everything a builder needs: workspace (VS Code, IDE), databases, services, environment variables, and configuration.
+2. **RDE Instances** - Cloned from a blueprint for each builder. Each instance is an isolated environment with its own project, RBAC role, and workspace URL.
 
 ```mermaid
 flowchart LR
@@ -66,7 +66,7 @@ When a platform engineer runs `qovery rde create`, Qovery:
 5. Invites the builder via email
 6. Triggers deployment
 
-The builder receives an email, clicks the workspace URL, and starts building -- no CLI, no Kubernetes knowledge required on their end.
+The builder receives an email, clicks the workspace URL, and starts building - no CLI, no Kubernetes knowledge required on their end.
 
 ## Who Is This For?
 
@@ -88,7 +88,7 @@ The builder receives an email, clicks the workspace URL, and starts building -- 
     - Open your workspace URL in the browser
     - Build with AI-assisted coding tools (VS Code, Claude Code, OpenCode)
     - Deploy and test your applications in isolation
-    - Focus on building -- the platform handles the rest
+    - Focus on building - the platform handles the rest
   </Card>
 </CardGroup>
 
@@ -111,7 +111,7 @@ The builder receives an email, clicks the workspace URL, and starts building -- 
   <Card title="Self-Service Portal" icon="browser">
     **Coming Soon**
 
-    A web portal where builders create their own environments with one click -- no CLI, no Kubernetes knowledge needed. SSO login, pick a template, click "Create".
+    A web portal where builders create their own environments with one click - no CLI, no Kubernetes knowledge needed. SSO login, pick a template, click "Create".
 
     - Web-based UI for non-technical users
     - SSO authentication (Google, Okta, Azure AD, OIDC)
@@ -148,12 +148,35 @@ qovery auth
 
 ### Step 2: Create Your Blueprint
 
-A blueprint is a project containing a template environment that will be cloned for each builder. A good blueprint includes:
+A blueprint is a project containing a template environment that will be cloned for each builder. It defines everything a builder needs: workspace IDE, tools, databases, environment variables, and configuration.
 
-- **A workspace service** -- VS Code Server, or any browser-based IDE your builders will use
-- **Databases and services** -- Any backing services builders need (PostgreSQL, Redis, etc.)
-- **Environment variables** -- Pre-configured credentials, API keys, and settings
-- **A TTL job** (optional) -- A lifecycle job that auto-stops idle environments to save costs
+#### Recommended: Use the Qovery AI Skill
+
+The fastest way to create a production-ready blueprint is using the `/qovery-builder-env` command in [OpenCode](https://opencode.ai) or Claude Code. This AI skill sets up an opinionated workspace blueprint in under 5 minutes:
+
+```bash
+# In OpenCode or Claude Code, run:
+/qovery-builder-env
+```
+
+The skill walks you through setup (organization, cluster, API keys) and creates a blueprint with:
+
+- **VS Code (code-server)** - Browser-based IDE accessible via URL
+- **Claude Code & OpenCode** - AI-assisted coding tools, ready to use
+- **Qovery CLI & GitHub CLI** - For deployments and repo management
+- **Node.js, Python, Git** - Common development dependencies
+- **TTL auto-shutdown job** - Automatically stops idle environments after 24 hours to save costs
+
+Once the skill completes, your blueprint is registered, deployed, validated, and ready to clone. You can skip ahead to [Step 4: Provision an RDE for a Builder](#step-4-provision-an-rde-for-a-builder).
+
+#### Alternative: Build Your Own Blueprint
+
+If you prefer to create a custom blueprint from scratch, set up a project with:
+
+- **A workspace service** - VS Code Server, or any browser-based IDE your builders will use
+- **Databases and services** - Any backing services builders need (PostgreSQL, Redis, etc.)
+- **Environment variables** - Pre-configured credentials, API keys, and settings
+- **A TTL job** (optional) - A lifecycle job that auto-stops idle environments to save costs
 
 <Tip>
 Start simple. You can always iterate on the blueprint based on builder feedback. A workspace service with basic dependencies is enough to get started.
@@ -256,7 +279,7 @@ As a builder, your platform engineer handles all the infrastructure setup. Here 
   </Step>
 
   <Step title="Start Building">
-    Your environment is fully isolated -- you cannot affect production or other builders' environments. Build, test, and deploy freely. If you use AI-assisted coding tools (Claude Code, OpenCode, GitHub Copilot), they work out of the box in your workspace.
+    Your environment is fully isolated - you cannot affect production or other builders' environments. Build, test, and deploy freely. If you use AI-assisted coding tools (Claude Code, OpenCode, GitHub Copilot), they work out of the box in your workspace.
   </Step>
 
   <Step title="Get Help When Needed">
@@ -283,13 +306,13 @@ As a builder, your platform engineer handles all the infrastructure setup. Here 
 
 When your blueprint evolves (new tools, updated dependencies, security patches), upgrade existing RDEs to stay in sync:
 
-**Image strategy** (default) -- Redeploy the environment with the latest images. Safe, no data loss:
+**Image strategy** (default) - Redeploy the environment with the latest images. Safe, no data loss:
 
 ```bash
 qovery rde upgrade --organization "my-org" --name "alice"
 ```
 
-**Reclone strategy** -- Delete the environment and re-clone from the blueprint. Use when the blueprint structure has changed significantly:
+**Reclone strategy** - Delete the environment and re-clone from the blueprint. Use when the blueprint structure has changed significantly:
 
 ```bash
 qovery rde upgrade --organization "my-org" --name "alice" --strategy "reclone"
@@ -325,7 +348,7 @@ qovery rde delete-all --organization "my-org" --confirm
 The Self-Service Portal is an upcoming capability. Contact your Qovery account manager or reach out on Slack for early access.
 </Info>
 
-While the CLI gives platform engineers full control over RDE management, the **Self-Service Portal** is designed for organizations that want to give builders complete autonomy -- without requiring them to use a CLI or understand infrastructure concepts.
+While the CLI gives platform engineers full control over RDE management, the **Self-Service Portal** is designed for organizations that want to give builders complete autonomy - without requiring them to use a CLI or understand infrastructure concepts.
 
 ### What Is the Self-Service Portal?
 
@@ -333,23 +356,23 @@ The portal is a web application deployed on your own Qovery infrastructure where
 
 - **Log in via SSO** (Google, Okta, Azure AD, or any OIDC provider)
 - **Browse available templates** (blueprints configured by platform engineers)
-- **Create an environment with one click** -- pick a template, click "Create", and wait for it to spin up
+- **Create an environment with one click** - pick a template, click "Create", and wait for it to spin up
 - **See a dashboard** of their environments with real-time status, workspace URLs, and TTL countdown
-- **Manage lifecycle** -- start, stop, extend TTL, or delete their environments directly from the UI
+- **Manage lifecycle** - start, stop, extend TTL, or delete their environments directly from the UI
 
 No CLI. No Kubernetes knowledge. No Slack messages asking the platform team to spin up an environment.
 
 ### How It Complements the CLI
 
-The portal does not replace the CLI -- it builds on top of it:
+The portal does not replace the CLI - it builds on top of it:
 
 | Aspect | CLI | Portal |
 |--------|-----|--------|
 | **Audience** | Platform engineers | Builders (non-technical) |
-| **Blueprint setup** | CLI (`qovery rde blueprint register`) | N/A -- platform engineers still use the CLI |
+| **Blueprint setup** | CLI (`qovery rde blueprint register`) | N/A - platform engineers still use the CLI |
 | **RDE creation** | CLI (`qovery rde create`) | One-click in the browser |
 | **RDE lifecycle** | CLI (`qovery rde start/stop/delete`) | Dashboard buttons |
-| **Bulk operations** | CLI (`qovery rde start-all/upgrade`) | N/A -- platform engineers still use the CLI |
+| **Bulk operations** | CLI (`qovery rde start-all/upgrade`) | N/A - platform engineers still use the CLI |
 | **Authentication** | Qovery CLI auth | SSO (Google, Okta, Azure AD, OIDC) |
 
 Platform engineers continue to use the CLI to set up blueprints, configure RBAC, and manage the platform. The portal is the builder-facing layer that abstracts all of that complexity.

--- a/docs/getting-started/guides/use-cases/remote-development-environments.mdx
+++ b/docs/getting-started/guides/use-cases/remote-development-environments.mdx
@@ -1,0 +1,423 @@
+---
+title: "Remote Development Environments"
+description: "Enable anyone in your organization to build and deploy applications autonomously with secure, pre-configured cloud development environments"
+---
+
+## Overview
+
+Remote Development Environments (RDE) give every team member -- including non-technical builders -- the ability to build and ship software in a secure, cloud-based workspace. Platform engineers define the environment once as a **blueprint**, and Qovery clones it on demand for each builder with full isolation, RBAC, and cost controls.
+
+The typical scenario: your organization has people who are technically curious -- they can build with AI-assisted coding tools, low-code platforms, or simple scripts -- but they are not infrastructure engineers. They need a safe, pre-configured environment where they can work autonomously without risking production systems or depending on the platform team for every deployment.
+
+RDE solves this by separating **who defines the environment** (platform engineers) from **who uses it** (builders), so both sides get what they need: control and autonomy.
+
+## Why Remote Development Environments?
+
+<CardGroup cols={3}>
+  <Card title="Builder Autonomy" icon="wand-magic-sparkles">
+    Non-technical builders can build and deploy without depending on platform or DevOps teams
+  </Card>
+
+  <Card title="Platform Control" icon="shield-halved">
+    SREs and platform engineers define blueprints, security boundaries, and RBAC policies
+  </Card>
+
+  <Card title="Security & Compliance" icon="lock">
+    Builders work in sandboxed environments on your own infrastructure -- SOC2, ISO 27001, DORA compliant
+  </Card>
+
+  <Card title="Cost Efficiency" icon="dollar-sign">
+    Environments spin up on demand and auto-stop when idle via TTL jobs
+  </Card>
+
+  <Card title="Consistent Setup" icon="clone">
+    Every builder gets the same pre-configured workspace with the right tools, dependencies, and access
+  </Card>
+
+  <Card title="Fast Onboarding" icon="rocket">
+    New team members are productive in minutes -- no local setup, no configuration drift
+  </Card>
+</CardGroup>
+
+## How It Works
+
+RDE is built on a two-tier system:
+
+1. **Blueprints** -- Template projects and environments created by platform engineers. A blueprint contains everything a builder needs: workspace (VS Code, IDE), databases, services, environment variables, and configuration.
+2. **RDE Instances** -- Cloned from a blueprint for each builder. Each instance is an isolated environment with its own project, RBAC role, and workspace URL.
+
+```mermaid
+flowchart LR
+    PE[Platform Engineer] -->|creates| BP[Blueprint]
+    BP -->|clone| RDE1[RDE - Alice]
+    BP -->|clone| RDE2[RDE - Bob]
+    BP -->|clone| RDE3[RDE - Carol]
+    RDE1 -->|workspace URL| B1[Builder Alice]
+    RDE2 -->|workspace URL| B2[Builder Bob]
+    RDE3 -->|workspace URL| B3[Builder Carol]
+```
+
+When a platform engineer runs `qovery rde create`, Qovery:
+
+1. Creates a new project for the builder (e.g., `rde-alice`)
+2. Creates an RBAC role scoped to that project
+3. Clones the blueprint environment into the new project
+4. Updates the TTL job to target the new environment (for auto-stop)
+5. Invites the builder via email
+6. Triggers deployment
+
+The builder receives an email, clicks the workspace URL, and starts building -- no CLI, no Kubernetes knowledge required on their end.
+
+## Who Is This For?
+
+<CardGroup cols={2}>
+  <Card title="Platform Engineers / SREs" icon="server">
+    **You set up and control the platform.**
+
+    - Create and maintain blueprint environments
+    - Define security boundaries and RBAC policies
+    - Provision RDEs for builders via CLI
+    - Monitor usage, manage lifecycle, control costs
+    - Upgrade all RDEs when the blueprint evolves
+  </Card>
+
+  <Card title="Builders / Non-Technical Team Members" icon="hammer">
+    **You use the workspace to build and deploy.**
+
+    - Accept an email invitation
+    - Open your workspace URL in the browser
+    - Build with AI-assisted coding tools (VS Code, Claude Code, OpenCode)
+    - Deploy and test your applications in isolation
+    - Focus on building -- the platform handles the rest
+  </Card>
+</CardGroup>
+
+## Two Approaches
+
+<CardGroup cols={2}>
+  <Card title="CLI-Based Management" icon="terminal">
+    **Available Now**
+
+    Platform engineers use the Qovery CLI to provision and manage RDEs. Full control over every aspect: blueprint registration, RDE creation, lifecycle management, upgrades, and cleanup.
+
+    - Scriptable and automatable
+    - Full control over RBAC, TTL, and deployment
+    - Ideal for platform teams who want maximum flexibility
+    - Works today
+
+    **Best for:** Technical platform teams managing RDEs for their organization
+  </Card>
+
+  <Card title="Self-Service Portal" icon="browser">
+    **Coming Soon**
+
+    A web portal where builders create their own environments with one click -- no CLI, no Kubernetes knowledge needed. SSO login, pick a template, click "Create".
+
+    - Web-based UI for non-technical users
+    - SSO authentication (Google, Okta, Azure AD, OIDC)
+    - One-click environment creation from templates
+    - Dashboard with status, URLs, and TTL controls
+    - Per-builder environment limits
+
+    **Best for:** Organizations with many non-technical builders who need full self-service
+  </Card>
+</CardGroup>
+
+## Prerequisites
+
+<Warning>
+**Cluster Required**: Before setting up RDEs, you need a Kubernetes cluster managed by Qovery. RDE environments will be deployed on this cluster.
+</Warning>
+
+<Check>You have a [Qovery account](https://console.qovery.com)</Check>
+<Check>You have a running Kubernetes cluster on Qovery ([setup guide](/getting-started/quickstart/cloud))</Check>
+<Check>You have the [Qovery CLI installed](/cli/overview)</Check>
+<Check>You have a project with at least one environment to use as a blueprint template</Check>
+
+## Getting Started with the CLI
+
+### Step 1: Install and Authenticate
+
+<Snippet file="install-qovery-cli.mdx" />
+
+Then authenticate with your Qovery account:
+
+```bash
+qovery auth
+```
+
+### Step 2: Create Your Blueprint
+
+A blueprint is a project containing a template environment that will be cloned for each builder. A good blueprint includes:
+
+- **A workspace service** -- VS Code Server, or any browser-based IDE your builders will use
+- **Databases and services** -- Any backing services builders need (PostgreSQL, Redis, etc.)
+- **Environment variables** -- Pre-configured credentials, API keys, and settings
+- **A TTL job** (optional) -- A lifecycle job that auto-stops idle environments to save costs
+
+<Tip>
+Start simple. You can always iterate on the blueprint based on builder feedback. A workspace service with basic dependencies is enough to get started.
+</Tip>
+
+Once your project and environment are ready, register it as a blueprint:
+
+```bash
+qovery rde blueprint register \
+  --organization "my-org" \
+  --project "builder-workspace"
+```
+
+Verify registration:
+
+```bash
+qovery rde blueprint list --organization "my-org"
+```
+
+### Step 3: Deploy the Blueprint
+
+Deploy the blueprint environment to validate that everything works:
+
+```bash
+qovery rde blueprint deploy \
+  --organization "my-org" \
+  --project "builder-workspace" \
+  --watch
+```
+
+<Tip>
+Always validate your blueprint by deploying and testing it before provisioning RDEs for builders. This ensures every cloned environment works out of the box.
+</Tip>
+
+Once validated, stop the blueprint environment to save resources:
+
+```bash
+qovery rde blueprint stop \
+  --organization "my-org" \
+  --project "builder-workspace" \
+  --watch
+```
+
+### Step 4: Provision an RDE for a Builder
+
+Create an RDE for a team member:
+
+```bash
+qovery rde create \
+  --organization "my-org" \
+  --blueprint "builder-workspace" \
+  --cluster "my-cluster" \
+  --name "alice" \
+  --email "alice@company.com"
+```
+
+This command:
+1. Creates a new project `rde-alice`
+2. Creates an RBAC role `RDE-alice` scoped to this project
+3. Clones the blueprint environment into `rde-alice`
+4. Updates the TTL job to target the new environment
+5. Sends an email invitation to `alice@company.com`
+6. Triggers deployment automatically
+
+### Step 5: Share the Workspace URL
+
+Once the RDE is deployed, get the workspace URLs:
+
+```bash
+qovery rde urls --organization "my-org"
+```
+
+Share the workspace URL with the builder. They can open it in their browser to access their pre-configured development environment.
+
+### Step 6: Verify
+
+Check the status of the RDE:
+
+```bash
+qovery rde status --organization "my-org" --name "alice"
+```
+
+List all RDEs across the organization:
+
+```bash
+qovery rde list --organization "my-org"
+```
+
+## For Builders: Using Your RDE
+
+As a builder, your platform engineer handles all the infrastructure setup. Here is what you need to do:
+
+<Steps>
+  <Step title="Accept the Invitation">
+    Check your email for a Qovery invitation from your platform engineer. Click the link to join your organization on Qovery.
+  </Step>
+
+  <Step title="Access Your Workspace">
+    Open the workspace URL provided by your platform engineer (or find it in the Qovery console). You will have a browser-based IDE (e.g., VS Code) with all tools and dependencies pre-installed.
+  </Step>
+
+  <Step title="Start Building">
+    Your environment is fully isolated -- you cannot affect production or other builders' environments. Build, test, and deploy freely. If you use AI-assisted coding tools (Claude Code, OpenCode, GitHub Copilot), they work out of the box in your workspace.
+  </Step>
+
+  <Step title="Get Help When Needed">
+    If something is not working, reach out to your platform engineer. They can check your RDE status, view logs, and restart your environment if needed.
+  </Step>
+</Steps>
+
+## Managing RDEs
+
+### Day-to-Day Operations
+
+| Task | Command |
+|------|---------|
+| List all RDEs | `qovery rde list --organization "my-org"` |
+| Check RDE status | `qovery rde status --organization "my-org" --name "alice"` |
+| Start an RDE | `qovery rde start --organization "my-org" --name "alice" --watch` |
+| Stop an RDE | `qovery rde stop --organization "my-org" --name "alice" --watch` |
+| Start all RDEs | `qovery rde start-all --organization "my-org"` |
+| Stop all RDEs | `qovery rde stop-all --organization "my-org"` |
+| View logs | `qovery rde logs --organization "my-org" --name "alice"` |
+| Get workspace URLs | `qovery rde urls --organization "my-org"` |
+
+### Upgrading RDEs
+
+When your blueprint evolves (new tools, updated dependencies, security patches), upgrade existing RDEs to stay in sync:
+
+**Image strategy** (default) -- Redeploy the environment with the latest images. Safe, no data loss:
+
+```bash
+qovery rde upgrade --organization "my-org" --name "alice"
+```
+
+**Reclone strategy** -- Delete the environment and re-clone from the blueprint. Use when the blueprint structure has changed significantly:
+
+```bash
+qovery rde upgrade --organization "my-org" --name "alice" --strategy "reclone"
+```
+
+<Warning>
+The `reclone` strategy will destroy the existing environment and recreate it from the blueprint. Any uncommitted work in the builder's workspace will be lost.
+</Warning>
+
+To upgrade all RDEs at once:
+
+```bash
+qovery rde upgrade --organization "my-org"
+```
+
+### Cleaning Up
+
+Delete a single RDE (stops the environment, deletes the project, RBAC role, and API token):
+
+```bash
+qovery rde delete --organization "my-org" --name "alice" --watch
+```
+
+Delete all RDEs:
+
+```bash
+qovery rde delete-all --organization "my-org" --confirm
+```
+
+## Self-Service Portal
+
+<Info>
+The Self-Service Portal is an upcoming capability. Contact your Qovery account manager or reach out on Slack for early access.
+</Info>
+
+While the CLI gives platform engineers full control over RDE management, the **Self-Service Portal** is designed for organizations that want to give builders complete autonomy -- without requiring them to use a CLI or understand infrastructure concepts.
+
+### What Is the Self-Service Portal?
+
+The portal is a web application deployed on your own Qovery infrastructure where non-technical builders can:
+
+- **Log in via SSO** (Google, Okta, Azure AD, or any OIDC provider)
+- **Browse available templates** (blueprints configured by platform engineers)
+- **Create an environment with one click** -- pick a template, click "Create", and wait for it to spin up
+- **See a dashboard** of their environments with real-time status, workspace URLs, and TTL countdown
+- **Manage lifecycle** -- start, stop, extend TTL, or delete their environments directly from the UI
+
+No CLI. No Kubernetes knowledge. No Slack messages asking the platform team to spin up an environment.
+
+### How It Complements the CLI
+
+The portal does not replace the CLI -- it builds on top of it:
+
+| Aspect | CLI | Portal |
+|--------|-----|--------|
+| **Audience** | Platform engineers | Builders (non-technical) |
+| **Blueprint setup** | CLI (`qovery rde blueprint register`) | N/A -- platform engineers still use the CLI |
+| **RDE creation** | CLI (`qovery rde create`) | One-click in the browser |
+| **RDE lifecycle** | CLI (`qovery rde start/stop/delete`) | Dashboard buttons |
+| **Bulk operations** | CLI (`qovery rde start-all/upgrade`) | N/A -- platform engineers still use the CLI |
+| **Authentication** | Qovery CLI auth | SSO (Google, Okta, Azure AD, OIDC) |
+
+Platform engineers continue to use the CLI to set up blueprints, configure RBAC, and manage the platform. The portal is the builder-facing layer that abstracts all of that complexity.
+
+### Key Capabilities
+
+<CardGroup cols={2}>
+  <Card title="SSO Authentication" icon="key">
+    Builders log in with their existing corporate identity. Supports Google Workspace, Okta, Azure AD, and generic OIDC providers.
+  </Card>
+
+  <Card title="Template-Based Creation" icon="layer-group">
+    Platform engineers define templates (blueprints) with specific tools and services. Builders pick the template that fits their use case.
+  </Card>
+
+  <Card title="Real-Time Dashboard" icon="chart-line">
+    Each builder sees their environments with live status, workspace URLs, and TTL remaining. No need to ask anyone for a URL or status update.
+  </Card>
+
+  <Card title="Per-Builder Limits" icon="gauge">
+    Platform engineers can set a maximum number of environments per builder to control costs and resource usage.
+  </Card>
+</CardGroup>
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Keep blueprints lean and focused">
+    Include only what builders actually need. A bloated blueprint means slower clone times and higher costs. Start with a workspace service and basic dependencies, then add more based on feedback.
+  </Accordion>
+
+  <Accordion title="Always use RBAC">
+    The `--skip-rbac` flag exists for testing, but in production always let Qovery create scoped RBAC roles. This ensures builders can only access their own environment and cannot accidentally modify other projects.
+  </Accordion>
+
+  <Accordion title="Configure TTL jobs for cost control">
+    Include a TTL (time-to-live) lifecycle job in your blueprint that auto-stops idle environments. This prevents forgotten environments from running indefinitely and accumulating costs.
+  </Accordion>
+
+  <Accordion title="Use meaningful naming conventions">
+    Name RDEs after the builder (`--name "alice"`) or their role (`--name "marketing-bob"`). This makes it easy to identify and manage environments at scale.
+  </Accordion>
+
+  <Accordion title="Upgrade regularly">
+    When you update the blueprint (new tools, security patches, dependency updates), upgrade all RDEs using `qovery rde upgrade`. The default `image` strategy is safe and non-disruptive.
+  </Accordion>
+
+  <Accordion title="Prepare an onboarding guide for builders">
+    Write a short internal guide for your builders: how to access their workspace, what tools are available, how to deploy, and who to contact for help. The less friction, the more adoption.
+  </Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="RDE CLI Reference" icon="terminal" href="/cli/commands/rde">
+    Full reference for all `qovery rde` commands, flags, and examples
+  </Card>
+
+  <Card title="Ephemeral Environments" icon="clock" href="/getting-started/guides/use-cases/ephemeral-environment">
+    Learn about on-demand temporary environments for development and testing
+  </Card>
+
+  <Card title="Cluster Setup" icon="cloud" href="/getting-started/quickstart/cloud">
+    Set up a Kubernetes cluster on AWS, GCP, Azure, or Scaleway
+  </Card>
+
+  <Card title="Preview Environments" icon="code-branch" href="/getting-started/guides/use-cases/preview-environments">
+    Automatically create environments for every pull request
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Adds a comprehensive **Getting Started guide for Remote Development Environments (RDE)** under How-to Guides
- Rewrites the **cloud migration guide** from a narrow Heroku-to-AWS tutorial into a broad "Migrate to Kubernetes" guide with AI-powered workflow

## Remote Development Environments Guide (new)

`docs/getting-started/guides/use-cases/remote-development-environments.mdx`

Covers the full RDE journey for two audiences:

**For Platform Engineers:**
- What RDEs are and the blueprint/instance architecture
- Blueprint creation via `/qovery-builder-env` AI skill (recommended) or manual setup
- Step-by-step CLI setup: install, authenticate, create blueprint, deploy, provision RDEs
- Day-to-day management, upgrade strategies, cleanup

**For Builders (Non-Technical Users):**
- Accepting the invitation, accessing the workspace, getting started

**Self-Service Portal (Coming Soon):**
- Vision for a web portal with SSO login, template picker, one-click create, status dashboard
- How it complements the CLI

**Best Practices:** Blueprint design, RBAC, cost control via TTL, naming, upgrades

## Migrate to Kubernetes Guide (rewrite)

`docs/getting-started/guides/use-cases/cloud-migration-and-scaling.mdx`

Replaces the narrow "Migrate from Heroku to AWS" manual tutorial with a comprehensive migration guide:

- **Broader scope:** Any source platform (Heroku, Render, OpenShift, VMs, Docker Compose) to any cloud provider (AWS, GCP, Azure, Scaleway)
- **AI-powered migration** via `/qovery-deploy` skill as the primary path
- **No Kubernetes expertise needed** - Qovery abstracts all K8s complexity
- **Cloud architect assistance** - link to book a demo for complex migrations
- **What Gets Migrated** reference table
- **Manual migration** kept as an alternative for teams that want full control
- **Updated FAQ** with modernized answers
- Modern Dockerfile examples (multi-stage Node.js instead of Ruby 2.7)

## Navigation

- Added "Remote Development Environments" as a flat item under How-to Guides in `docs.json`
- Migration guide nav label updates automatically from the new page title

## Files Changed

- `docs/getting-started/guides/use-cases/remote-development-environments.mdx` (new)
- `docs/getting-started/guides/use-cases/cloud-migration-and-scaling.mdx` (rewrite)
- `docs/docs.json` (navigation update)