### PR TITLE
fix: correct Envoy Gateway default resource values in cluster advanced settings

### DIFF
--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -1107,7 +1107,7 @@ If you don't specify custom image repository and tag, ensure your cluster includ
 
 **Description:** vCPU request value in millicores assigned to Envoy Gateway pods. This defines the minimum CPU resources guaranteed for each pod. Must be less than or equal to `envoy.vcpu.limit_in_milli_cpu`.
 
-**Default Value:** `100`
+**Default Value:** `250`
 
 <a id="envoy-vcpu-limit-in-milli-cpu"></a>
 
@@ -1119,7 +1119,7 @@ If you don't specify custom image repository and tag, ensure your cluster includ
 
 **Description:** vCPU limit value in millicores assigned to Envoy Gateway pods. This defines the maximum CPU resources that each pod can consume. Must be greater than or equal to `envoy.vcpu.request_in_milli_cpu`.
 
-**Default Value:** `1000`
+**Default Value:** `250`
 
 <a id="envoy-memory-request-in-mib"></a>
 
@@ -1131,7 +1131,7 @@ If you don't specify custom image repository and tag, ensure your cluster includ
 
 **Description:** Memory request value in MiB assigned to Envoy Gateway pods. This defines the minimum memory resources guaranteed for each pod. Must be less than or equal to `envoy.memory.limit_in_mib`.
 
-**Default Value:** `256`
+**Default Value:** `768`
 
 <a id="envoy-memory-limit-in-mib"></a>
 
@@ -1143,7 +1143,7 @@ If you don't specify custom image repository and tag, ensure your cluster includ
 
 **Description:** Memory limit value in MiB assigned to Envoy Gateway pods. This defines the maximum memory resources that each pod can consume. Must be greater than or equal to `envoy.memory.request_in_mib`.
 
-**Default Value:** `1024`
+**Default Value:** `768`
 
 <a id="envoy-gateway-api-http-request-timeout-seconds"></a>
 


### PR DESCRIPTION
## Summary

Corrects four documented default values for Envoy Gateway pod resources that were out of sync with the actual code defaults in `KubernetesProvider.kt`.

| Setting | Old (wrong) | New (correct) |
|---|---|---|
| `envoy.vcpu.request_in_milli_cpu` | `100` | `250` |
| `envoy.vcpu.limit_in_milli_cpu` | `1000` | `250` |
| `envoy.memory.request_in_mib` | `256` | `768` |
| `envoy.memory.limit_in_mib` | `1024` | `768` |

Identified during a systematic audit of all cluster advanced settings documentation against the Kotlin backend source.