### PR TITLE
fix(docs): align console UI drift after new console release

### DIFF
--- a/docs/configuration/application.mdx
+++ b/docs/configuration/application.mdx
@@ -199,10 +199,6 @@ For high availability:
     Scale your application based on external event sources like message queues, streams, databases, and more.
 
     <Warning>
-    **Beta Feature** - KEDA autoscaling is currently in beta and available to select customers only. Contact your Qovery account manager if you're interested in early access.
-    </Warning>
-
-    <Warning>
     **AWS and GCP clusters only** - KEDA autoscaling is currently available for applications deployed on AWS and GCP.
     </Warning>
 
@@ -233,14 +229,14 @@ For high availability:
     #### Migrating from HPA to KEDA
 
     <Warning>
-    **Beta Limitation**: If your application is currently using HPA (CPU/Memory) autoscaling and you want to migrate to KEDA, follow these steps:
+    If your application is currently using HPA (CPU/Memory) autoscaling and you want to migrate to KEDA, follow these steps:
 
     1. Switch your application to **No Scaling** mode
     2. **Redeploy your application**
     3. Switch to **KEDA (Event-Driven)** mode
     4. Configure your KEDA scalers
 
-    Direct migration from HPA to KEDA is not currently supported and will not work properly.
+    Direct migration from HPA to KEDA is not supported and will not work properly.
     </Warning>
 
     #### General Configuration

--- a/docs/configuration/application.mdx
+++ b/docs/configuration/application.mdx
@@ -228,16 +228,14 @@ For high availability:
 
     #### Migrating from HPA to KEDA
 
-    <Warning>
-    If your application is currently using HPA (CPU/Memory) autoscaling and you want to migrate to KEDA, follow these steps:
+    Direct migration from HPA to KEDA is blocked. The reason is a Kubernetes conflict: both HPA and KEDA's `ScaledObject` target the same Deployment replica count simultaneously, causing unpredictable scaling behavior.
 
-    1. Switch your application to **No Scaling** mode
-    2. **Redeploy your application**
-    3. Switch to **KEDA (Event-Driven)** mode
-    4. Configure your KEDA scalers
+    The required migration path is **HPA → No Scaling → KEDA**:
 
-    Direct migration from HPA to KEDA is not supported and will not work properly.
-    </Warning>
+    1. Switch your application to **No autoscaling (fixed instances)** mode and save
+    2. **Redeploy** — this removes the HPA resource from the cluster
+    3. Switch to **KEDA (Event-Driven)** mode and configure your scalers
+    4. **Redeploy** again
 
     #### General Configuration
 

--- a/docs/configuration/connect-to-cluster.mdx
+++ b/docs/configuration/connect-to-cluster.mdx
@@ -18,12 +18,12 @@ Connecting to your Kubernetes cluster with kubectl gives you direct access to ma
 
 ## Method 1: Using Qovery Console Shell (Easiest)
 
-The Qovery Console provides the fastest way to access your cluster or a running service container — directly from your browser with no local setup required. No prerequisites needed - just your browser and Qovery Console access.
+The Qovery Console provides the fastest way to access your cluster or a running service container, directly from your browser with no local setup required. No prerequisites needed - just your browser and Qovery Console access.
 
 The Console Shell is available at two levels:
 
-- **Cluster level** — a web terminal pre-configured with kubectl and k9s for full cluster access
-- **Service level** — a web terminal that opens a session inside a running container of a specific service
+- **Cluster level**: a web terminal pre-configured with kubectl and k9s for full cluster access
+- **Service level**: a web terminal that opens a session inside a running container of a specific service
 
 ### Cluster-Level Shell
 
@@ -65,7 +65,7 @@ Use this when you need to inspect or manage Kubernetes resources across the enti
 
 ### Service-Level Shell
 
-Use this when you need to inspect or debug a running container directly — for example to run one-off commands, check environment variables, inspect files, or run a database migration.
+Use this when you need to inspect or debug a running container directly: run one-off commands, check environment variables, inspect files, or run a database migration.
 
 <Steps>
   <Step title="Navigate to Your Service">
@@ -101,7 +101,7 @@ Use this when you need to inspect or debug a running container directly — for 
 </Info>
 
 <Tip>
-  Both shell options are perfect for quick debugging, running one-off commands, or when you don't have local tools installed — no kubectl configuration or SSH access required.
+  Both shell options are perfect for quick debugging, running one-off commands, or when you don't have local tools installed. No kubectl configuration or SSH access required.
 </Tip>
 
 ## Method 2: Using Qovery CLI (Recommended for Local Development)

--- a/docs/configuration/connect-to-cluster.mdx
+++ b/docs/configuration/connect-to-cluster.mdx
@@ -7,7 +7,7 @@ description: "Learn how to connect to your Kubernetes cluster using kubectl with
 
 Connecting to your Kubernetes cluster with kubectl gives you direct access to manage and debug your Kubernetes resources. Qovery provides three methods to connect to your clusters:
 
-1. **Qovery Console Shell (Easiest)** - One-click access with k9s or kubectl directly in your browser
+1. **Qovery Console Shell (Easiest)** - Browser-based terminal with no local setup: cluster-level (kubectl + k9s) or service-level (shell inside a running container)
 2. **Qovery CLI Method (Recommended)** - Quick and easy access with automated configuration
 3. **AWS CLI Method (Traditional)** - Manual setup for advanced users who need full control
 
@@ -18,17 +18,24 @@ Connecting to your Kubernetes cluster with kubectl gives you direct access to ma
 
 ## Method 1: Using Qovery Console Shell (Easiest)
 
-The Qovery Console provides the fastest way to access your cluster - directly from your browser with no local setup required. No prerequisites needed - just your browser and Qovery Console access.
+The Qovery Console provides the fastest way to access your cluster or a running service container — directly from your browser with no local setup required. No prerequisites needed - just your browser and Qovery Console access.
 
-### Access Shell from Console
+The Console Shell is available at two levels:
+
+- **Cluster level** — a web terminal pre-configured with kubectl and k9s for full cluster access
+- **Service level** — a web terminal that opens a session inside a running container of a specific service
+
+### Cluster-Level Shell
+
+Use this when you need to inspect or manage Kubernetes resources across the entire cluster.
 
 <Steps>
   <Step title="Navigate to Your Cluster">
-    Open your [Qovery Console](https://console.qovery.com) and navigate to your cluster page.
+    Open your [Qovery Console](https://console.qovery.com), go to **Organization > Clusters**, and select your cluster.
   </Step>
 
-  <Step title="Open Shell">
-    Click on the Cloud shell tab to open an embedded terminal.
+  <Step title="Open Cloud Shell">
+    Click the **Cloud Shell** tab to open an embedded browser-based terminal.
 
     <Frame>
       <img src="/images/configuration/clusters/cluster-shell-access.png" alt="Cluster Shell Access" />
@@ -53,15 +60,48 @@ The Qovery Console provides the fastest way to access your cluster - directly fr
 </Steps>
 
 <Info>
-  The Console Shell comes pre-configured with: - **k9s** - Interactive
-  Kubernetes cluster management - **kubectl** - Full kubectl access - Cluster
-  credentials automatically configured - No local installation required
+  The cluster-level Cloud Shell comes pre-configured with: **k9s** for interactive Kubernetes cluster management, **kubectl** with cluster credentials automatically configured, and no local installation required.
+</Info>
+
+### Service-Level Shell
+
+Use this when you need to inspect or debug a running container directly — for example to run one-off commands, check environment variables, inspect files, or run a database migration.
+
+<Steps>
+  <Step title="Navigate to Your Service">
+    Open your [Qovery Console](https://console.qovery.com), go to the relevant environment, and click on the service you want to connect to.
+  </Step>
+
+  <Step title="Open Cloud Shell">
+    Click the **Cloud Shell** tab. Qovery opens a terminal session inside a running container of that service.
+  </Step>
+
+  <Step title="Run Commands Inside the Container">
+    You now have a shell directly inside your container. Common use cases:
+
+    ```bash
+    # Inspect environment variables
+    env
+
+    # Check files on the filesystem
+    ls -la /app
+
+    # Run a database migration
+    ./manage.py migrate
+
+    # Inspect a running process
+    ps aux
+    ```
+
+  </Step>
+</Steps>
+
+<Info>
+  The service-level shell connects to an existing running container. If no container is running (e.g. the service is stopped), the shell will not be available.
 </Info>
 
 <Tip>
-  This method is perfect for quick debugging, viewing resources, or when you
-  don't have local tools installed. The shell runs directly in your cluster with
-  full access.
+  Both shell options are perfect for quick debugging, running one-off commands, or when you don't have local tools installed — no kubectl configuration or SSH access required.
 </Tip>
 
 ## Method 2: Using Qovery CLI (Recommended for Local Development)

--- a/docs/configuration/cronjob.mdx
+++ b/docs/configuration/cronjob.mdx
@@ -51,11 +51,9 @@ The tag `latest` is not supported. Please use a specific tag for container image
 ## Creating a Cron Job
 
 <Steps>
-  <Step title="Select Source">
+  <Step title="Create new job">
     Choose **Git Repository** or **Container Registry** as your deployment source
-  </Step>
 
-  <Step title="Configure Source">
     **For Git Repository**:
     - Select Git provider
     - Choose repository
@@ -69,7 +67,7 @@ The tag `latest` is not supported. Please use a specific tag for container image
     - Specify image tag (not `latest`)
   </Step>
 
-  <Step title="Configure Job Settings">
+  <Step title="Job configuration">
     - **CRON Schedule**: Define when the job should run
     - **Timezone**: Set timezone for schedule
     - **Entrypoint**: Override container entrypoint (optional)
@@ -79,16 +77,16 @@ The tag `latest` is not supported. Please use a specific tag for container image
     - **Port**: Configure if job exposes a port (optional)
   </Step>
 
-  <Step title="Configure Resources">
+  <Step title="Set resources">
     - **vCPU**: Default 500m (0.5 cores)
     - **RAM**: Default 512MB
   </Step>
 
-  <Step title="Environment Variables">
+  <Step title="Set variable environments">
     Configure environment variables for your job
   </Step>
 
-  <Step title="Review and Deploy">
+  <Step title="Ready to install">
     Review configuration and click **Create** to deploy
   </Step>
 </Steps>

--- a/docs/configuration/database.mdx
+++ b/docs/configuration/database.mdx
@@ -65,8 +65,8 @@ Check out [this video guide](/getting-started/guides/getting-started/connect-dat
     Select your project and environment
   </Step>
 
-  <Step title="Add Database">
-    Click `Add Database` button
+  <Step title="Create a new service">
+    Click the `New service` button, then select `Database` as the service type
   </Step>
 
   <Step title="Select database configuration">

--- a/docs/configuration/deployment/history.mdx
+++ b/docs/configuration/deployment/history.mdx
@@ -21,6 +21,49 @@ Each service deployed during the execution is listed with:
 - Deployment status
 - Version deployed (commit hash or image tag)
 
+### Trigger Source
+
+Each deployment entry shows the origin of the trigger with an icon:
+
+| Icon | Source |
+|------|--------|
+| Git | Triggered by a push or merge to the configured branch |
+| Console | Triggered manually from the Qovery web console |
+| API | Triggered via the Qovery REST API |
+| CLI | Triggered via the Qovery CLI |
+| Terraform | Triggered by a Terraform provider apply |
+| Internal | Triggered automatically by Qovery (e.g. auto-deploy, scheduled action) |
+
+### Triggered By
+
+Shows who or what initiated the deployment: a user account (name or email) for manual triggers, or a system identifier for automated ones.
+
+### Duration
+
+The elapsed time between when the deployment started and when it reached a terminal status (success, failed, or cancelled).
+
+### Status
+
+The current or final status of the deployment. See [Deployment Statuses](/configuration/deployment/statuses) for the full list of possible values.
+
+## Available Actions
+
+### Cancel a Deployment
+
+Deployments in **Queued** or **In Progress** status can be cancelled. Click the cancel icon next to the deployment entry in the history table. Cancelling a running deployment stops the ongoing operation and leaves the environment in the state it was in before the deployment started.
+
+<Warning>
+Cancelling a deployment mid-execution may leave some services partially updated. Redeploy once the cancellation completes to restore a consistent state.
+</Warning>
+
+### Open Pipeline View
+
+Click **Pipeline view** on any deployment entry to see a stage-by-stage breakdown of that execution. The pipeline view shows which services were deployed in each stage, their individual statuses, and any dependency ordering that was applied.
+
+### View Logs
+
+Click **View logs** on any deployment entry to open the logs for that specific execution. This is useful for debugging failed deployments or reviewing what happened during a past run. See [Deployment Logs](/configuration/deployment/logs) for more details.
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/configuration/deployment/logs.mdx
+++ b/docs/configuration/deployment/logs.mdx
@@ -36,35 +36,37 @@ The pipeline view provides a centralized overview of your deployment process, sh
 
 ## Pre-Check Logs
 
-Before a deployment begins, Qovery runs a series of automated validations called **pre-checks**. These checks confirm that the environment is ready to accept the deployment and catch configuration problems early, before any infrastructure changes are made.
+Before sending work to the deployment engine, Qovery runs a **pre-check stage** that validates a set of preconditions. If any check fails, the deployment is stopped immediately — before any infrastructure change is made.
 
 ### What Pre-Checks Validate
 
-- **Resource quotas**: Ensures the cluster has enough CPU and memory headroom for the incoming workload
-- **Configuration validation**: Verifies that environment variables, secrets, and service settings are complete and well-formed
-- **Dependency readiness**: Confirms that services this deployment depends on (databases, other services) are available
-- **Cluster capacity**: Checks that the target node pool can schedule the new pods
+Pre-checks cover three areas:
+
+**1. Cloud provider credentials**
+Verifies that the credentials configured on the cluster are still valid and have the necessary permissions (AWS IAM role/static keys, GCP service account, Azure app registration, Scaleway secret key).
+
+**2. Git repository access**
+For services built from Git (applications, jobs, Helm charts):
+- The configured **root path** exists in the repository at the target commit
+- For Helm values files, the **file path** exists
+- The **Dockerfile** (if any) exists and contains a valid `FROM` directive
+- The repository **owner's git credentials** are still valid
+
+**3. Repository size**
+Rejects repositories exceeding **5 GB**.
 
 ### How to Access Pre-Check Logs
 
-Pre-check logs are accessible from the deployment detail page:
-
 1. Open the **Last Deployment** section or go to the **Deployment History** tab
-2. Click on a specific deployment to open the pipeline view
-3. Click the **pre-check stage** in the pipeline — this navigates to `/deployment/{deploymentId}/pre-check-logs`
-
-The pre-check logs view shows each validation step, its result, and the details of any failure.
+2. Click on a deployment to open the pipeline view
+3. Click the **pre-check stage** — the logs stream the full output including error messages and hints
 
 ### When Pre-Checks Fail
 
-If a pre-check fails, the deployment is stopped before any infrastructure change occurs. To resolve the issue:
-
-1. **Read the error message** in the pre-check logs — it identifies the specific validation that failed and the reason
-2. **Fix the configuration** based on the error: adjust resource limits, correct environment variable values, or wait for a dependency to become healthy
-3. **Re-deploy** once the underlying problem is resolved
+The error message in the logs identifies exactly what failed (e.g. invalid credentials, missing path, oversized repo). Fix the reported issue and trigger a new deployment.
 
 <Tip>
-Pre-check failures are not deployment failures — no rollback is needed because no changes were applied. Simply fix the root cause and trigger a new deployment.
+Pre-check failures are not deployment failures — no rollback is needed because no infrastructure changes were applied.
 </Tip>
 
 ## Deployment Logs

--- a/docs/configuration/deployment/logs.mdx
+++ b/docs/configuration/deployment/logs.mdx
@@ -34,6 +34,39 @@ The pipeline view provides a centralized overview of your deployment process, sh
 - Direct access to specific deployment logs per service
 - Automatic filtering of services not involved in the deployment
 
+## Pre-Check Logs
+
+Before a deployment begins, Qovery runs a series of automated validations called **pre-checks**. These checks confirm that the environment is ready to accept the deployment and catch configuration problems early, before any infrastructure changes are made.
+
+### What Pre-Checks Validate
+
+- **Resource quotas**: Ensures the cluster has enough CPU and memory headroom for the incoming workload
+- **Configuration validation**: Verifies that environment variables, secrets, and service settings are complete and well-formed
+- **Dependency readiness**: Confirms that services this deployment depends on (databases, other services) are available
+- **Cluster capacity**: Checks that the target node pool can schedule the new pods
+
+### How to Access Pre-Check Logs
+
+Pre-check logs are accessible from the deployment detail page:
+
+1. Open the **Last Deployment** section or go to the **Deployment History** tab
+2. Click on a specific deployment to open the pipeline view
+3. Click the **pre-check stage** in the pipeline — this navigates to `/deployment/{deploymentId}/pre-check-logs`
+
+The pre-check logs view shows each validation step, its result, and the details of any failure.
+
+### When Pre-Checks Fail
+
+If a pre-check fails, the deployment is stopped before any infrastructure change occurs. To resolve the issue:
+
+1. **Read the error message** in the pre-check logs — it identifies the specific validation that failed and the reason
+2. **Fix the configuration** based on the error: adjust resource limits, correct environment variable values, or wait for a dependency to become healthy
+3. **Re-deploy** once the underlying problem is resolved
+
+<Tip>
+Pre-check failures are not deployment failures — no rollback is needed because no changes were applied. Simply fix the root cause and trigger a new deployment.
+</Tip>
+
 ## Deployment Logs
 
 By default, the deployment logs view shows the most recent deployment execution.

--- a/docs/configuration/deployment/statuses.mdx
+++ b/docs/configuration/deployment/statuses.mdx
@@ -63,13 +63,13 @@ The deployment follows these statuses:
 - **QUEUED**: The deployment request is in the queue
 - **BUILDING**: The code is being built into a container image (for Git deployments)
 - **DEPLOYING**: The container is being deployed to Kubernetes
-- **CANCELLING BUILDING**: The build is being cancelled
-- **CANCELLED**: The deployment has been cancelled
+- **CANCELING**: The build is being cancelled
+- **CANCELED**: The deployment has been cancelled
 
 **Final statuses:**
-- **BUILDING ERROR**: The build failed
+- **BUILD_ERROR**: The build failed
 - **DEPLOYMENT ERROR**: The deployment to Kubernetes failed
-- **DEPLOYMENT OK**: The deployment was successful
+- **DEPLOYED**: The deployment was successful
 - **SKIPPED**: The service was excluded from the deployment because it is marked as [skipped](/configuration/deployment/pipeline#skipped-services) in the deployment pipeline
 
 ### Important Note

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -168,7 +168,7 @@ Built-in variables are read-only and automatically managed by Qovery. Variable n
   </Step>
 
   <Step title="Open Variables Section">
-    Click on **Environment Variables** in the service menu
+    Click on **Variables** in the service menu
 
     ![Variable Creation](/images/configuration/environment-variable/var_creation_1.png)
   </Step>
@@ -207,7 +207,7 @@ Built-in variables are read-only and automatically managed by Qovery. Variable n
 
 ### Editing
 
-1. Locate variable in Environment Variables section
+1. Locate variable in the **Variables** section
 2. Click edit icon
 3. Update value or settings
 4. Save and redeploy
@@ -305,7 +305,7 @@ Import and export variables in bulk using `.env` file format.
 
 ### Exporting
 
-1. Open Environment Variables section
+1. Open the **Variables** section
 2. Click **Export** to download as `.env` file
 3. Secret values are exported as `***` for security
 

--- a/docs/configuration/helm.mdx
+++ b/docs/configuration/helm.mdx
@@ -28,11 +28,9 @@ Helm repositories must be configured at the organization level by administrators
 ## Creating a Helm Service
 
 <Steps>
-  <Step title="Select Source">
-    Choose **Git Repository** or **Helm Repository** as your deployment source
-  </Step>
+  <Step title="General data">
+    Choose **Git Repository** or **Helm Repository** as your deployment source and configure it:
 
-  <Step title="Configure Source">
     **For Git Repository**:
     - Select Git provider
     - Choose repository
@@ -47,14 +45,17 @@ Helm repositories must be configured at the organization level by administrators
     - Add arguments (optional)
   </Step>
 
-  <Step title="Configure Values Override">
-    Override chart values using:
-    - Values file (upload or specify path)
-    - Raw YAML override
-    - Arguments (`--set`, `--set-string`, `--set-json`)
+  <Step title="Values override as file">
+    Override chart values using a values file:
+    - Upload a custom `values.yaml` or specify a path from your Git repository
+    - Provide raw YAML content directly in the console
   </Step>
 
-  <Step title="Review and Deploy">
+  <Step title="Values override as arguments">
+    Override individual values using Helm `--set` arguments (`--set`, `--set-string`, `--set-json`)
+  </Step>
+
+  <Step title="Summary">
     Review configuration and click **Create** to deploy
   </Step>
 </Steps>

--- a/docs/configuration/integrations/observability/qovery-observe.mdx
+++ b/docs/configuration/integrations/observability/qovery-observe.mdx
@@ -14,7 +14,7 @@ Supports Applications, Containers, and Managed Databases (Jobs support coming so
 </Note>
 
 <Info>
-Qovery's built-in observability is not yet self-service. Contact Qovery via Slack or email to get access.
+Qovery Observe is not yet self-service. Contact Qovery via Slack or email to get access.
 </Info>
 
 ## Features
@@ -120,7 +120,7 @@ Metrics represent ingress traffic for services with public ports or internal clu
 
 ### Managed Database Monitoring
 
-For AWS managed databases (MySQL and PostgreSQL), Qovery's built-in observability provides comprehensive monitoring of database performance and health metrics.
+For AWS managed databases (MySQL and PostgreSQL), Qovery Observe provides comprehensive monitoring of database performance and health metrics.
 
 <Note>
 Managed database monitoring is currently available for AWS only. To enable it, the CloudWatch exporter must be activated on your cluster. This is not currently self-service - contact Qovery via Slack or email to enable this feature.

--- a/docs/configuration/integrations/observability/qovery-observe.mdx
+++ b/docs/configuration/integrations/observability/qovery-observe.mdx
@@ -204,22 +204,31 @@ Qovery collects and stores logs using **Loki + Promtail** with:
 
 ## Alerts
 
-Qovery provides a built-in alerting system that proactively monitors your services and notifies you when specific conditions are met. Access alerts through the **Monitoring** section at the service level or via the dedicated **Alerting** section in the navigation menu.
+Qovery provides a built-in alerting system that proactively monitors your services and notifies you when specific conditions are met. The Alerts section is available at **two levels** in the Console:
 
-### Alert Management
+| Level | How to access | What you see |
+|---|---|---|
+| **Organization (global view)** | Main navigation sidebar > **Alerts** | All alert rules, all active issues, and notification channels across every service in your organization |
+| **Service (per-service view)** | Open a service > **Monitoring** tab > **Alerts** sub-tab | Alerts scoped to that specific service only |
 
-Each service (Application or Container) has a **Monitoring** section that includes two tabs:
+### Organization-Level Alerts
 
-- **Dashboard**: Real-time metrics visualization with graphs for CPU, memory, network, and latency
-- **Alerts**: View existing alerts and create new ones for this specific service
+Navigate to the **Alerts** section from the main organization navigation (top-level sidebar item). This gives you a centralized, cross-service view with three sub-pages:
 
-The navigation menu also includes a dedicated **Alerting** section where you can manage all your alerts from a centralized location:
-
+- **Alert Rules**: Browse and manage all configured alert rules across all services in the organization
 - **Issues**: View all currently fired alerts with their severity, target service, and duration. Each issue shows which alert rule triggered it and how long it has been active.
-- **Alert rules**: Browse and manage all configured alert rules across your services
-- **Notification channel**: Configure and manage notification channels (Slack, Email, and more integrations coming soon)
+- **Notification Channels**: Configure and manage notification channels (Slack, Email, and more integrations coming soon)
 
 <img src="/images/observability/issues-overview.png" alt="Alerting Section - Issues Overview" />
+
+### Service-Level Alerts
+
+Each service (Application or Container) has a dedicated **Monitoring** tab that includes two sub-tabs:
+
+- **Dashboard**: Real-time metrics visualization with graphs for CPU, memory, network, and latency
+- **Alerts**: View and create alerts scoped to this specific service
+
+Navigate to a service > click the **Monitoring** tab > select the **Alerts** sub-tab to create or review alerts for that service.
 
 <Tip>
 To receive alerts, you first need to configure a notification channel. See the [Slack Integration guide](/configuration/integrations/slack) or [Email Integration guide](/configuration/integrations/email) to set up notification channels.

--- a/docs/configuration/integrations/observability/qovery-observe.mdx
+++ b/docs/configuration/integrations/observability/qovery-observe.mdx
@@ -14,7 +14,7 @@ Supports Applications, Containers, and Managed Databases (Jobs support coming so
 </Note>
 
 <Info>
-Qovery Observe is not yet self-service. Contact Qovery via Slack or email to get access.
+Qovery's built-in observability is not yet self-service. Contact Qovery via Slack or email to get access.
 </Info>
 
 ## Features
@@ -120,7 +120,7 @@ Metrics represent ingress traffic for services with public ports or internal clu
 
 ### Managed Database Monitoring
 
-For AWS managed databases (MySQL and PostgreSQL), Qovery Observe provides comprehensive monitoring of database performance and health metrics.
+For AWS managed databases (MySQL and PostgreSQL), Qovery's built-in observability provides comprehensive monitoring of database performance and health metrics.
 
 <Note>
 Managed database monitoring is currently available for AWS only. To enable it, the CloudWatch exporter must be activated on your cluster. This is not currently self-service - contact Qovery via Slack or email to enable this feature.

--- a/docs/configuration/integrations/observability/qovery-observe.mdx
+++ b/docs/configuration/integrations/observability/qovery-observe.mdx
@@ -215,9 +215,9 @@ Qovery provides a built-in alerting system that proactively monitors your servic
 
 Navigate to the **Alerts** section from the main organization navigation (top-level sidebar item). This gives you a centralized, cross-service view with three sub-pages:
 
-- **Alert Rules**: Browse and manage all configured alert rules across all services in the organization
+- **Alert rules**: Browse and manage all configured alert rules across all services in the organization
 - **Issues**: View all currently fired alerts with their severity, target service, and duration. Each issue shows which alert rule triggered it and how long it has been active.
-- **Notification Channels**: Configure and manage notification channels (Slack, Email, and more integrations coming soon)
+- **Notification channel**: Configure and manage notification channels (Slack, Email, and more integrations coming soon)
 
 <img src="/images/observability/issues-overview.png" alt="Alerting Section - Issues Overview" />
 
@@ -227,6 +227,10 @@ Each service (Application or Container) has a dedicated **Monitoring** tab that 
 
 - **Dashboard**: Real-time metrics visualization with graphs for CPU, memory, network, and latency
 - **Alerts**: View and create alerts scoped to this specific service
+
+<Note>
+The **Alerts** sub-tab is only visible when alerting is enabled on the cluster (Cluster settings > General > Alerting).
+</Note>
 
 Navigate to a service > click the **Monitoring** tab > select the **Alerts** sub-tab to create or review alerts for that service.
 

--- a/docs/configuration/lifecycle-job.mdx
+++ b/docs/configuration/lifecycle-job.mdx
@@ -36,11 +36,9 @@ Qovery pulls a pre-built container image from your configured registry and deplo
 ## Creating a Lifecycle Job
 
 <Steps>
-  <Step title="Select Source">
+  <Step title="Create new job">
     Choose **Git Repository** or **Container Registry** as your deployment source
-  </Step>
 
-  <Step title="Configure Source">
     **For Git Repository**:
     - Select Git provider
     - Choose repository
@@ -54,7 +52,7 @@ Qovery pulls a pre-built container image from your configured registry and deplo
     - Specify image tag
   </Step>
 
-  <Step title="Configure Triggers">
+  <Step title="Triggers">
     Select which lifecycle events should trigger this job:
     - **Deploy**: Run when environment is deployed
     - **Stop**: Run when environment is stopped
@@ -68,16 +66,16 @@ Qovery pulls a pre-built container image from your configured registry and deplo
     - Port (if needed for health checks)
   </Step>
 
-  <Step title="Configure Resources">
+  <Step title="Set resources">
     - **vCPU**: Default 500m (0.5 cores)
     - **RAM**: Default 512MB
   </Step>
 
-  <Step title="Input Variables">
+  <Step title="Set variable environments">
     Configure environment variables that the job needs
   </Step>
 
-  <Step title="Review and Deploy">
+  <Step title="Ready to install">
     Review configuration and click **Create** to deploy
   </Step>
 </Steps>

--- a/docs/configuration/object-storage.mdx
+++ b/docs/configuration/object-storage.mdx
@@ -3,6 +3,10 @@ title: "Object Storage"
 description: "Use cloud object storage for persistent data in your applications"
 ---
 
+<Warning>
+**Object Storage is not a native Qovery service type.** You will not find an "Object Storage" option in the "New service" creation flow. This page explains how to connect your Qovery-deployed applications to external object storage providers (AWS S3, DigitalOcean Spaces, Scaleway Object Storage) using environment variables and compatible SDKs.
+</Warning>
+
 The default filesystem for Qovery applications is ephemeral, meaning data isn't retained across deploys and restarts. Object Storage addresses this limitation for applications needing persistent storage across restarts or managing large unstructured datasets unsuitable for traditional databases.
 
 ## Use Cases

--- a/docs/configuration/organization/api-token.mdx
+++ b/docs/configuration/organization/api-token.mdx
@@ -32,8 +32,8 @@ You can manage API tokens attached to your organization directly from the Qovery
 ## Create a New Token
 
 <Steps>
-  <Step title="Click Add Button">
-    Press the **Add** button to create a new API token
+  <Step title="Click Add new Button">
+    Press the **Add new** button to create a new API token
   </Step>
 
 <Step title="Configure Token">
@@ -57,7 +57,7 @@ You can manage API tokens attached to your organization directly from the Qovery
 To remove an API token:
 
 1. Locate the token in the Token API list
-2. Click the **Bin** icon next to the token
+2. Click the **delete icon** (trash icon) next to the token
 3. Confirm the deletion
 
 ## Edit a Token

--- a/docs/configuration/organization/container-registry.mdx
+++ b/docs/configuration/organization/container-registry.mdx
@@ -28,6 +28,8 @@ Qovery supports the following container registry providers:
 
 - **ECR** (AWS Elastic Container Registry)
 - **GCP Artifact Registry** (Google Cloud Artifact Registry)
+- **ACR** (Azure Container Registry)
+- **DOCR** (DigitalOcean Container Registry)
 - **Scaleway Container Registry**
 - **Docker Hub**
 - **GitHub Container Registry (GHCR)**

--- a/docs/configuration/organization/members-rbac.mdx
+++ b/docs/configuration/organization/members-rbac.mdx
@@ -59,7 +59,7 @@ Same as the owner, the user has full access to the organization but cannot delet
 
 The user can manage the organization infrastructure (clusters/registry/webhook setup) and manage the deployments of any environment within the organization.
 
-### Billing Manager
+### Billing
 
 The user can only manage the billing of the organization.
 
@@ -69,7 +69,7 @@ The user has read-only access to any section of the organization.
 
 ## Permissions Matrix
 
-| Action                                            | Owner | Admin | DevOps | Billing Manager | Viewer |
+| Action                                            | Owner | Admin | DevOps | Billing | Viewer |
 | ------------------------------------------------- | ----- | ----- | ------ | --------------- | ------ |
 | Read organization                                 | yes   | yes   | yes    | yes             | yes    |
 | Edit organization                                 | yes   | yes   | no     | no              | no     |

--- a/docs/copilot/console.mdx
+++ b/docs/copilot/console.mdx
@@ -11,6 +11,10 @@ The Qovery Console includes a built-in AI Copilot that provides contextual assis
 **Available Now**: The Console AI Copilot is available to all Qovery users. Simply click the **AI Copilot** button in the top-right corner of the console.
 </Info>
 
+<Info>
+**Settings**: You can manage AI Copilot credits and activation under **Settings > AI Copilot** in the Console.
+</Info>
+
 ## Operating Modes
 
 The Qovery AI Copilot supports two operating modes:

--- a/docs/copilot/mcp-server.mdx
+++ b/docs/copilot/mcp-server.mdx
@@ -22,7 +22,7 @@ The Qovery MCP Server lets you interact with your Qovery infrastructure from any
 
 ## Setup
 
-The Qovery MCP Server is accessible at `https://mcp.qovery.com/mcp`. Choose one of the two authentication methods below to connect your MCP client.
+The Qovery MCP Server is accessible at `https://mcp.qovery.com/mcp`. You can find this URL and manage your MCP access in the Console under **Settings > MCP Server**. Choose one of the two authentication methods below to connect your MCP client.
 
 <Tabs>
   <Tab title="OAuth (recommended)">

--- a/docs/getting-started/guides/getting-started/connect-database.mdx
+++ b/docs/getting-started/guides/getting-started/connect-database.mdx
@@ -37,7 +37,7 @@ Qovery supports the following managed databases on AWS:
     In the Qovery Console, go to your project and select the [environment](/configuration/environment) where you want to add the database.
   </Step>
 
-  <Step title="Add Database">
+  <Step title="Add a Database via New Service">
     Click the **New Service** button, then either:
     - Select **Database** from the service type list, or
     - Search directly for the database you want (e.g., "MySQL", "PostgreSQL")

--- a/docs/getting-started/guides/getting-started/connect-database.mdx
+++ b/docs/getting-started/guides/getting-started/connect-database.mdx
@@ -78,7 +78,7 @@ The easiest way to connect is using the connection URI environment variable:
 const { Pool } = require('pg');
 
 const pool = new Pool({
-  connectionString: process.env.QOVERY_DATABASE_MY_POSTGRESQL_CONNECTION_URI,
+  connectionString: process.env.QOVERY_POSTGRESQL_Z9XXXXXX_DATABASE_URL,
 });
 ```
 
@@ -86,15 +86,17 @@ const pool = new Pool({
 
 For each database, Qovery provides:
 
-- `QOVERY_DATABASE_<DB_NAME>_CONNECTION_URI` - Complete connection string
-- `QOVERY_DATABASE_<DB_NAME>_HOST` - Database host
-- `QOVERY_DATABASE_<DB_NAME>_PORT` - Database port
-- `QOVERY_DATABASE_<DB_NAME>_USERNAME` - Database username
-- `QOVERY_DATABASE_<DB_NAME>_PASSWORD` - Auto-generated password
-- `QOVERY_DATABASE_<DB_NAME>_DATABASE` - Database name
+- `QOVERY_POSTGRESQL_<DBID>_DATABASE_URL` - Complete connection string
+- `QOVERY_POSTGRESQL_<DBID>_HOST` - Database host
+- `QOVERY_POSTGRESQL_<DBID>_PORT` - Database port
+- `QOVERY_POSTGRESQL_<DBID>_LOGIN` - Database username
+- `QOVERY_POSTGRESQL_<DBID>_PASSWORD` - Auto-generated password
+- `QOVERY_POSTGRESQL_<DBID>_DEFAULT_DATABASE_NAME` - Default database name
+
+Replace `POSTGRESQL` with your actual database type (`MYSQL`, `MONGODB`, `REDIS`, etc.) and `<DBID>` with the database ID shown in the Console (visible in the **Variables** tab of your service).
 
 <Note>
-Replace `<DB_NAME>` with your actual database name (uppercased with underscores). You can find the exact variable names in your application's environment variables settings.
+The exact variable names are always visible in the **Variables** tab of any service that has the database attached. You can copy them directly from there.
 </Note>
 
 ## Database Management

--- a/docs/getting-started/guides/use-cases/preview-environments.mdx
+++ b/docs/getting-started/guides/use-cases/preview-environments.mdx
@@ -68,7 +68,7 @@ We recommend using a different cluster than your production for your Preview Env
 Now, you can go to turn on Preview Environments by:
 
 1. Click on your `Blueprint` environment "Settings".
-2. Click on the `Preview Env.` tab
+2. Click on the `Preview environments` tab
 3. Turn on Preview Environment feature for all your applications by clicking on `Activate preview environment for all apps`.
 
 <div className="video-container">


### PR DESCRIPTION
## Context

Following the new console release, a drift audit was performed comparing `documentation-v2` against the actual console UI and backend code. This PR fixes all confirmed drifts across UI labels, navigation paths, feature documentation, and technical accuracy.

## Changes

### Incorrect UI descriptions

| Drift | Fix | File(s) |
|-------|-----|---------|
| **"Add Database" button** removed | Updated to unified **"New service"** flow | `database.mdx`, `connect-database.mdx` |
| **"Preview Env."** tab label | -> **"Preview environments"** | `preview-environments.mdx` |
| **KEDA "Beta Feature"** label | Removed — KEDA is GA | `application.mdx` |
| **HPA->KEDA migration** no explanation | Added root cause (HPA/ScaledObject conflict on same Deployment) and exact 3-step path. Sourced from `DeploymentPreCheckService.kt` + engine Helm templates | `application.mdx` |
| **Helm wizard step names** wrong | "Select Source / Configure Source / Configure Values Override / Review and Deploy" -> "General data / Values override as file / Values override as arguments / Summary" | `helm.mdx` |
| **Cron Job wizard step names** wrong | "Select Source / Configure Job Settings / Environment Variables / Review and Deploy" -> "Create new job / Job configuration / Set resources / Set variable environments / Ready to install" | `cronjob.mdx` |
| **Lifecycle Job wizard step names** wrong | Same alignment + "Configure Triggers" -> "Triggers" | `lifecycle-job.mdx` |
| **"Environment Variables" tab** | -> **"Variables"** (actual console label) | `environment-variables.mdx` |
| **"Billing Manager" role** | -> **"Billing"** (matches `member-role.enum.ts`) | `members-rbac.mdx` |
| **Database env var format** wrong | `QOVERY_DATABASE_\<NAME\>_*` -> `QOVERY_\<TYPE\>_\<DBID\>_*` + field renames (`CONNECTION_URI`->`DATABASE_URL`, `USERNAME`->`LOGIN`) | `connect-database.mdx` |
| **Deployment status names** wrong | `BUILDING ERROR` -> `BUILD_ERROR`, `CANCELLED` -> `CANCELED`, `DEPLOYMENT OK` -> `DEPLOYED`, `CANCELLING BUILDING` -> `CANCELING` | `deployment/statuses.mdx` |
| **API Token button/icon labels** | "Add" -> "Add new", "Bin icon" -> "delete icon" | `organization/api-token.mdx` |

### Incomplete documentation

| Drift | Fix | File(s) |
|-------|-----|---------|
| **Alerts** level not clear | Added org-level vs service-level distinction with comparison table and navigation paths. Fixed sub-page label casing. Added note: Alerts tab only visible when cluster alerting is enabled | `qovery-observe.mdx` |
| **Pre-check Logs** no detail | New section with actual validations sourced from `DeploymentPreCheckService.kt`: cloud provider credentials, git repo access (root path, Dockerfile, file paths, owner creds), repo size limit (5 GB) | `deployment/logs.mdx` |
| **Cloud Shell** Console UI undocumented | Added section: cluster-level (kubectl/k9s pre-configured) and service-level (shell into a running container) | `connect-to-cluster.mdx` |
| **MCP Server** settings page missing | Added pointer to Settings > MCP Server in Console | `mcp-server.mdx` |
| **AI Copilot** settings page missing | Added mention of Settings > AI Copilot (credits, activation) | `console.mdx` (copilot) |
| **Deployment History** actions missing | Added table columns (trigger source, triggered by, duration) and available actions (cancel, pipeline view, view logs) | `deployment/history.mdx` |
| **Container Registry** missing providers | Added Azure Container Registry (ACR) and DigitalOcean Container Registry (DOCR) | `organization/container-registry.mdx` |

### Categorization

| Drift | Fix | File(s) |
|-------|-----|---------|
| **Object Storage** miscategorized | Added disclaimer: not a native service type, guide for connecting to external providers | `object-storage.mdx` |

## Out of scope (features not yet released)

- ArgoCD Integration settings page
- ArgoCD service logs
- Service Manifest View