### PR TITLE
fix: remove incorrect Karpenter non-production restriction note

### DIFF
--- a/docs/configuration/integrations/kubernetes/eks/managed.mdx
+++ b/docs/configuration/integrations/kubernetes/eks/managed.mdx
@@ -31,7 +31,7 @@ You can read our [blog post](https://www.qovery.com/blog/save-up-to-60-on-aws-co
 
     * **Cluster name**: enter the name of your choice for your cluster.
     * **Description**: enter a description to identify better your cluster.
-    * **Production cluster**: select this option if your cluster will be used for production. Note: Karpenter is currently only available for non-production clusters.
+    * **Production cluster**: select this option if your cluster will be used for production.
     * **Region**: select the geographical area in which you want your cluster to be hosted.
     * **Credentials**: select one of the existing cloud provider credentials or create new credentials using the section above.
 


### PR DESCRIPTION
Karpenter is available for all EKS clusters regardless of production status.