### PR TITLE
docs: rename RDE Portal to AI Builder Portal, update blueprint tab structure

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -581,8 +581,8 @@
         ]
       },
       {
-        "product": "RDE Portal",
-        "description": "Self-service remote development environments for your team",
+        "product": "AI Builder Portal",
+        "description": "Self-service AI builder portal for your team on your infrastructure",
         "icon": "laptop-code",
         "tabs": [
           {

--- a/docs/getting-started/guides/use-cases/remote-development-environments.mdx
+++ b/docs/getting-started/guides/use-cases/remote-development-environments.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Remote Development Environments"
-description: "This page has moved to the Remote Dev Environments section."
+description: "This page has moved to the AI Builder Portal section."
 ---
 
 <head>
   <meta http-equiv="refresh" content="0; url=/rde/overview" />
 </head>
 
-This page has moved. If you are not redirected automatically, go to [Remote Dev Environments Portal](/rde/overview).
+This page has moved. If you are not redirected automatically, go to [AI Builder Portal](/rde/overview).

--- a/docs/getting-started/quickstart/remote-dev-environments.mdx
+++ b/docs/getting-started/quickstart/remote-dev-environments.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Remote Dev Environments"
-description: "This page has moved to the Remote Dev Environments section."
+description: "This page has moved to the AI Builder Portal section."
 ---
 
 <head>
   <meta http-equiv="refresh" content="0; url=/rde/overview" />
 </head>
 
-This page has moved. If you are not redirected automatically, go to [Remote Dev Environments Portal](/rde/overview).
+This page has moved. If you are not redirected automatically, go to [AI Builder Portal](/rde/overview).

--- a/docs/rde/admin/access-control.mdx
+++ b/docs/rde/admin/access-control.mdx
@@ -4,7 +4,7 @@ description: "Control who can create workspaces from each blueprint using ACL ru
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
@@ -37,7 +37,7 @@ The portal supports three access modes for each blueprint:
   </Step>
 
   <Step title="Go to the Access Control Tab">
-    Click the **Access Control** tab in the blueprint detail view.
+    Click the **Access** tab in the blueprint detail view.
   </Step>
 
   <Step title="Add Rules">
@@ -88,7 +88,7 @@ This would grant access to all `@company.com` employees plus two specific extern
 
 ## Removing Rules
 
-To remove an ACL rule, navigate to the blueprint's **Access Control** tab, find the rule you want to remove, and click the **delete** icon. Save your changes.
+To remove an ACL rule, navigate to the blueprint's **Access** tab, find the rule you want to remove, and click the **delete** icon. Save your changes.
 
 <Note>
 Removing all rules from a blueprint returns it to **open access** mode. Any authenticated user in your organization will be able to see and use it.

--- a/docs/rde/admin/blueprint-management.mdx
+++ b/docs/rde/admin/blueprint-management.mdx
@@ -4,12 +4,12 @@ description: "Register, configure, and manage blueprint templates for your team'
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
 
-A **blueprint** is a pre-configured workspace template. When a builder clicks "Create" in the RDE Portal, they are creating a private copy of a blueprint - pre-loaded with the right tools, the right database connections, and the right credentials for their role. They don't configure anything. They just pick a template and start building.
+A **blueprint** is a pre-configured workspace template. When a builder clicks "Create" in the AI Builder Portal, they are creating a private copy of a blueprint - pre-loaded with the right tools, the right database connections, and the right credentials for their role. They don't configure anything. They just pick a template and start building.
 
 From a technical perspective, each blueprint maps to a **Qovery project and environment**. When a builder creates a workspace, the system clones that environment into a new Qovery project scoped to that builder. The blueprint is the master template; each workspace is an isolated copy.
 
@@ -19,7 +19,7 @@ As an admin, you decide what each blueprint contains, who can access it, and wha
 
 <Steps>
   <Step title="Open the Admin Panel">
-    Navigate to **Admin > Blueprints** in the RDE Portal.
+    Navigate to **Admin > Blueprints** in the AI Builder Portal.
   </Step>
 
   <Step title="Click Register">
@@ -161,7 +161,7 @@ When a blueprint is in **Testing** state, it appears in the catalog with a "Comi
 
 By default, the portal connects terminal sessions and live preview to the first service in the blueprint environment. If your blueprint has multiple services, you can specify which service is the **primary service** - the one used for shell connections and preview.
 
-Navigate to **Admin > Blueprints > [Blueprint] > Settings** and select the primary service from the dropdown. The dropdown lists all services in the blueprint's Qovery environment.
+Navigate to **Admin > Blueprints > [Blueprint] > General** and select the primary service from the dropdown. The dropdown lists all services in the blueprint's Qovery environment.
 
 <Tip>
 Set the primary service to the container running your IDE (e.g., code-server) so that terminal sessions and live preview connect to the right service automatically.
@@ -176,7 +176,7 @@ Choose how the portal organizes Qovery projects when builders create workspaces:
 | **Dedicated** (default) | Each workspace gets its own Qovery project. Full isolation between workspaces. |
 | **Shared** | All workspaces from this blueprint share a single Qovery project. Environments are created within the shared project. Uses fewer Qovery resources. |
 
-Configure this in **Admin > Blueprints > [Blueprint] > Settings > Project Mode**.
+Configure this in **Admin > Blueprints > [Blueprint] > General**.
 
 <Info>
 Use **shared** mode when you want to reduce the number of Qovery projects in your organization. Use **dedicated** mode (default) when workspace isolation is a priority.
@@ -199,13 +199,13 @@ For example, a template of `rde-{user}-{blueprint}` for a user `alice@company.co
 Names are automatically sanitized to be Qovery-compatible (lowercase, alphanumeric, hyphens only).
 </Info>
 
-Configure naming templates in **Admin > Blueprints > [Blueprint] > Settings > Workspace Naming**.
+Configure naming templates in **Admin > Blueprints > [Blueprint] > General**.
 
 ## Target Cluster
 
 If your organization has multiple Kubernetes clusters, you can specify which cluster should be used for workspaces created from a specific blueprint.
 
-Navigate to **Admin > Blueprints > [Blueprint] > Settings > Target Cluster** and select the cluster from the dropdown. If no cluster is specified, the portal uses the default cluster.
+Navigate to **Admin > Blueprints > [Blueprint] > General** and select the target cluster from the dropdown. If no cluster is specified, the portal uses the default cluster.
 
 This is useful for:
 - **Data residency** - Route workspaces to clusters in specific regions
@@ -349,7 +349,7 @@ To use this template as your blueprint's workspace container:
 1. Create a Qovery project and environment for your blueprint
 2. Add a container service using the image from the [template repository](https://github.com/evoxmusic/remote-dev-env-template)
 3. Configure the environment variables listed below
-4. Register the environment as a blueprint in the RDE Portal
+4. Register the environment as a blueprint in the AI Builder Portal
 
 Alternatively, **fork the repository** and build a custom image tailored to your organization's needs.
 

--- a/docs/rde/admin/member-management.mdx
+++ b/docs/rde/admin/member-management.mdx
@@ -1,21 +1,21 @@
 ---
 title: "Member Management"
-description: "Invite and manage team members in the RDE Portal"
+description: "Invite and manage team members in the AI Builder Portal"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
 
-The member management page lets you control who has access to your RDE Portal and what role they have. You can invite new members, assign roles, and remove members who no longer need access.
+The member management page lets you control who has access to your AI Builder Portal and what role they have. You can invite new members, assign roles, and remove members who no longer need access.
 
 ## Inviting Members
 
 <Steps>
   <Step title="Open Member Management">
-    Navigate to **Admin > Members** in the RDE Portal.
+    Navigate to **Admin > Members** in the AI Builder Portal.
   </Step>
 
   <Step title="Click Invite">
@@ -34,7 +34,7 @@ The member management page lets you control who has access to your RDE Portal an
 When the invited user clicks the link, they log in through **Qovery SSO** using their existing Qovery credentials. No separate account creation is needed.
 
 <Info>
-The RDE Portal uses Qovery SSO for authentication. Users log in with the same credentials they use for the Qovery Console. No separate user database is needed.
+The AI Builder Portal uses Qovery SSO for authentication. Users log in with the same credentials they use for the Qovery Console. No separate user database is needed.
 </Info>
 
 ## Roles

--- a/docs/rde/admin/portal-customization.mdx
+++ b/docs/rde/admin/portal-customization.mdx
@@ -4,12 +4,12 @@ description: "Customize branding, welcome screens, and workspace layouts for you
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
 
-Make the RDE Portal your own with **custom branding**, a tailored **welcome screen**, and per-blueprint **layout configuration**. These settings let you align the portal with your company identity and control the development experience your builders get.
+Make the AI Builder Portal your own with **custom branding**, a tailored **welcome screen**, and per-blueprint **layout configuration**. These settings let you align the portal with your company identity and control the development experience your builders get.
 
 ## Branding
 
@@ -44,7 +44,7 @@ Use the welcome screen to **onboard new builders**. Explain what they can do in 
 
 ## Layout Configuration
 
-Each blueprint can have its own **layout settings** that control what builders see inside the workspace editor. Navigate to **Admin > Blueprints > [Blueprint] > Settings > Layout**.
+Each blueprint can have its own **layout settings** that control what builders see inside the workspace editor. Navigate to **Admin > Blueprints > [Blueprint] > Workspace**.
 
 ### Tabs
 
@@ -78,9 +78,28 @@ Toggle the **preview panel** visibility for the blueprint. When enabled, builder
 
 Disable the preview panel for blueprints where a live preview is not relevant (e.g., backend API services, CLI tools, data processing scripts).
 
-## AI Configuration
+## AI & Data Tab
 
-Configure AI providers for each blueprint in a single, unified settings panel. Navigate to **Admin > Blueprints > [Blueprint] > Settings > AI Configuration**.
+The AI & Data tab combines AI provider configuration and a data sources reference grid into a single view. Navigate to **Admin > Blueprints > [Blueprint] > AI & Data**.
+
+### Data Sources
+
+The AI & Data tab includes a **Data Sources** grid showing supported database types. Each tile represents a database or data warehouse that can be connected to your blueprint:
+
+<CardGroup cols={4}>
+  <Card title="PostgreSQL" icon="database" />
+  <Card title="MySQL" icon="database" />
+  <Card title="Snowflake" icon="snowflake" />
+  <Card title="BigQuery" icon="chart-simple" />
+</CardGroup>
+
+Click any tile to view setup instructions for connecting that data source to your blueprint environment. The instructions guide you through configuring the necessary environment variables and connection credentials in your Qovery blueprint environment.
+
+<Info>
+Data source connections are configured at the Qovery environment level using environment variables. The Data Sources grid provides setup guidance for each database type - the actual credentials and connection parameters are managed through your blueprint's Qovery environment configuration.
+</Info>
+
+### AI Configuration
 
 The AI configuration uses an accordion interface where each provider can be independently enabled and configured.
 

--- a/docs/rde/admin/publish-approvals.mdx
+++ b/docs/rde/admin/publish-approvals.mdx
@@ -4,7 +4,7 @@ description: "Review and approve workspace deployment requests from your team"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview

--- a/docs/rde/admin/security-center.mdx
+++ b/docs/rde/admin/security-center.mdx
@@ -4,7 +4,7 @@ description: "Monitor connections, configure IP firewall rules, and audit worksp
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
@@ -21,7 +21,7 @@ It has three tabs:
 
 <Steps>
   <Step title="Open the Admin Panel">
-    Log in to the RDE Portal as an admin and navigate to **Admin > Security Center**.
+    Log in to the AI Builder Portal as an admin and navigate to **Admin > Security Center**.
   </Step>
 
   <Step title="Select a Tab">

--- a/docs/rde/admin/workspace-management.mdx
+++ b/docs/rde/admin/workspace-management.mdx
@@ -4,7 +4,7 @@ description: "Monitor and manage all workspaces across your organization"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview

--- a/docs/rde/getting-started/admin-setup.mdx
+++ b/docs/rde/getting-started/admin-setup.mdx
@@ -1,21 +1,21 @@
 ---
 title: "Admin Setup"
-description: "Configure the RDE Portal, register blueprints, and set up access control for your team"
+description: "Configure the AI Builder Portal, register blueprints, and set up access control for your team"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is currently in preview. Setup steps may change as the product evolves.
+**Preview**: AI Builder Portal is currently in preview. Setup steps may change as the product evolves.
 </Warning>
 
 ## Overview
 
-As an admin, you configure the RDE Portal so your team can create their own workspaces. This guide walks through the complete setup - from portal configuration to inviting your first builder.
+As an admin, you configure the AI Builder Portal so your team can create their own workspaces. This guide walks through the complete setup - from portal configuration to inviting your first builder.
 
 ## Prerequisites
 
 Before starting, make sure you have:
 
-<Check>Qovery account on a **Business** or **Enterprise** plan with the **RDE Portal add-on** enabled - see [Pricing](https://www.qovery.com/pricing)</Check>
+<Check>Qovery account on a **Business** or **Enterprise** plan with the **AI Builder Portal add-on** enabled - see [Pricing](https://www.qovery.com/pricing)</Check>
 <Check>**Organization admin** access on your Qovery account</Check>
 <Check>A running Kubernetes cluster on Qovery</Check>
 <Check>At least one project with an environment to use as a blueprint template</Check>
@@ -25,7 +25,7 @@ Before starting, make sure you have:
 Connect the portal to your Qovery organization and apply your branding.
 
 <Steps>
-  <Step title="Open the RDE Portal">
+  <Step title="Open the AI Builder Portal">
     Go to [rde.qovery.com](https://rde.qovery.com) and log in with your Qovery credentials. You must have **organization admin** access to see the admin panel.
   </Step>
 
@@ -103,7 +103,7 @@ Control who can use each blueprint with access control lists (ACLs).
   </Step>
 
   <Step title="Go to Access Control">
-    Click the **Access Control** tab on the blueprint detail page.
+    Click the **Access** tab on the blueprint detail page.
   </Step>
 
   <Step title="Choose an Access Policy">
@@ -125,17 +125,23 @@ You can combine domain and email restrictions. For example, allow all `@yourcomp
 
 ## Step 4: Configure Blueprint Settings
 
-Optionally fine-tune each blueprint with AI provider configuration and workspace layout settings.
+Optionally fine-tune each blueprint using the dedicated tabs on the blueprint detail page.
 
-### AI Configuration
+### General Tab
 
-Configure AI providers for the workspace in a unified panel. Each provider can be independently enabled:
+Configure the blueprint's display name, description, target cluster, primary service, workspace project mode, and naming templates. Navigate to **Admin > Blueprints > [Blueprint] > General**.
+
+### AI & Data Tab
+
+Configure AI providers for the workspace. Each provider can be independently enabled:
 
 - **Anthropic** - Powers Claude Code and can power the Chat panel. Choose between User OAuth (builders use their own account) or API Key injection (seamless, billed to your organization).
 - **OpenAI** - Powers the Chat panel with GPT models. Requires an API key.
 - **Custom provider** - Any OpenAI-compatible API endpoint for the Chat panel. Useful for internally hosted models.
 
-### Layout
+The AI & Data tab also includes a **Data Sources** reference grid showing supported database types (PostgreSQL, MySQL, Snowflake, BigQuery, and others). Click any tile to view setup instructions for connecting that data source to your blueprint.
+
+### Workspace Tab
 
 Control which tabs appear in the workspace editor:
 
@@ -145,6 +151,10 @@ Control which tabs appear in the workspace editor:
 - **Custom commands** - admin-defined command tabs
 
 You can also **lock the layout** to prevent builders from rearranging tabs, and **toggle preview panel visibility** to show or hide the live app preview by default.
+
+### Access Tab
+
+Configure who can create workspaces from this blueprint using ACL rules. See [Step 3](#step-3-configure-access-control) above.
 
 ## Step 5: Invite Members
 

--- a/docs/rde/getting-started/create-your-first-workspace.mdx
+++ b/docs/rde/getting-started/create-your-first-workspace.mdx
@@ -4,16 +4,16 @@ description: "Spin up your first remote development environment and start buildi
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is currently in preview. Features and capabilities are under active development and may change.
+**Preview**: AI Builder Portal is currently in preview. Features and capabilities are under active development and may change.
 </Warning>
 
 ## Overview
 
-This guide walks you through creating your first workspace in the RDE Portal. You will pick a blueprint, name your workspace, and start developing - all from your browser.
+This guide walks you through creating your first workspace in the AI Builder Portal. You will pick a blueprint, name your workspace, and start developing - all from your browser.
 
 ## Prerequisites
 
-<Check>A Qovery account in an organization with the **RDE Portal add-on** enabled (Business or Enterprise plan)</Check>
+<Check>A Qovery account in an organization with the **AI Builder Portal add-on** enabled (Business or Enterprise plan)</Check>
 <Check>At least one blueprint available in the catalog (configured by your admin - see [Admin Setup](/rde/getting-started/admin-setup))</Check>
 
 ## Create a Workspace

--- a/docs/rde/overview.mdx
+++ b/docs/rde/overview.mdx
@@ -1,25 +1,25 @@
 ---
-title: "Remote Dev Environments Portal"
-description: "A self-service web portal that gives every team member their own isolated cloud development environment - no CLI or Kubernetes knowledge required."
+title: "AI Builder Portal"
+description: "A self-service web portal that gives every team member their own isolated cloud development environment with built-in AI tools - on your infrastructure, under your rules."
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is currently in preview. Features and capabilities are under active development and may change.
+**Preview**: AI Builder Portal is currently in preview. Features and capabilities are under active development and may change.
 </Warning>
 
 <Note>
-**Plan requirement**: The RDE Portal is available as an add-on on the **Business** and **Enterprise** plans. See [Qovery Pricing](https://www.qovery.com/pricing) for details.
+**Plan requirement**: The AI Builder Portal is available as an add-on on the **Business** and **Enterprise** plans. See [Qovery Pricing](https://www.qovery.com/pricing) for details.
 </Note>
 
 <Info>
 Looking for the CLI-based approach? See [Remote Development Environments with the CLI](/getting-started/guides/use-cases/remote-development-environments) for managing RDEs via `qovery rde` commands.
 </Info>
 
-## Why Remote Dev Environments?
+## Your Team Is Already Building with AI
 
-AI coding tools have turned non-technical employees into builders. Finance analysts, sales ops leads, product managers, even executives - are using tools like Lovable, Bolt.new, and Replit to build and deploy applications with company data. No ticket filed. No IT approval. No one asking where the data goes.
+AI coding tools turned everyone into builders. But the apps they ship live on infrastructure you don't control. The AI Builder Portal gives them the same one-click experience - on your cloud, under your rules.
 
-Consider the example: your finance analyst builds a retention analysis tool connected to your production database on Lovable. She didn't know she needed to ask IT. She just described what she wanted and the AI built it. The tool is live, connected to sensitive data, running on shared infrastructure you don't control - and your security team has zero visibility into it.
+Finance analysts, sales ops leads, product managers, even executives - are using tools like Lovable, Bolt.new, and Replit to build and deploy applications with company data. No ticket filed. No IT approval. No one asking where the data goes.
 
 This is shadow IT. Not the spreadsheet macros of the past - deployed web applications with database access, API keys in vendor-managed servers, and no audit trail. Every one of these apps is a compliance surface your CISO can't see.
 
@@ -28,7 +28,7 @@ This is shadow IT. Not the spreadsheet macros of the past - deployed web applica
     On external platforms, your code, API keys, and data live on shared infrastructure you don't control. No VPC peering, no private networking, no meaningful audit trail. In regulated industries - finance, healthcare, legal - this creates compliance gaps that certifications alone can't close.
   </Card>
   <Card title="The Solution" icon="shield-check">
-    The RDE Portal provides the same one-click builder experience - but on your own infrastructure, under your control. SSO, pre-configured blueprints, workspace isolation, publish approvals, full audit trails. **Secure by architecture, not by policy.**
+    The AI Builder Portal provides the same one-click builder experience - but on your own infrastructure, under your control. SSO, pre-configured blueprints, workspace isolation, publish approvals, full audit trails. **Secure by architecture, not by policy.**
   </Card>
 </CardGroup>
 
@@ -40,17 +40,17 @@ For a full analysis of the enterprise risks of Lovable, Bolt.new, and Replit, re
 
 ## Overview
 
-The Remote Dev Environments (RDE) Portal is a **self-service web application** accessible at [rde.qovery.com](https://rde.qovery.com). It lets platform engineers define blueprint environments and gives builders - engineers and non-technical team members alike - the ability to create their own isolated cloud workspaces with one click. Just log in with your Qovery account to get started.
+The AI Builder Portal is a **self-service web application** accessible at [rde.qovery.com](https://rde.qovery.com). It lets platform engineers define blueprint environments and gives builders - engineers and non-technical team members alike - the ability to create their own isolated cloud workspaces with one click. Just log in with your Qovery account to get started.
 
 The portal includes a **built-in terminal with Claude Code and OpenCode chat** for AI-assisted development, **live app preview** with viewport switching, **publish workflows** for deploying to production, and **git snapshots** for versioning your work. Authentication is handled through your existing Qovery account - no additional signup required.
 
-## Two Approaches to RDE
+## Two Approaches
 
 <CardGroup cols={2}>
   <Card title="CLI-Based Management" icon="terminal" href="/getting-started/guides/use-cases/remote-development-environments">
     **Available Now** - Platform engineers use `qovery rde` CLI commands for full control over environment provisioning, lifecycle management, and user access. Best for teams that want programmatic or automated RDE workflows.
   </Card>
-  <Card title="Self-Service Portal" icon="browser" href="https://rde.qovery.com">
+  <Card title="AI Builder Portal" icon="browser" href="https://rde.qovery.com">
     **Preview** - A web-based UI at [rde.qovery.com](https://rde.qovery.com) where builders create environments themselves. No CLI, no Kubernetes knowledge needed. Requires a **Business** or **Enterprise** plan. This is what this documentation section covers.
   </Card>
 </CardGroup>
@@ -89,7 +89,7 @@ The portal includes a **built-in terminal with Claude Code and OpenCode chat** f
 
 ## Secure by Design
 
-The RDE Portal uses a **split architecture** - the portal itself (UI and API) is hosted by Qovery at `rde.qovery.com`, while your **workspace containers run entirely on your own Kubernetes cluster**. Your cluster is never exposed to the internet - Qovery agents on your cluster initiate all connections outbound via TLS/gRPC.
+The AI Builder Portal uses a **split architecture** - the portal itself (UI and API) is hosted by Qovery at `rde.qovery.com`, while your **workspace containers run entirely on your own Kubernetes cluster**. Your cluster is never exposed to the internet - Qovery agents on your cluster initiate all connections outbound via TLS/gRPC.
 
 <CardGroup cols={2}>
   <Card title="Your Code Stays on Your Infrastructure" icon="server">
@@ -183,11 +183,28 @@ Each workspace is an isolated clone of the blueprint. One builder's workspace ca
   </Card>
 </CardGroup>
 
+## Why Not Lovable, Bolt, or Replit?
+
+External AI builder platforms give your team speed. The AI Builder Portal gives them the same speed - with the governance, security, and data residency your organization requires.
+
+| Feature | Lovable / Bolt / Replit | AI Builder Portal |
+|---------|------------------------|-------------------|
+| **One-click environments** | Yes | Yes |
+| **Built-in AI coding** | Yes | Claude Code + OpenCode |
+| **Data residency** | Vendor servers | Your Kubernetes cluster |
+| **SSO / RBAC / Audit** | No | Yes |
+| **Publish approvals** | No | Admin-controlled |
+| **Compliance posture** | Vendor-dependent | Inherits your cluster |
+
+<Info>
+For a detailed security comparison, see [Security & Data Residency](/rde/reference/security#comparison-with-hosted-alternatives).
+</Info>
+
 ## Prerequisites
 
-Before using the RDE Portal, make sure you have:
+Before using the AI Builder Portal, make sure you have:
 
-- An **active Qovery account** on a **Business** or **Enterprise** plan with the **RDE Portal add-on** enabled - see [Pricing](https://www.qovery.com/pricing)
+- An **active Qovery account** on a **Business** or **Enterprise** plan with the **AI Builder Portal add-on** enabled - see [Pricing](https://www.qovery.com/pricing)
 - A **running Kubernetes cluster** on Qovery
 - At least one **Qovery project and environment** to use as a blueprint template
 - **Organization admin access** for initial portal configuration

--- a/docs/rde/reference/architecture.mdx
+++ b/docs/rde/reference/architecture.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Architecture"
-description: "Understand how the RDE Portal works under the hood"
+description: "Understand how the AI Builder Portal works under the hood"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Architecture details may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Architecture details may change as the product evolves.
 </Warning>
 
 ## Overview
 
-The RDE Portal is a web application hosted by Qovery at [rde.qovery.com](https://rde.qovery.com). It consists of three components: a **web frontend**, an **API server** (Backend-for-Frontend), and a **database** - all managed by Qovery. The portal orchestrates workspace containers that run on **your** Kubernetes cluster.
+The AI Builder Portal is a web application hosted by Qovery at [rde.qovery.com](https://rde.qovery.com). It consists of three components: a **web frontend**, an **API server** (Backend-for-Frontend), and a **database** - all managed by Qovery. The portal orchestrates workspace containers that run on **your** Kubernetes cluster.
 
 A critical design principle: **your cluster is never exposed to the internet**. Qovery agents running on your cluster initiate all connections outbound to the Qovery control plane via TLS/gRPC. The control plane never connects inbound to your infrastructure.
 
@@ -20,7 +20,7 @@ This page explains the architecture, connectivity model, and data flow. For secu
 ```mermaid
 flowchart TB
     Browser["User's Browser"]
-    Portal["RDE Portal (rde.qovery.com)"]
+    Portal["AI Builder Portal (rde.qovery.com)"]
     CP["Qovery Control Plane"]
     Auth0["Auth0 (auth.qovery.com)"]
 
@@ -48,7 +48,7 @@ flowchart TB
 
 ## Cluster Connectivity Model
 
-This is the foundation of the RDE Portal's security architecture.
+This is the foundation of the AI Builder Portal's security architecture.
 
 Your Kubernetes cluster runs **Qovery agents** - Engine, Shell agent, and other components - that maintain persistent **outbound TLS/gRPC connections** to the Qovery control plane. Your cluster never exposes inbound ports to the internet.
 
@@ -243,7 +243,7 @@ Workspaces do not need public domains, load balancers, or ingress rules for deve
 
 ## Deployment Architecture
 
-The RDE Portal uses a **split deployment model**: the portal is hosted by Qovery as a managed service at `rde.qovery.com`, while workspace containers run on your Kubernetes cluster.
+The AI Builder Portal uses a **split deployment model**: the portal is hosted by Qovery as a managed service at `rde.qovery.com`, while workspace containers run on your Kubernetes cluster.
 
 ```mermaid
 flowchart TB
@@ -314,7 +314,7 @@ No source code, AI conversations, or application data is stored in the portal da
     How the portal keeps your data on your infrastructure with full admin control.
   </Card>
   <Card title="Troubleshooting" icon="wrench" href="/rde/reference/troubleshooting">
-    Common issues and solutions for the RDE Portal.
+    Common issues and solutions for the AI Builder Portal.
   </Card>
   <Card title="Admin Setup" icon="gear" href="/rde/getting-started/admin-setup">
     Configure the portal for your organization.

--- a/docs/rde/reference/security.mdx
+++ b/docs/rde/reference/security.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Security & Data Residency"
-description: "How the RDE Portal keeps your data on your infrastructure with full admin control"
+description: "How the AI Builder Portal keeps your data on your infrastructure with full admin control"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Security features are under active development and may evolve.
+**Preview**: AI Builder Portal is in preview. Security features are under active development and may evolve.
 </Warning>
 
 ## Overview
 
-Security is a foundational principle of the RDE Portal. The portal uses a **split architecture**: the control plane (portal UI and API) is hosted by Qovery at `rde.qovery.com`, while the **data plane** (workspace containers where your code, AI interactions, and applications run) stays **entirely on your own Kubernetes cluster**.
+Security is a foundational principle of the AI Builder Portal. The portal uses a **split architecture**: the control plane (portal UI and API) is hosted by Qovery at `rde.qovery.com`, while the **data plane** (workspace containers where your code, AI interactions, and applications run) stays **entirely on your own Kubernetes cluster**.
 
 **Your cluster is never exposed to the internet.** Qovery agents running on your cluster initiate all connections **outbound** to the Qovery control plane via TLS/gRPC. The control plane never connects inbound to your infrastructure. Source code, AI conversations, and development data never leave your cluster.
 
@@ -17,12 +17,12 @@ This page explains the security architecture in detail: the connectivity model, 
 
 ## Split Architecture: Control Plane vs. Data Plane
 
-The RDE Portal separates **orchestration** from **execution**. Qovery hosts the portal that manages the workflow. Your cluster hosts the workspaces where actual development happens.
+The AI Builder Portal separates **orchestration** from **execution**. Qovery hosts the portal that manages the workflow. Your cluster hosts the workspaces where actual development happens.
 
 ```mermaid
 flowchart TB
     subgraph Qovery["Qovery-Hosted (rde.qovery.com)"]
-        Portal["RDE Portal"]
+        Portal["AI Builder Portal"]
         DB["Database (Config Only)"]
     end
 
@@ -56,7 +56,7 @@ flowchart TB
 
 | Component | Where it runs | What it stores |
 |-----------|---------------|----------------|
-| **RDE Portal** | Qovery (rde.qovery.com) | Portal configuration (ACLs, theme, publish settings). Relays streaming traffic in memory - no code persisted. |
+| **AI Builder Portal** | Qovery (rde.qovery.com) | Portal configuration (ACLs, theme, publish settings). Relays streaming traffic in memory - no code persisted. |
 | **Portal Database** | Qovery (rde.qovery.com) | Configuration metadata only. No source code, no user data, no AI conversations. |
 | **Qovery Agents** | Your cluster | No persistent storage - agents relay traffic between the control plane and workspace containers. |
 | **Workspace containers** | Your cluster | Source code, dependencies, environment variables - isolated per user |
@@ -70,7 +70,7 @@ flowchart TB
 
 ## Cluster Connectivity Model
 
-This is the most important security property of the RDE Portal.
+This is the most important security property of the AI Builder Portal.
 
 Your Kubernetes cluster runs **Qovery agents** (Engine, Shell agent, and other components) that maintain persistent **outbound TLS/gRPC connections** to the Qovery control plane. Your cluster never exposes inbound ports to the internet - it is never directly addressable from outside your network.
 
@@ -260,7 +260,7 @@ For organizations in regulated industries - **financial services, healthcare, in
 
 When a finance analyst builds an internal tool on Lovable, that tool's code and the data it touches live on Lovable's shared infrastructure. Your auditor is not looking at Lovable's SOC 2 certificate - they are looking at your data perimeter. If company data flows through a vendor's shared cloud, you have a gap that no policy document closes.
 
-The RDE Portal solves this at the architecture level, not the policy level:
+The AI Builder Portal solves this at the architecture level, not the policy level:
 
 - **Your code never leaves your cluster.** Workspace containers run on your Kubernetes infrastructure. Source code, AI interactions, and application data stay inside your perimeter.
 - **Your cluster is never exposed.** Qovery agents initiate outbound TLS/gRPC connections to the control plane. No inbound ports. Not directly reachable from the internet. Ever.
@@ -273,13 +273,13 @@ For a CISO review, share the [Security & Data Residency](/rde/reference/security
 
 ## Comparison with Hosted Alternatives
 
-Non-technical teams across your organization are already using AI-powered builder tools like Lovable, Bolt.new, and Replit to create applications - often with company data and without IT oversight. These platforms offer consumer-grade governance: shared multi-tenant infrastructure, limited networking controls, no VPC peering, and incomplete audit trails. The RDE Portal provides the same ease of use with enterprise-grade security - your code and data stay on your infrastructure.
+Non-technical teams across your organization are already using AI-powered builder tools like Lovable, Bolt.new, and Replit to create applications - often with company data and without IT oversight. These platforms offer consumer-grade governance: shared multi-tenant infrastructure, limited networking controls, no VPC peering, and incomplete audit trails. The AI Builder Portal provides the same ease of use with enterprise-grade security - your code and data stay on your infrastructure.
 
 <Info>
 For a detailed analysis, read [Lovable, Bolt, and Replit Are Wonderful - Until Your CISO Finds Out](https://www.qovery.com/blog/lovable-bolt-replit-enterprise-limitations).
 </Info>
 
-| Aspect | RDE Portal | External AI Builders (Lovable, Bolt, Replit) |
+| Aspect | AI Builder Portal | External AI Builders (Lovable, Bolt, Replit) |
 |--------|-----------|------------------------|
 | **Where code lives** | Your Kubernetes cluster | Vendor's shared infrastructure |
 | **Where AI runs** | Your containers | Vendor's servers |
@@ -299,7 +299,7 @@ Because workspace containers run on your existing Qovery cluster, they inherit y
 
 ## Summary
 
-The RDE Portal is **secure by architecture, not by policy.** Security is not a layer added on top - it is the foundational design. The model can be summarized in three principles:
+The AI Builder Portal is **secure by architecture, not by policy.** Security is not a layer added on top - it is the foundational design. The model can be summarized in three principles:
 
 1. **Your code and data stay on your infrastructure.** Workspace containers run on your Kubernetes cluster. Source code, AI conversations, terminal history, and application data never leave your environment. The portal control plane (hosted by Qovery) manages orchestration and configuration only.
 

--- a/docs/rde/reference/troubleshooting.mdx
+++ b/docs/rde/reference/troubleshooting.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Troubleshooting"
-description: "Common issues and solutions for the RDE Portal"
+description: "Common issues and solutions for the AI Builder Portal"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Architecture details may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Architecture details may change as the product evolves.
 </Warning>
 
 ## Overview
 
-This page covers common issues you may encounter with the RDE Portal and how to resolve them. Issues are organized by category - expand the relevant section to find your problem and solution.
+This page covers common issues you may encounter with the AI Builder Portal and how to resolve them. Issues are organized by category - expand the relevant section to find your problem and solution.
 
 ## Portal Access Issues
 
@@ -56,7 +56,7 @@ This page covers common issues you may encounter with the RDE Portal and how to 
     **Symptoms:** A banner appears warning that your browser may not be fully supported.
 
     **Solutions:**
-    - The RDE Portal is optimized for **Chromium-based browsers** (Google Chrome, Microsoft Edge, Brave, Arc). Terminal rendering and WebSocket connections work best on these browsers.
+    - The AI Builder Portal is optimized for **Chromium-based browsers** (Google Chrome, Microsoft Edge, Brave, Arc). Terminal rendering and WebSocket connections work best on these browsers.
     - Firefox and Safari may work for basic portal navigation but can have issues with terminal display and live preview.
     - For the best experience, switch to a Chromium-based browser.
   </Accordion>

--- a/docs/rde/user/git-history.mdx
+++ b/docs/rde/user/git-history.mdx
@@ -4,12 +4,12 @@ description: "Save and restore your work with git snapshots"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
 
-The RDE Portal automatically tracks your work using **git snapshots**. Save your progress at any time and restore previous versions if needed. Think of snapshots as save points - you can always go back if something goes wrong.
+The AI Builder Portal automatically tracks your work using **git snapshots**. Save your progress at any time and restore previous versions if needed. Think of snapshots as save points - you can always go back if something goes wrong.
 
 ## Creating Snapshots
 

--- a/docs/rde/user/live-preview.mdx
+++ b/docs/rde/user/live-preview.mdx
@@ -4,7 +4,7 @@ description: "Preview your running application directly in the workspace editor"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview

--- a/docs/rde/user/publishing.mdx
+++ b/docs/rde/user/publishing.mdx
@@ -4,7 +4,7 @@ description: "Deploy your workspace application to a production URL"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview

--- a/docs/rde/user/using-the-editor.mdx
+++ b/docs/rde/user/using-the-editor.mdx
@@ -4,7 +4,7 @@ description: "Work with the terminal, Claude Code, and AI chat in your workspace
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview

--- a/docs/rde/user/workspace-dashboard.mdx
+++ b/docs/rde/user/workspace-dashboard.mdx
@@ -4,12 +4,12 @@ description: "Manage all your workspaces from a single dashboard"
 ---
 
 <Warning>
-**Preview**: Remote Dev Environments Portal is in preview. Features may change as the product evolves.
+**Preview**: AI Builder Portal is in preview. Features may change as the product evolves.
 </Warning>
 
 ## Overview
 
-The workspace dashboard is your home screen in the RDE Portal. It shows all your workspaces, lets you create new ones from the blueprint catalog, and provides quick actions for managing workspace lifecycle.
+The workspace dashboard is your home screen in the AI Builder Portal. It shows all your workspaces, lets you create new ones from the blueprint catalog, and provides quick actions for managing workspace lifecycle.
 
 ## Dashboard Layout
 


### PR DESCRIPTION
## Summary

Updates RDE Portal documentation to align with the rde-portal code changes and the updated marketing page at [qovery.com/solutions/remote-dev-environments](https://www.qovery.com/solutions/remote-dev-environments).

## Changes

### Product Rename (21 files)
- Renamed "Remote Dev Environments Portal" / "RDE Portal" to **AI Builder Portal** across all documentation pages and `docs.json`
- Technical identifiers (`RDE_OWNER_EMAIL`, `/rde/` URL paths, `qovery rde` CLI) kept unchanged

### Blueprint Settings Tab Restructure (4 files)
- Updated navigation paths from `> Settings > ...` to the new tab names:
  - **General** tab: primary service, project mode, naming templates, target cluster
  - **AI & Data** tab: AI provider configuration + data sources grid
  - **Workspace** tab: layout configuration (tabs, preview panel)
  - **Access** tab: ACL rules
- Restructured admin-setup.mdx Step 4 to document all new tabs

### Overview Messaging Alignment
- Updated title and hero section to match marketing page tone
- Added comparison table: AI Builder Portal vs Lovable/Bolt/Replit

### Data Sources Documentation
- Added Data Sources reference grid documentation to the AI & Data tab section in portal-customization.mdx
- Documents the instructional tiles (PostgreSQL, MySQL, Snowflake, BigQuery)

### Redirect Stubs
- Updated 2 redirect stub pages with new product name