### PR TITLE
Move ArgoCD integration under CI/CD Integrations, remove GitOps section

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -375,7 +375,8 @@
                       "configuration/integrations/ci-cd/github-actions",
                       "configuration/integrations/ci-cd/gitlab-ci",
                       "configuration/integrations/ci-cd/circleci",
-                      "configuration/integrations/ci-cd/jenkins"
+                      "configuration/integrations/ci-cd/jenkins",
+                      "configuration/integrations/argocd"
                     ]
                   }
                 ]
@@ -393,12 +394,6 @@
                   "configuration/integrations/observability/qovery-observe",
                   "configuration/integrations/observability/datadog",
                   "configuration/integrations/observability/kubecost"
-                ]
-              },
-              {
-                "group": "GitOps",
-                "pages": [
-                  "configuration/integrations/argocd"
                 ]
               },
               {


### PR DESCRIPTION
## Summary
- Moved the ArgoCD Integration page from the standalone GitOps section into CI/CD Integrations
- Removed the now-empty GitOps navigation section