### PR TITLE
docs: update RDE Portal documentation for May 2026 features

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -609,7 +609,8 @@
                   "rde/admin/workspace-management",
                   "rde/admin/publish-approvals",
                   "rde/admin/member-management",
-                  "rde/admin/portal-customization"
+                  "rde/admin/portal-customization",
+                  "rde/admin/security-center"
                 ]
               }
             ]

--- a/docs/rde/admin/blueprint-management.mdx
+++ b/docs/rde/admin/blueprint-management.mdx
@@ -32,6 +32,10 @@ As an admin, you decide what each blueprint contains, who can access it, and wha
 
   <Step title="Choose the Environment">
     Select the specific environment within the project to use as the blueprint source. This is the environment that will be cloned when builders create workspaces.
+
+    <Info>
+    If the selected project contains multiple environments, a dropdown appears to let you choose which environment to use as the blueprint source.
+    </Info>
   </Step>
 
   <Step title="Set Display Name">
@@ -81,6 +85,132 @@ Removing a blueprint does **not** delete existing workspaces created from it. Th
 </Warning>
 
 If you want to permanently clean up, delete the associated workspaces from the [workspace management](/rde/admin/workspace-management) page before or after removing the blueprint.
+
+## Create Blueprint from Template
+
+Instead of registering an existing Qovery environment as a blueprint, you can create a new blueprint directly from a pre-built template - no pre-existing environment required.
+
+<Steps>
+  <Step title="Open the Template Gallery">
+    Navigate to **Admin > Blueprints**, click the dropdown arrow next to the **Register Blueprint** button, and select **Create from Template**.
+  </Step>
+
+  <Step title="Pick a Template">
+    Browse the template gallery organized by persona category:
+
+    <CardGroup cols={3}>
+      <Card title="Developers" icon="code">
+        Full-stack, frontend, and backend starter templates.
+      </Card>
+      <Card title="Data" icon="database">
+        Data science and analytics templates.
+      </Card>
+      <Card title="Marketing" icon="bullhorn">
+        Campaign tools and content management templates.
+      </Card>
+      <Card title="Sales" icon="chart-line">
+        CRM tools and pipeline reporting templates.
+      </Card>
+      <Card title="Finance" icon="calculator">
+        Financial analysis and reporting templates.
+      </Card>
+      <Card title="Other" icon="grid-2">
+        General-purpose templates.
+      </Card>
+    </CardGroup>
+
+    Select the template that best fits your use case.
+  </Step>
+
+  <Step title="Configure the Blueprint">
+    Fill in the configuration form:
+
+    - **Blueprint name** - Display name shown to builders in the catalog
+    - **Target cluster** - The Kubernetes cluster where workspaces will run
+    - **Resource allocation** - CPU, RAM, and storage limits for the workspace
+    - **Docker image repository** - Container registry and image for the workspace
+    - **Project repository URL** (optional) - Git repository to auto-clone into new workspaces
+  </Step>
+
+  <Step title="Create">
+    Click **Create**. The portal provisions the Qovery project and environment automatically. The new blueprint appears in the catalog once provisioning is complete.
+  </Step>
+</Steps>
+
+<Tip>
+Use templates when you want a quick starting point without manually setting up Qovery projects and environments first. You can always customize the resulting blueprint environment in the Qovery Console after creation.
+</Tip>
+
+## Blueprint Lifecycle
+
+Each blueprint has an **admin state** that controls its visibility and availability in the catalog.
+
+| State | Catalog Visibility | Description |
+|-------|-------------------|-------------|
+| **Testing** | Shown with a "Coming Soon" badge | New blueprints start in this state. Admins can test them before making them available. |
+| **Enabled** | Fully visible and launchable | Builders can create workspaces from this blueprint. |
+| **Disabled** | Hidden from catalog | The blueprint is not available to builders. Existing workspaces are unaffected. |
+
+To change a blueprint's state, open the blueprint detail page and use the state action buttons (**Enable**, **Disable**, **Set Testing**).
+
+<Info>
+When a blueprint is in **Testing** state, it appears in the catalog with a "Coming Soon" badge. Only admins can launch test sessions from it - builders see the badge but cannot create workspaces.
+</Info>
+
+## Primary Service
+
+By default, the portal connects terminal sessions and live preview to the first service in the blueprint environment. If your blueprint has multiple services, you can specify which service is the **primary service** - the one used for shell connections and preview.
+
+Navigate to **Admin > Blueprints > [Blueprint] > Settings** and select the primary service from the dropdown. The dropdown lists all services in the blueprint's Qovery environment.
+
+<Tip>
+Set the primary service to the container running your IDE (e.g., code-server) so that terminal sessions and live preview connect to the right service automatically.
+</Tip>
+
+## Workspace Project Mode
+
+Choose how the portal organizes Qovery projects when builders create workspaces:
+
+| Mode | Behavior |
+|------|----------|
+| **Dedicated** (default) | Each workspace gets its own Qovery project. Full isolation between workspaces. |
+| **Shared** | All workspaces from this blueprint share a single Qovery project. Environments are created within the shared project. Uses fewer Qovery resources. |
+
+Configure this in **Admin > Blueprints > [Blueprint] > Settings > Project Mode**.
+
+<Info>
+Use **shared** mode when you want to reduce the number of Qovery projects in your organization. Use **dedicated** mode (default) when workspace isolation is a priority.
+</Info>
+
+## Naming Templates
+
+Customize how workspace projects and environments are named in Qovery using template variables:
+
+| Variable | Resolves to |
+|----------|-------------|
+| `{user}` | The builder's username (from email) |
+| `{blueprint}` | The blueprint display name |
+| `{random}` | A random alphanumeric string |
+| `{name}` | The workspace name chosen by the builder |
+
+For example, a template of `rde-{user}-{blueprint}` for a user `alice@company.com` creating from "Frontend Starter" would produce `rde-alice-frontend-starter`.
+
+<Info>
+Names are automatically sanitized to be Qovery-compatible (lowercase, alphanumeric, hyphens only).
+</Info>
+
+Configure naming templates in **Admin > Blueprints > [Blueprint] > Settings > Workspace Naming**.
+
+## Target Cluster
+
+If your organization has multiple Kubernetes clusters, you can specify which cluster should be used for workspaces created from a specific blueprint.
+
+Navigate to **Admin > Blueprints > [Blueprint] > Settings > Target Cluster** and select the cluster from the dropdown. If no cluster is specified, the portal uses the default cluster.
+
+This is useful for:
+- **Data residency** - Route workspaces to clusters in specific regions
+- **Resource isolation** - Separate development workloads across clusters
+- **Specialized hardware** - Use different node types or GPU-enabled clusters for specific blueprint use cases
 
 ## Managing Blueprints with Terraform
 

--- a/docs/rde/admin/portal-customization.mdx
+++ b/docs/rde/admin/portal-customization.mdx
@@ -18,11 +18,16 @@ Navigate to **Admin > Settings** to configure portal-wide branding.
 | Setting | Description |
 |---------|-------------|
 | **Portal Name** | Displayed in the header and browser tab title. Use your company name or a team-specific label. |
-| **Logo** | Your company logo, shown in the top navigation bar. Upload a PNG or SVG file. |
-| **Primary Color** | The portal generates a full color palette from your primary brand color - buttons, links, accents, and hover states all adapt automatically. |
+| **Logo (Light)** | Your company logo for light mode, shown in the top navigation bar. Upload a PNG or SVG file. |
+| **Logo (Dark)** | Your company logo for dark mode. If not provided, the light logo is used in both modes. Upload a PNG or SVG file. |
+| **Accent Color** | The portal generates a full color palette from your accent color - buttons, links, accents, and hover states all adapt automatically. Use the color picker or enter a hex value. |
+
+<Tip>
+Use the **Reset** controls next to the accent color and logos to revert to the Qovery defaults at any time.
+</Tip>
 
 <Info>
-Branding changes take effect immediately for all users. No restart or redeployment is required.
+Branding changes take effect immediately for all users. No restart or redeployment is required. The portal automatically applies the appropriate logo variant based on the user's system theme (light or dark mode).
 </Info>
 
 ## Welcome Screen
@@ -73,38 +78,51 @@ Toggle the **preview panel** visibility for the blueprint. When enabled, builder
 
 Disable the preview panel for blueprints where a live preview is not relevant (e.g., backend API services, CLI tools, data processing scripts).
 
-## Claude Authentication
+## AI Configuration
 
-Configure how **Claude Code** authenticates in workspaces for each blueprint. Navigate to **Admin > Blueprints > [Blueprint] > Settings**.
+Configure AI providers for each blueprint in a single, unified settings panel. Navigate to **Admin > Blueprints > [Blueprint] > Settings > AI Configuration**.
 
-<Tabs>
-  <Tab title="User OAuth">
-    Builders authenticate with their own Anthropic account when they first open Claude Code. This is free to set up but usage is capped by each user's individual Anthropic plan.
+The AI configuration uses an accordion interface where each provider can be independently enabled and configured.
 
-    **Best for:** Teams where builders already have Anthropic accounts, or when you want each user to manage their own usage.
-  </Tab>
-  <Tab title="API Key">
-    You provide an Anthropic API key at the blueprint level. Claude Code authenticates automatically with no action required from the builder. Usage is billed to your organization's Anthropic account.
+### Anthropic (Claude)
 
-    **Best for:** Seamless onboarding where you want builders to start coding immediately without any authentication steps. You control and pay for the usage centrally.
-  </Tab>
-</Tabs>
-
-## LLM Provider Configuration
-
-Configure the **Chat panel** LLM provider for each blueprint. This controls which AI model powers the OpenCode chat experience in workspaces.
-
-Navigate to **Admin > Blueprints > [Blueprint] > Settings > Chat Provider**.
+Controls both Claude Code (terminal) and can power the Chat panel.
 
 | Setting | Description |
 |---------|-------------|
-| **Provider** | Choose between Anthropic, OpenAI, or a custom provider. |
-| **API Key** | The API key for the selected provider. |
-| **Model** | The specific model to use (e.g., `claude-sonnet-4-20250514`, `gpt-4o`). |
+| **Enabled** | Toggle to enable or disable Anthropic as a provider for this blueprint. |
+| **Authentication Mode** | Choose between **User OAuth** (builders authenticate with their own Anthropic account) or **API Key** (you provide a key, billed to your organization). |
+| **API Key** | Required when using API Key authentication mode. Stored encrypted with AES-256-GCM. |
+| **Model** | The Claude model to use (e.g., `claude-sonnet-4-20250514`). |
 
-<Note>
-LLM provider settings apply to the Chat panel only. Claude Code authentication is configured separately (see above).
-</Note>
+### OpenAI
+
+Powers the Chat panel with OpenAI models.
+
+| Setting | Description |
+|---------|-------------|
+| **Enabled** | Toggle to enable or disable OpenAI as a provider. |
+| **API Key** | Your OpenAI API key. Stored encrypted with AES-256-GCM. |
+| **Model** | The model to use (e.g., `gpt-4o`). |
+
+### Custom Provider
+
+Use any OpenAI-compatible API endpoint as the Chat panel provider.
+
+| Setting | Description |
+|---------|-------------|
+| **Enabled** | Toggle to enable or disable the custom provider. |
+| **API Key** | API key for the custom endpoint. Stored encrypted with AES-256-GCM. |
+| **Model** | The model identifier expected by the custom endpoint. |
+| **Endpoint URL** | The base URL of the OpenAI-compatible API (e.g., `https://your-llm-gateway.internal/v1`). |
+
+<Info>
+You can enable multiple providers simultaneously. Anthropic powers Claude Code, while the Chat panel uses whichever provider is configured for it (Anthropic, OpenAI, or Custom). If multiple chat providers are enabled, the first enabled provider in order (Anthropic, OpenAI, Custom) is used.
+</Info>
+
+<Tip>
+For organizations that require AI traffic to stay within your network, use the Custom provider with an internally hosted model endpoint. This ensures no AI data leaves your infrastructure.
+</Tip>
 
 <Tip>
 Start with the default layout and iterate based on builder feedback. You can change layout settings at any time - they apply to new workspaces and existing workspaces on their next load.

--- a/docs/rde/admin/security-center.mdx
+++ b/docs/rde/admin/security-center.mdx
@@ -1,0 +1,208 @@
+---
+title: "Security Center"
+description: "Monitor connections, configure IP firewall rules, and audit workspace access"
+---
+
+<Warning>
+**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+</Warning>
+
+## Overview
+
+The Security Center is an admin page that provides visibility into active connections, IP-based firewall controls, and an audit log of all connection activity across your organization's workspaces.
+
+It has three tabs:
+
+- **Overview** - Summary of active sessions and recent firewall events
+- **Firewall** - IP allowlist and denylist rules for controlling access
+- **Activity** - Full log of connection sessions and firewall events
+
+## Accessing the Security Center
+
+<Steps>
+  <Step title="Open the Admin Panel">
+    Log in to the RDE Portal as an admin and navigate to **Admin > Security Center**.
+  </Step>
+
+  <Step title="Select a Tab">
+    Use the tab bar at the top to switch between **Overview**, **Firewall**, and **Activity**.
+  </Step>
+</Steps>
+
+## Overview Tab
+
+The Overview tab provides a quick summary of the current security posture:
+
+- **Active connection sessions** - The number of currently open shell and preview connections across all workspaces.
+- **Recent firewall events** - A summary of recent firewall activity, including blocked connection attempts.
+
+Use this tab as a starting point to assess whether anything needs attention before diving into the Firewall or Activity tabs.
+
+## Firewall Rules
+
+The Firewall tab lets you define IP-based access rules that control who can connect to workspaces. Rules apply to both **shell (terminal) connections** and **preview (HTTP) connections**.
+
+Each firewall rule has the following fields:
+
+| Field | Description |
+|-------|-------------|
+| **Action** | `allow` or `deny` - whether the rule permits or blocks the connection |
+| **CIDR Range** | An IP address or CIDR block (e.g., `192.168.1.0/24` or `10.0.0.5`) |
+| **Description** | A human-readable label for the rule (e.g., "Office VPN" or "Block suspicious range") |
+| **Priority** | The position in the rule list - rules are evaluated top to bottom |
+
+### Creating a Rule
+
+<Steps>
+  <Step title="Open the Firewall Tab">
+    Navigate to **Admin > Security Center > Firewall**.
+  </Step>
+
+  <Step title="Add a New Rule">
+    Click **Add Rule**. Fill in the action (`allow` or `deny`), the CIDR range, and a description.
+  </Step>
+
+  <Step title="Save">
+    Click **Save**. The rule takes effect immediately for all new connections.
+  </Step>
+</Steps>
+
+<Tip>
+Start with a deny rule for known bad IP ranges, then add allow rules for your office and VPN networks. This gives you a clear picture of what is explicitly permitted.
+</Tip>
+
+### Rule Evaluation Order
+
+Rules are evaluated **in order from top to bottom**. The first rule that matches the connecting IP address wins - no further rules are checked.
+
+This means rule ordering matters. Consider the following example:
+
+| Priority | Action | CIDR | Description |
+|----------|--------|------|-------------|
+| 1 | Allow | `10.0.0.0/8` | Internal network |
+| 2 | Deny | `10.0.5.0/24` | Restricted subnet |
+| 3 | Deny | `0.0.0.0/0` | Block everything else |
+
+In this configuration, a connection from `10.0.5.15` would be **allowed** because it matches rule 1 first. The deny rule at priority 2 never executes for that IP. To block the restricted subnet, move the deny rule above the broader allow rule.
+
+<Warning>
+First-match-wins means that a broad allow rule placed before a narrow deny rule will override the deny. Always place more specific rules above more general ones.
+</Warning>
+
+### CIDR Notation
+
+Rules accept standard CIDR notation:
+
+| Format | Meaning |
+|--------|---------|
+| `192.168.1.100` | A single IP address (equivalent to `192.168.1.100/32`) |
+| `192.168.1.0/24` | All IPs from `192.168.1.0` to `192.168.1.255` (256 addresses) |
+| `10.0.0.0/8` | All IPs from `10.0.0.0` to `10.255.255.255` |
+| `0.0.0.0/0` | All IPv4 addresses |
+
+### Default Behavior
+
+When no firewall rules are configured, **all connections are allowed**. The firewall only activates when at least one rule is present.
+
+<Info>
+If you add rules, make sure your intended users are covered by an allow rule - or that they are not matched by any deny rule. Any IP that does not match any rule is **allowed** by default, even when other rules exist.
+</Info>
+
+### Reordering Rules
+
+Because evaluation order determines which rule matches first, you can reorder rules by dragging them in the Firewall tab. After reordering, click **Save** to apply the new priority order.
+
+<AccordionGroup>
+  <Accordion title="Example: Allow only office IPs">
+    1. Add a rule: **Allow** `203.0.113.0/24` (your office network)
+    2. Add a rule: **Deny** `0.0.0.0/0` (everything else)
+    3. Ensure the allow rule is above the deny rule
+
+    Result: Only connections from your office IP range are permitted. All other IPs are blocked.
+  </Accordion>
+
+  <Accordion title="Example: Block a specific IP while allowing all others">
+    1. Add a rule: **Deny** `198.51.100.42` (the IP to block)
+
+    Result: Connections from `198.51.100.42` are blocked. All other IPs are allowed by the default policy.
+  </Accordion>
+
+  <Accordion title="Example: Allow VPN and office, block everything else">
+    1. Add a rule: **Allow** `10.8.0.0/16` (VPN range)
+    2. Add a rule: **Allow** `203.0.113.0/24` (office network)
+    3. Add a rule: **Deny** `0.0.0.0/0` (block all other traffic)
+
+    Result: Only VPN and office connections are allowed.
+  </Accordion>
+</AccordionGroup>
+
+## Activity & Connection Audit
+
+The Activity tab provides a full log of connection sessions and firewall events.
+
+### Connection Sessions
+
+Every time a user opens a terminal or accesses a preview, the session is recorded:
+
+| Field | Description |
+|-------|-------------|
+| **User Email** | The authenticated email of the user who initiated the session |
+| **IP Address** | The IP address the connection originated from |
+| **Connection Type** | `shell` (terminal session) or `preview` (HTTP preview request) |
+| **Timestamp** | When the connection was established |
+| **Status** | Whether the connection is active or has ended |
+
+### Firewall Events
+
+When a connection is blocked by a firewall rule, the event is logged separately:
+
+| Field | Description |
+|-------|-------------|
+| **IP Address** | The IP that was blocked |
+| **Matched Rule** | The specific firewall rule that caused the block |
+| **Timestamp** | When the blocked connection attempt occurred |
+| **Connection Type** | `shell` or `preview` |
+
+Use the Activity tab to investigate suspicious access attempts, verify that firewall rules are working as expected, and maintain an audit trail of who accessed which workspaces and when.
+
+## How the Firewall Works
+
+The firewall is enforced at two integration points: **shell WebSocket connections** and **preview proxy HTTP requests**.
+
+### Shell Connections
+
+When a user opens a terminal in a workspace:
+
+1. The portal receives a shell connection request.
+2. Before establishing the WebSocket, the firewall evaluates the user's IP address against the rule list.
+3. If a deny rule matches first, the connection is rejected and the terminal displays a `firewall_blocked` message.
+4. If an allow rule matches first, or no rules match (default allow), the connection proceeds normally.
+5. The connection attempt is logged in the Activity tab regardless of the outcome.
+
+### Preview Connections
+
+When a user accesses the live preview panel:
+
+1. The portal receives an HTTP request for the preview proxy.
+2. The firewall evaluates the user's IP address against the rule list.
+3. If a deny rule matches first, the request is rejected.
+4. If an allow rule matches first, or no rules match, the request is proxied to the workspace container.
+5. The connection attempt is logged in the Activity tab.
+
+<Note>
+Both allowed and blocked connections are recorded. This means the Activity tab provides a complete audit trail of all access to your organization's workspaces, not just blocked attempts.
+</Note>
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Security & Data Residency" icon="lock" href="/rde/reference/security">
+    Learn about the portal's security architecture and data residency model.
+  </Card>
+  <Card title="Workspace Management" icon="server" href="/rde/admin/workspace-management">
+    Monitor and manage all workspaces across your organization.
+  </Card>
+  <Card title="Access Control" icon="shield-halved" href="/rde/admin/access-control">
+    Configure blueprint-level access rules by email or domain.
+  </Card>
+</CardGroup>

--- a/docs/rde/admin/workspace-management.mdx
+++ b/docs/rde/admin/workspace-management.mdx
@@ -21,9 +21,10 @@ Navigate to **Admin > Workspaces** to see all workspaces in your organization. E
 | **Owner Email** | The email address of the builder who owns the workspace |
 | **Blueprint** | The blueprint template the workspace was created from |
 | **Status** | Current state: Running, Stopped, Deploying, or Error |
+| **Cluster** | The Kubernetes cluster where the workspace is running (visible when the organization has multiple clusters) |
 | **Created** | When the workspace was first created |
 
-You can filter workspaces by status or search by workspace name or owner email to quickly find what you need.
+You can filter workspaces by status or cluster, and search by workspace name or owner email to quickly find what you need.
 
 ## Workspace Actions
 
@@ -64,6 +65,26 @@ The admin dashboard provides summary statistics at the top of the workspace mana
 - **Total Blueprints** - Number of registered blueprints in the organization
 
 Use these stats to get a quick sense of resource utilization and identify workspaces that need attention.
+
+<Info>
+Workspace statuses update reactively. During active transitions (deploying, restarting), the dashboard polls every 3 seconds. Once all workspaces reach a stable state, polling slows to every 15 seconds to reduce API load.
+</Info>
+
+## Infrastructure Overview
+
+The admin dashboard includes an **infrastructure topology graph** that visualizes the relationship between clusters, blueprints, and workspaces across your organization.
+
+The graph displays:
+
+- **Cluster nodes** - Each Kubernetes cluster in your organization
+- **Blueprint nodes** - Blueprints connected to their target cluster, showing owner and status
+- **Workspace nodes** - Active workspaces connected to their source blueprint, showing status indicators
+
+The graph auto-layouts using a hierarchical top-down arrangement. Use it to quickly understand how workspaces are distributed across your infrastructure and identify clusters or blueprints with high utilization.
+
+<Tip>
+The infrastructure graph updates in real time. Workspace status changes (deploying, running, stopped, error) are reflected automatically with adaptive polling - faster updates during active changes, slower polling when stable.
+</Tip>
 
 ## Workspace Limits
 

--- a/docs/rde/getting-started/admin-setup.mdx
+++ b/docs/rde/getting-started/admin-setup.mdx
@@ -45,8 +45,9 @@ Connect the portal to your Qovery organization and apply your branding.
     Navigate to **Admin > Settings** and configure the following to match your organization:
 
     - **Portal name** - displayed in the header and browser tab
-    - **Logo** - your company logo for the portal header
-    - **Primary brand color** - applied to buttons, links, and accent elements
+    - **Logo (Light mode)** - your company logo for light backgrounds
+    - **Logo (Dark mode)** - optional logo variant for dark backgrounds (falls back to the light logo if not set)
+    - **Accent color** - applied to buttons, links, and accent elements throughout the portal
   </Step>
 
   <Step title="Configure the Welcome Screen (Optional)">
@@ -83,6 +84,10 @@ Blueprints are Qovery environments that serve as templates. When a builder creat
     Give the blueprint a **display name** that builders will see in the catalog (e.g., "Full-Stack Starter" or "Backend API"). Add an optional **description** to help builders understand what the blueprint includes.
   </Step>
 </Steps>
+
+<Tip>
+New blueprints start in **Testing** state. After verifying the blueprint works correctly, change its state to **Enabled** in the blueprint detail page to make it available to builders. See [Blueprint Management](/rde/admin/blueprint-management#blueprint-lifecycle) for details.
+</Tip>
 
 <Tip>
 Start with a simple blueprint - a single workspace container with basic dev tools. You can always add databases, services, and advanced configuration later. Need a ready-made image? Use the [official workspace template](https://github.com/evoxmusic/remote-dev-env-template) - an all-in-one image with code-server, Claude Code, OpenCode, and multi-language support. See [Blueprint Management](/rde/admin/blueprint-management#official-workspace-template) for details.
@@ -122,20 +127,13 @@ You can combine domain and email restrictions. For example, allow all `@yourcomp
 
 Optionally fine-tune each blueprint with AI provider configuration and workspace layout settings.
 
-### Claude Authentication
+### AI Configuration
 
-Choose how Claude Code authenticates in workspaces created from this blueprint:
+Configure AI providers for the workspace in a unified panel. Each provider can be independently enabled:
 
-- **User OAuth** - each builder authenticates with their own Anthropic account. Free tier available but usage is capped.
-- **API Key injection** - the portal injects an API key into the workspace. Seamless for builders, billed per usage to the key owner.
-
-### LLM Provider
-
-Configure the AI provider for the workspace chat panel:
-
-- **Anthropic** - Claude models
-- **OpenAI** - GPT models
-- **Custom provider** - any OpenAI-compatible API endpoint
+- **Anthropic** - Powers Claude Code and can power the Chat panel. Choose between User OAuth (builders use their own account) or API Key injection (seamless, billed to your organization).
+- **OpenAI** - Powers the Chat panel with GPT models. Requires an API key.
+- **Custom provider** - Any OpenAI-compatible API endpoint for the Chat panel. Useful for internally hosted models.
 
 ### Layout
 

--- a/docs/rde/getting-started/create-your-first-workspace.mdx
+++ b/docs/rde/getting-started/create-your-first-workspace.mdx
@@ -36,9 +36,16 @@ This guide walks you through creating your first workspace in the RDE Portal. Yo
   </Step>
 
   <Step title="Wait for Deployment">
-    Your workspace status will show as **Deploying**. This typically takes 2-4 minutes depending on the blueprint complexity (number of services, databases, and container images involved).
+    The portal shows **real-time provisioning progress** as your workspace is created. You will see each phase as it completes:
 
-    You will be redirected to the workspace editor automatically once deployment completes.
+    1. **Validating** - Checking blueprint configuration and your permissions
+    2. **Creating project** - Setting up the isolated Qovery project for your workspace
+    3. **Cloning blueprint** - Copying the blueprint environment into your workspace
+    4. **Configuring** - Applying settings, environment variables, and access controls
+    5. **Deploying** - Building and starting your workspace containers (this is the longest phase, typically 1-3 minutes)
+    6. **Finalizing** - Verifying all services are running
+
+    You will be redirected to the workspace editor automatically once all phases complete.
   </Step>
 </Steps>
 
@@ -71,11 +78,11 @@ Toggle **auto-refresh** to automatically reload the preview when your applicatio
 
 The top bar displays:
 
-- **Workspace name** - click to rename your workspace
+- **Logo** - click to return to the workspace dashboard
+- **Workspace name** - the name of your current workspace
 - **Deployment status** - current state of your environment
-- **History** - browse and restore git snapshots
-- **Preview** - open the live preview in a new tab
 - **Publish** - submit your application for production deployment
+- **Actions menu** (...) - workspace actions including Restart, Stop, and Delete
 
 ## Your First Commands
 

--- a/docs/rde/overview.mdx
+++ b/docs/rde/overview.mdx
@@ -76,6 +76,15 @@ The portal includes a **built-in terminal with Claude Code and OpenCode chat** f
   <Card title="Portal Customization" icon="palette">
     Custom branding with your logo, colors, and portal name. Configure the welcome screen and per-blueprint layout settings.
   </Card>
+  <Card title="Security Center" icon="shield">
+    Monitor active connections, configure IP firewall rules, and audit all workspace access from a centralized admin panel.
+  </Card>
+  <Card title="Blueprint Templates" icon="wand-magic-sparkles">
+    Create blueprints from a built-in template gallery with pre-configured templates for developers, data teams, marketing, sales, and finance.
+  </Card>
+  <Card title="Multi-Cluster Support" icon="server">
+    Route workspaces to specific Kubernetes clusters per blueprint for data residency, resource isolation, or specialized hardware requirements.
+  </Card>
 </CardGroup>
 
 ## Secure by Design

--- a/docs/rde/reference/architecture.mdx
+++ b/docs/rde/reference/architecture.mdx
@@ -114,6 +114,8 @@ The database holds:
 - Member role assignments
 - User tags and workspace tag assignments
 - One-time authentication tickets for secure sessions
+- Connection audit logs (shell and preview session history)
+- IP firewall rules and blocked connection events
 
 <Note>
 The database does **not** store workspace state. Workspace lifecycle (running, stopped, deploying, error) and configuration are managed entirely through the Qovery API.
@@ -201,6 +203,10 @@ When the portal needs to list a user's workspaces, it:
 <Tip>
 Because Qovery's API is the single source of truth, there are no sync issues between the portal and Qovery. If you modify a workspace directly in the Qovery Console, the portal reflects the change automatically.
 </Tip>
+
+<Info>
+The portal supports **multi-cluster** organizations. Admins can assign specific Kubernetes clusters to specific blueprints via the [Target Cluster](/rde/admin/blueprint-management#target-cluster) setting. Workspace discovery spans all clusters in the organization.
+</Info>
 
 ## Terminal & Preview
 
@@ -294,6 +300,8 @@ The portal splits data storage between its database and the Qovery API:
 | Theme and branding | Portal database |
 | Member roles | Portal database |
 | User tags | Portal database |
+| Connection audit logs | Portal database |
+| Firewall rules and events | Portal database |
 
 <Note>
 No source code, AI conversations, or application data is stored in the portal database. All development data lives exclusively in workspace containers on your cluster.

--- a/docs/rde/reference/security.mdx
+++ b/docs/rde/reference/security.mdx
@@ -202,8 +202,10 @@ Each workspace is a **separate Qovery environment** running as isolated containe
 ### Audit & Visibility
 
 - **All workspace operations** (create, start, stop, delete, publish) are logged through Qovery's audit trail
+- **Connection auditing** - Every shell and preview connection is logged with user email, IP address, connection type, and timestamp. View active and historical sessions in the [Security Center](/rde/admin/security-center)
+- **IP firewall** - Configure allow/deny rules with CIDR support to restrict which IP addresses can connect to workspaces. Blocked connection attempts are logged as firewall events. See [Security Center](/rde/admin/security-center) for configuration
 - **Publish workflow** maintains a full history of requests, approvals, and rejections with timestamps and reviewer identity
-- **Admin dashboard** provides real-time visibility into all workspaces across the organization: who created them, their status, and which blueprint they're based on
+- **Admin dashboard** provides real-time visibility into all workspaces across the organization, including an infrastructure topology graph showing clusters, blueprints, and workspace distribution
 
 ## Token & Secret Management
 

--- a/docs/rde/reference/troubleshooting.mdx
+++ b/docs/rde/reference/troubleshooting.mdx
@@ -51,6 +51,15 @@ This page covers common issues you may encounter with the RDE Portal and how to 
     - Check that your browser allows third-party cookies, or that `auth.qovery.com` is not blocked by browser extensions.
     - Try logging in from an incognito/private window to rule out extension interference.
   </Accordion>
+
+  <Accordion title="Browser compatibility warning banner">
+    **Symptoms:** A banner appears warning that your browser may not be fully supported.
+
+    **Solutions:**
+    - The RDE Portal is optimized for **Chromium-based browsers** (Google Chrome, Microsoft Edge, Brave, Arc). Terminal rendering and WebSocket connections work best on these browsers.
+    - Firefox and Safari may work for basic portal navigation but can have issues with terminal display and live preview.
+    - For the best experience, switch to a Chromium-based browser.
+  </Accordion>
 </AccordionGroup>
 
 ## Workspace Issues
@@ -137,6 +146,15 @@ This page covers common issues you may encounter with the RDE Portal and how to 
     - **Resize** the terminal panel by dragging the divider. This triggers a terminal re-fit that recalculates dimensions.
     - If the issue persists, open a new terminal tab.
     - Some programs output ANSI escape codes that may not render correctly. Try running `reset` in the terminal to clear the state.
+  </Accordion>
+
+  <Accordion title="Terminal shows 'Connection blocked by firewall'">
+    **Symptoms:** The terminal displays a firewall blocked message instead of connecting.
+
+    **Solutions:**
+    - Your IP address has been blocked by a firewall rule configured by your admin. Contact your admin to verify your IP is allowed.
+    - If you are connecting from a VPN or corporate network, your outbound IP may differ from what you expect. Ask your admin to check the IP address shown in the Security Center's activity log.
+    - Your admin can review blocked connection attempts in **Admin > Security > Activity**.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/rde/user/live-preview.mdx
+++ b/docs/rde/user/live-preview.mdx
@@ -21,6 +21,23 @@ Your application needs to be **running and listening on a port** for the preview
 The preview uses a secure proxy connection to your workspace. Traffic stays within your infrastructure and is not exposed publicly until you explicitly [publish](/rde/user/publishing) your application.
 </Info>
 
+## Navigation
+
+The preview panel includes **browser-like navigation controls** for moving through pages in your application:
+
+| Control | Description |
+|---------|-------------|
+| **Back arrow** | Navigate to the previous page in your browsing history within the preview |
+| **Forward arrow** | Navigate forward after going back |
+| **Port selector** | A dropdown on the left side of the URL bar showing the active port. Switch between ports if your application exposes multiple services. |
+| **Path bar** | An editable path field showing the current URL path. Edit the path and press **Enter** to navigate directly to a specific route in your application. |
+
+The navigation tracks page changes automatically, including single-page application (SPA) route transitions (pushState, replaceState, popstate, and hashchange events).
+
+<Info>
+The path bar and navigation controls may be hidden for some blueprints. Admins can toggle path bar visibility in the blueprint settings.
+</Info>
+
 ## Viewport Switching
 
 Use the **viewport icons** in the preview panel header to test your application at different screen sizes:
@@ -59,6 +76,20 @@ Click the **refresh button** in the preview header to reload the preview on dema
 - You want to see the latest state of your application after making changes
 - The preview is showing stale content
 - You need to reset application state (e.g., clear client-side state)
+
+## Public URL
+
+If your admin has enabled the **public URL** option for the blueprint, you can toggle between the proxied preview (default) and a public Qovery URL for your application.
+
+The public URL exposes your application's port through Qovery's standard ingress, making it accessible outside the portal. This is useful for:
+
+- Sharing your work-in-progress with colleagues who don't have portal access
+- Testing with external services that need to call back to your application (webhooks, OAuth callbacks)
+- Testing on a real mobile device
+
+<Warning>
+Public URLs bypass the portal's proxy and expose your application directly. Only use this when you specifically need external access. The proxied preview (default) keeps your application private to the portal.
+</Warning>
 
 ## Troubleshooting
 

--- a/docs/rde/user/using-the-editor.mdx
+++ b/docs/rde/user/using-the-editor.mdx
@@ -26,12 +26,18 @@ The top bar provides workspace-level controls:
 
 | Element | Description |
 |---------|-------------|
-| **Workspace name** | Click to rename your workspace inline |
+| **Logo** | Click the logo to navigate back to the workspace dashboard |
+| **Workspace name** | Displays the current workspace name |
 | **Status badge** | Shows the current workspace state (Running, Deploying, etc.) |
-| **History** | Open the git snapshot history panel |
-| **Preview** | Open the live preview in a new browser tab |
 | **Publish** | Start the publish workflow to deploy your application |
+| **Actions menu** | Click the ellipsis (...) icon to access workspace actions: Restart, Stop, and Delete |
 | **User avatar** | Your account menu |
+
+Note: The old History and Preview buttons have been removed from the top bar. History is accessible from within the editor, and the preview panel is always visible on the right side.
+
+<Tip>
+Click the logo in the top-left corner to return to the workspace dashboard at any time. Your workspace continues running in the background.
+</Tip>
 
 ## Terminal Tabs
 

--- a/docs/rde/user/workspace-dashboard.mdx
+++ b/docs/rde/user/workspace-dashboard.mdx
@@ -23,6 +23,8 @@ At the top of the dashboard, a **horizontal card list** displays all blueprints 
 You only see blueprints your admin has granted you access to. If no blueprints appear, contact your admin to request access.
 </Info>
 
+Blueprints in **Testing** state appear in the catalog with a **"Coming Soon"** badge. These blueprints are being validated by your admin and are not yet available to create workspaces from.
+
 ### Workspace Cards
 
 Below the catalog, your existing workspaces are displayed as **cards**. Each card shows:


### PR DESCRIPTION
## Summary

Updates the RDE Portal documentation to reflect all features developed on May 22-23, 2026 (~105 commits, 67+ files changed in the portal codebase).

### New page
- **Security Center** (`rde/admin/security-center.mdx`) -- Connection auditing, IP firewall with CIDR rules, and activity logs

### Updated pages (13)

| Page | Changes |
|------|---------|
| **blueprint-management** | Template gallery, blueprint lifecycle (testing/enabled/disabled), primary service selector, project mode (dedicated/shared), naming templates, target cluster |
| **portal-customization** | Dark/light logo variants, accent color picker with reset, unified multi-provider AI configuration (Anthropic/OpenAI/Custom accordion) |
| **workspace-management** | Cluster column and filter, infrastructure topology graph, reactive status polling |
| **live-preview** | Back/forward navigation, editable path bar with port selector, public URL toggle |
| **using-the-editor** | Simplified topbar (logo nav, actions ellipsis menu), removed old History/Preview buttons |
| **admin-setup** | Dark logo step, multi-provider AI config, blueprint admin state tip |
| **create-your-first-workspace** | Real-time SSE provisioning progress phases, updated top bar |
| **workspace-dashboard** | Coming Soon badge for testing blueprints |
| **security** | Connection auditing and IP firewall in Audit & Visibility section |
| **architecture** | Firewall/audit tables in data model, multi-cluster support |
| **troubleshooting** | Firewall blocked connection entry, browser compatibility entry |
| **overview** | Security Center, Blueprint Templates, Multi-Cluster capabilities cards |
| **docs.json** | Added security-center to For Admins navigation |

### Stats
- 14 files changed
- ~508 lines added, ~49 lines removed