### PR TITLE
docs: add Autonomous Agents documentation tab to AI Builder Portal

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -629,6 +629,7 @@
                   "rde/agents/agent-blueprints",
                   "rde/agents/managing-runs",
                   "rde/agents/linear-integration",
+                  "rde/agents/jira-integration",
                   "rde/agents/agent-template"
                 ]
               }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -618,6 +618,22 @@
             ]
           },
           {
+            "tab": "Autonomous Agents",
+            "icon": "robot",
+            "groups": [
+              {
+                "group": "Autonomous Agents",
+                "pages": [
+                  "rde/agents/overview",
+                  "rde/agents/getting-started",
+                  "rde/agents/agent-blueprints",
+                  "rde/agents/managing-runs",
+                  "rde/agents/linear-integration"
+                ]
+              }
+            ]
+          },
+          {
             "tab": "For Users",
             "icon": "user",
             "groups": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -628,7 +628,8 @@
                   "rde/agents/getting-started",
                   "rde/agents/agent-blueprints",
                   "rde/agents/managing-runs",
-                  "rde/agents/linear-integration"
+                  "rde/agents/linear-integration",
+                  "rde/agents/agent-template"
                 ]
               }
             ]

--- a/docs/rde/admin/blueprint-management.mdx
+++ b/docs/rde/admin/blueprint-management.mdx
@@ -15,6 +15,10 @@ From a technical perspective, each blueprint maps to a **Qovery project and envi
 
 As an admin, you decide what each blueprint contains, who can access it, and what it can connect to. This is where governance happens - invisibly to the builder, but completely under your control. The blueprint itself is a standard Qovery environment, managed through the Qovery Console, CLI, or [Terraform](/rde/admin/blueprint-management#managing-blueprints-with-terraform) as usual.
 
+<Info>
+Blueprints come in two types: **Workspace Blueprints** (the default, covered on this page) and **Agent Blueprints** (for autonomous AI agents). When you click "Create Blueprint", a chooser dialog lets you select the type. For agent blueprint configuration, see [Agent Blueprints](/rde/agents/agent-blueprints).
+</Info>
+
 ## Registering a Blueprint
 
 <Steps>

--- a/docs/rde/agents/agent-blueprints.mdx
+++ b/docs/rde/agents/agent-blueprints.mdx
@@ -39,7 +39,7 @@ These settings are specific to agent blueprints. They control which runtime exec
 | **In-Review State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent opens a pull request. Optional. |
 | **Needs-Human State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent fails or times out. Optional. |
 | **Max Concurrent Runs** | Number | `3` | Maximum number of issues the agent works on simultaneously. Each concurrent run launches a separate workspace. |
-| **Run Timeout** | Number (minutes) | `30` | Maximum duration for a single agent run. The workspace is stopped when the timeout is reached, and the issue transitions to the Needs-Human state if configured. |
+| **Run Timeout** | Number (minutes) | `60` | Maximum duration for a single agent run. The workspace is stopped when the timeout is reached, and the issue transitions to the Needs-Human state if configured. |
 
 ## Runtime Details
 

--- a/docs/rde/agents/agent-blueprints.mdx
+++ b/docs/rde/agents/agent-blueprints.mdx
@@ -65,6 +65,24 @@ Agent blueprints created through the wizard use these default resource allocatio
 
 The target cluster defaults to the first non-production cluster in your organization.
 
+## Git Provider Support
+
+Agent blueprints support three git providers for cloning repositories, pushing branches, and creating pull requests:
+
+| Provider | Supported |
+|----------|-----------|
+| GitHub | Yes |
+| GitLab | Yes |
+| Bitbucket | Yes |
+
+The provider is detected automatically from the repository URL configured in the blueprint. The agent template handles authentication, branch creation, and PR creation for all three providers.
+
+## Official Agent Template
+
+Agent blueprints created through the wizard use the [official agent template](https://github.com/Qovery/autonomous-agent-template) (`ghcr.io/qovery/autonomous-agent-template:latest`) as the base Docker image. This image includes all five AI runtimes, development tooling, and the autonomous entrypoint script.
+
+You can extend the template with project-specific dependencies by creating a custom Dockerfile that builds on top of the official image. See [Agent Template](/rde/agents/agent-template) for details on customization, environment variables, and the governance proxy.
+
 ## API Key Management
 
 The API key for the selected runtime is stored as an environment variable on the blueprint's Qovery environment. Different runtimes use different environment variable names - see the [Runtime Details](#runtime-details) table for the mapping.

--- a/docs/rde/agents/agent-blueprints.mdx
+++ b/docs/rde/agents/agent-blueprints.mdx
@@ -1,0 +1,115 @@
+---
+title: "Agent Blueprints"
+description: "Configure blueprints for autonomous AI agents - runtime selection, repository setup, Linear integration, and resource tuning."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+## Overview
+
+An agent blueprint is a blueprint with autonomous mode enabled. It defines which AI runtime to use, which repositories to clone, and how to connect to your project tracker. When a matching issue appears in Linear, the system launches a workspace from this blueprint and runs the agent autonomously.
+
+Agent blueprints share the same underlying infrastructure as workspace blueprints - lifecycle states, target cluster selection, and Qovery environment mapping all work the same way. See [Blueprint Management](/rde/admin/blueprint-management) for those shared concepts.
+
+## Workspace vs Agent Blueprints
+
+| Aspect | Workspace Blueprint | Agent Blueprint |
+|---|---|---|
+| **Purpose** | Human development environment | Autonomous AI agent |
+| **Trigger** | User creates workspace from catalog | Issue labeled in project tracker |
+| **Appears in catalog** | Yes | No |
+| **Additional config** | None | Runtime, repositories, Linear mapping |
+| **Lifecycle states** | Testing / Enabled / Disabled | Testing / Enabled / Disabled |
+| **Target cluster** | Configurable | Configurable |
+| **Access control** | ACLs apply | N/A (not in user catalog) |
+
+## Configuration Reference
+
+These settings are specific to agent blueprints. They control which runtime executes the agent, how the agent connects to Linear, and how many runs can execute concurrently.
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| **Autonomous Enabled** | Boolean | `false` | Enables autonomous mode on the blueprint. When disabled, the blueprint behaves as a standard workspace blueprint. |
+| **Agent Runtime** | Enum | `claude` | The AI coding runtime that drives the agent. See [Runtime Details](#runtime-details) for options. |
+| **Linear Team** | String or null | `null` | The Linear team whose issues the agent monitors. Required when autonomous mode is enabled. |
+| **Issue Label** | String | `qovery-agent-ready` | The Linear label that triggers an agent run. When an issue in the configured team receives this label, the agent claims it. |
+| **In-Progress State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent claims it. Required when autonomous mode is enabled. |
+| **In-Review State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent opens a pull request. Optional. |
+| **Needs-Human State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent fails or times out. Optional. |
+| **Max Concurrent Runs** | Number | `3` | Maximum number of issues the agent works on simultaneously. Each concurrent run launches a separate workspace. |
+| **Run Timeout** | Number (minutes) | `30` | Maximum duration for a single agent run. The workspace is stopped when the timeout is reached, and the issue transitions to the Needs-Human state if configured. |
+
+## Runtime Details
+
+Each agent blueprint specifies one AI coding runtime. The runtime determines which CLI tool runs inside the workspace and which API key environment variable is required.
+
+| Runtime | CLI Command | API Key Env Var |
+|---|---|---|
+| Claude Code | `claude -p` | `ANTHROPIC_API_KEY` |
+| OpenCode | `opencode run` | `ANTHROPIC_API_KEY` |
+| Codex | `codex --full-auto` | `OPENAI_API_KEY` |
+| Gemini CLI | `gemini -p` | `GEMINI_API_KEY` |
+| Cursor CLI | `cursor-agent` | `ANTHROPIC_API_KEY` |
+
+## Resource Defaults
+
+Agent blueprints created through the wizard use these default resource allocations. You can adjust them under **Advanced** during creation or by editing the blueprint later.
+
+| Resource | Default |
+|---|---|
+| CPU | 4000 mCPU (4 vCPU) |
+| Memory | 4096 MB (4 GB) |
+| Storage | 10 GB |
+
+The target cluster defaults to the first non-production cluster in your organization.
+
+## API Key Management
+
+The API key for the selected runtime is stored as an environment variable on the blueprint's Qovery environment. Different runtimes use different environment variable names - see the [Runtime Details](#runtime-details) table for the mapping.
+
+The key is set during blueprint creation when you enter it in the wizard. To update it later:
+
+1. Open the Qovery Console.
+2. Navigate to the project and environment backing the agent blueprint.
+3. Edit the environment variables and update the relevant API key.
+
+<Info>
+The API key is stored encrypted and injected into the workspace container at launch. It is never exposed in the portal UI after initial entry.
+</Info>
+
+## Editing Agent Blueprint Settings
+
+To modify an existing agent blueprint:
+
+1. Navigate to **Admin > Blueprints** in the portal.
+2. Click the blueprint name to open its settings.
+3. Select the **Autonomous** tab.
+
+From this tab you can:
+
+- Enable or disable autonomous mode
+- Change the AI runtime
+- Update the Linear team, issue label, and workflow state mappings
+- Adjust concurrency limits and run timeout
+
+<Warning>
+The **In-Progress State** is required for the agent to claim issues. If autonomous mode is enabled but no In-Progress state is set, the save button is disabled and the agent cannot run. Configure this field before enabling autonomous mode.
+</Warning>
+
+If the portal does not have a Linear token configured, a warning is displayed on the Autonomous tab prompting you to connect Linear first. See [Linear Integration](/rde/agents/linear-integration) for setup instructions.
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Getting Started" icon="play" href="/rde/agents/getting-started">
+    Set up your first autonomous agent from scratch.
+  </Card>
+  <Card title="Managing Runs" icon="list-check" href="/rde/agents/managing-runs">
+    Monitor active runs, review results, and troubleshoot failures.
+  </Card>
+  <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
+    Configure labels, workflow states, and issue routing.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/agent-blueprints.mdx
+++ b/docs/rde/agents/agent-blueprints.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Blueprints"
-description: "Configure blueprints for autonomous AI agents - runtime selection, repository setup, Linear integration, and resource tuning."
+description: "Configure blueprints for autonomous AI agents - runtime selection, repository setup, Linear or Jira integration, and resource tuning."
 ---
 
 import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
@@ -9,7 +9,7 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 ## Overview
 
-An agent blueprint is a blueprint with autonomous mode enabled. It defines which AI runtime to use, which repositories to clone, and how to connect to your project tracker. When a matching issue appears in Linear, the system launches a workspace from this blueprint and runs the agent autonomously.
+An agent blueprint is a blueprint with autonomous mode enabled. It defines which AI runtime to use, which repositories to clone, and how to connect to your project tracker (Linear or Jira). When a matching issue is triggered, the system launches a workspace from this blueprint and runs the agent autonomously.
 
 Agent blueprints share the same underlying infrastructure as workspace blueprints - lifecycle states, target cluster selection, and Qovery environment mapping all work the same way. See [Blueprint Management](/rde/admin/blueprint-management) for those shared concepts.
 
@@ -18,28 +18,31 @@ Agent blueprints share the same underlying infrastructure as workspace blueprint
 | Aspect | Workspace Blueprint | Agent Blueprint |
 |---|---|---|
 | **Purpose** | Human development environment | Autonomous AI agent |
-| **Trigger** | User creates workspace from catalog | Agent @mentioned or assigned on issue |
+| **Trigger** | User creates workspace from catalog | Agent triggered from a Linear or Jira issue |
 | **Appears in catalog** | Yes | No |
-| **Additional config** | None | Runtime, repositories, Linear mapping |
+| **Additional config** | None | Runtime, repositories, tracker mapping |
 | **Lifecycle states** | Testing / Enabled / Disabled | Testing / Enabled / Disabled |
 | **Target cluster** | Configurable | Configurable |
 | **Access control** | ACLs apply | N/A (not in user catalog) |
 
 ## Configuration Reference
 
-These settings are specific to agent blueprints. They control which runtime executes the agent, how the agent connects to Linear, and how many runs can execute concurrently.
+These settings are specific to agent blueprints. They control which runtime executes the agent, which tracker the agent connects to, and how many runs can execute concurrently.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
 | **Autonomous Enabled** | Boolean | `false` | Enables autonomous mode on the blueprint. When disabled, the blueprint behaves as a standard workspace blueprint. |
 | **Agent Runtime** | Enum | `claude` | The AI coding runtime that drives the agent. See [Runtime Details](#runtime-details) for options. |
-| **Linear Team** | String or null | `null` | The Linear team whose issues the agent monitors. Required when autonomous mode is enabled. |
-| **In-Progress State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent claims it. Required when autonomous mode is enabled. |
-| **In-Review State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent opens a pull request. Optional. |
-| **Needs-Human State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent fails or times out. Optional. |
+| **Provider** | Enum | `linear` | The project tracker the agent connects to: `linear` or `jira`. Defaults to whichever tracker is connected. |
+| **Team / Project** | String or null | `null` | The Linear team or Jira project whose issues the agent monitors. Required when autonomous mode is enabled. |
+| **Claimed State / Status** | String or null | `null` | The workflow state (Linear) or status (Jira) the issue transitions to when the agent claims it. Required when autonomous mode is enabled. |
+| **Review State / Status** | String or null | `null` | The state or status the issue transitions to when the agent opens a pull request. Optional. |
+| **Failed State / Status** | String or null | `null` | The state or status the issue transitions to when the agent fails or times out. Optional. |
 | **System Prompt** | String | (empty) | Optional instructions prepended to the issue context when the agent starts. Use this to provide project-specific guidance to the AI runtime. |
 | **Max Concurrent Runs** | Number | `3` | Maximum number of issues the agent works on simultaneously. Each concurrent run launches a separate workspace. |
-| **Run Timeout** | Number (minutes) | `60` | Maximum duration for a single agent run. The workspace is stopped when the timeout is reached, and the issue transitions to the Needs-Human state if configured. |
+| **Run Timeout** | Number (minutes) | `60` | Maximum duration for a single agent run. The workspace is stopped when the timeout is reached, and the issue transitions to the failed state if configured. |
+
+Tracker-specific field names and semantics differ slightly between Linear and Jira. See [Linear Integration](/rde/agents/linear-integration#workflow-state-mapping) and [Jira Integration](/rde/agents/jira-integration#status-mapping) for the exact mappings.
 
 ## Runtime Details
 
@@ -99,6 +102,8 @@ The API key is stored encrypted and injected into the workspace container at lau
 
 ## Editing Agent Blueprint Settings
 
+New agent blueprints are created from the **Admin > Agent Blueprints** page using the **Create Agent Blueprint** wizard. This page lists all agent blueprints, each tagged with a Linear or Jira provider badge.
+
 To modify an existing agent blueprint:
 
 1. Navigate to **Admin > Blueprints** in the portal.
@@ -109,14 +114,14 @@ From this tab you can:
 
 - Enable or disable autonomous mode
 - Change the AI runtime
-- Update the Linear team and workflow state mappings
+- Update the tracker's team/project and state/status mappings
 - Adjust concurrency limits and run timeout
 
 <Warning>
-The **In-Progress State** is required for the agent to claim issues. If autonomous mode is enabled but no In-Progress state is set, the save button is disabled and the agent cannot run. Configure this field before enabling autonomous mode.
+The **claimed state/status** is required for the agent to claim issues. If autonomous mode is enabled but no claimed state is set, the save button is disabled and the agent cannot run. Configure this field before enabling autonomous mode.
 </Warning>
 
-If the portal does not have Linear connected via OAuth, a warning is displayed on the Autonomous tab prompting you to connect Linear first. See [Linear Integration](/rde/agents/linear-integration#connecting-linear) for setup instructions.
+If the portal does not have the selected tracker connected via OAuth, a warning is displayed prompting you to connect it first. See [Linear Integration](/rde/agents/linear-integration#connecting-linear) or [Jira Integration](/rde/agents/jira-integration#connecting-jira) for setup instructions.
 
 ## Next Steps
 
@@ -129,5 +134,8 @@ If the portal does not have Linear connected via OAuth, a warning is displayed o
   </Card>
   <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
     Configure labels, workflow states, and issue routing.
+  </Card>
+  <Card title="Jira Integration" icon="arrows-rotate" href="/rde/agents/jira-integration">
+    Configure the project, status mapping, and assignment triggering.
   </Card>
 </CardGroup>

--- a/docs/rde/agents/agent-blueprints.mdx
+++ b/docs/rde/agents/agent-blueprints.mdx
@@ -18,7 +18,7 @@ Agent blueprints share the same underlying infrastructure as workspace blueprint
 | Aspect | Workspace Blueprint | Agent Blueprint |
 |---|---|---|
 | **Purpose** | Human development environment | Autonomous AI agent |
-| **Trigger** | User creates workspace from catalog | Issue labeled in project tracker |
+| **Trigger** | User creates workspace from catalog | Agent @mentioned or assigned on issue |
 | **Appears in catalog** | Yes | No |
 | **Additional config** | None | Runtime, repositories, Linear mapping |
 | **Lifecycle states** | Testing / Enabled / Disabled | Testing / Enabled / Disabled |
@@ -34,10 +34,10 @@ These settings are specific to agent blueprints. They control which runtime exec
 | **Autonomous Enabled** | Boolean | `false` | Enables autonomous mode on the blueprint. When disabled, the blueprint behaves as a standard workspace blueprint. |
 | **Agent Runtime** | Enum | `claude` | The AI coding runtime that drives the agent. See [Runtime Details](#runtime-details) for options. |
 | **Linear Team** | String or null | `null` | The Linear team whose issues the agent monitors. Required when autonomous mode is enabled. |
-| **Issue Label** | String | `qovery-agent-ready` | The Linear label that triggers an agent run. When an issue in the configured team receives this label, the agent claims it. |
 | **In-Progress State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent claims it. Required when autonomous mode is enabled. |
 | **In-Review State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent opens a pull request. Optional. |
 | **Needs-Human State** | String or null | `null` | The Linear workflow state the issue transitions to when the agent fails or times out. Optional. |
+| **System Prompt** | String | (empty) | Optional instructions prepended to the issue context when the agent starts. Use this to provide project-specific guidance to the AI runtime. |
 | **Max Concurrent Runs** | Number | `3` | Maximum number of issues the agent works on simultaneously. Each concurrent run launches a separate workspace. |
 | **Run Timeout** | Number (minutes) | `60` | Maximum duration for a single agent run. The workspace is stopped when the timeout is reached, and the issue transitions to the Needs-Human state if configured. |
 
@@ -109,14 +109,14 @@ From this tab you can:
 
 - Enable or disable autonomous mode
 - Change the AI runtime
-- Update the Linear team, issue label, and workflow state mappings
+- Update the Linear team and workflow state mappings
 - Adjust concurrency limits and run timeout
 
 <Warning>
 The **In-Progress State** is required for the agent to claim issues. If autonomous mode is enabled but no In-Progress state is set, the save button is disabled and the agent cannot run. Configure this field before enabling autonomous mode.
 </Warning>
 
-If the portal does not have a Linear token configured, a warning is displayed on the Autonomous tab prompting you to connect Linear first. See [Linear Integration](/rde/agents/linear-integration) for setup instructions.
+If the portal does not have Linear connected via OAuth, a warning is displayed on the Autonomous tab prompting you to connect Linear first. See [Linear Integration](/rde/agents/linear-integration#connecting-linear) for setup instructions.
 
 ## Next Steps
 

--- a/docs/rde/agents/agent-template.mdx
+++ b/docs/rde/agents/agent-template.mdx
@@ -63,6 +63,8 @@ When the portal launches a workspace from the template, the container executes a
     | Cursor CLI | `cursor-agent "<task>"` |
 
     The command is wrapped in a `timeout` using the configured run timeout. Exit code 124 indicates a timeout.
+
+    During execution, the agent can stream live progress updates to Linear via the portal's progress endpoint. These appear as real-time "thought" activities in the Linear issue, giving your team visibility into what the agent is doing.
   </Step>
 
   <Step title="Commit and push">
@@ -74,7 +76,7 @@ When the portal launches a workspace from the template, the container executes a
   </Step>
 
   <Step title="Report results">
-    The container posts a lifecycle comment on the Linear issue with the PR URL, transitions the issue to the In-Review state (if configured), and calls back to the portal API to record the result. The portal then stops the workspace.
+    The container calls back to the portal API to record the result. The portal then emits structured activities to the Linear agent session - updating the plan to completed, adding external URLs (dashboard link, PR link), and posting a response or error activity visible inline in Linear. A lifecycle comment is also posted on the issue for audit purposes. The workspace is automatically cleaned up after completion.
   </Step>
 </Steps>
 

--- a/docs/rde/agents/agent-template.mdx
+++ b/docs/rde/agents/agent-template.mdx
@@ -1,0 +1,189 @@
+---
+title: "Agent Template"
+description: "The official Docker image template for running autonomous AI agents on Qovery - architecture, environment variables, customization, and governance."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+## Overview
+
+The [autonomous agent template](https://github.com/Qovery/autonomous-agent-template) is the official Docker image for running headless AI agents on Qovery. When deployed as a workspace, the container automatically fetches a Linear issue, runs an AI agent, opens a pull request, and exits.
+
+You can use the template directly or extend it with project-specific dependencies.
+
+## Quick Start
+
+### Use the image directly
+
+```dockerfile
+FROM ghcr.io/qovery/autonomous-agent-template:latest
+
+# Add your project-specific dependencies
+RUN apt-get update && apt-get install -y your-deps
+```
+
+### Or build from source
+
+```bash
+git clone https://github.com/Qovery/autonomous-agent-template.git
+cd autonomous-agent-template
+docker build -t my-autonomous-agent .
+```
+
+Then register the image as a blueprint in the portal and enable autonomous mode. See [Getting Started](/rde/agents/getting-started) for the full walkthrough.
+
+## How the Agent Run Works
+
+When the portal launches a workspace from the template, the container executes a 7-step autonomous cycle:
+
+<Steps>
+  <Step title="Start governance proxy">
+    If configured, the entrypoint starts an HTTP proxy that intercepts all outbound traffic from the agent and applies organization policies (allowlists, secret detection, rate limiting).
+  </Step>
+
+  <Step title="Fetch the Linear issue">
+    The script reads the issue ID from environment variables, calls the Linear API, and writes the issue title and description to a task file.
+  </Step>
+
+  <Step title="Clone the repository and create a branch">
+    The target repository is cloned using the configured git token. A branch is created automatically from the issue key and title (e.g., `agent/ENG-123-fix-login-validation`).
+  </Step>
+
+  <Step title="Run the AI agent">
+    The configured runtime executes headlessly with the task file as the prompt:
+
+    | Runtime | Command |
+    |---------|---------|
+    | Claude Code | `claude -p "<task>"` |
+    | OpenCode | `opencode run "<task>"` |
+    | Codex | `codex --full-auto "<task>"` |
+    | Gemini CLI | `gemini -p "<task>"` |
+    | Cursor CLI | `cursor-agent "<task>"` |
+
+    The command is wrapped in a `timeout` using the configured run timeout. Exit code 124 indicates a timeout.
+  </Step>
+
+  <Step title="Commit and push">
+    If the agent made code changes, they are committed and pushed to the branch. If no changes were made, the run reports a failure ("no code changes").
+  </Step>
+
+  <Step title="Open a pull request">
+    A PR is created on the git provider (GitHub, GitLab, or Bitbucket) with the issue context in the body. The PR title includes the Linear issue key.
+  </Step>
+
+  <Step title="Report results">
+    The container posts a lifecycle comment on the Linear issue with the PR URL, transitions the issue to the In-Review state (if configured), and calls back to the portal API to record the result. The portal then stops the workspace.
+  </Step>
+</Steps>
+
+## Environment Variables
+
+These variables are injected automatically by the portal when it launches the workspace. You do not set them manually.
+
+| Variable | Description |
+|----------|-------------|
+| `LINEAR_API_TOKEN` | Linear API token for reading issues and posting comments |
+| `LINEAR_ISSUE_ID` | Linear issue node ID to work on |
+| `LINEAR_ISSUE_KEY` | Human-readable issue key (e.g., `ENG-123`) |
+| `RDE_AUTONOMOUS_AGENT` | Runtime to use: `claude`, `opencode`, `codex`, `gemini`, or `cursor` |
+| `RDE_RUN_CALLBACK_URL` | Portal API callback URL for reporting results |
+| `RDE_RUN_TIMEOUT_MIN` | Hard timeout for the agent run (minutes) |
+| `RDE_LINEAR_STATE_REVIEW_ID` | Linear workflow state ID for the In-Review transition (optional) |
+| `RDE_LINEAR_STATE_FAILED_ID` | Linear workflow state ID for the Needs-Human transition (optional) |
+| `ANTHROPIC_API_KEY` | API key for Claude Code, OpenCode, or Cursor runtimes |
+| `OPENAI_API_KEY` | API key for Codex runtime |
+| `GEMINI_API_KEY` | API key for Gemini CLI runtime |
+| `BLUEPRINT_GIT_REPOSITORY` | Target repository URL |
+| `BLUEPRINT_GIT_TOKEN` | Git token for clone, push, and PR creation |
+| `BLUEPRINT_GIT_PROVIDER` | Git provider: `github`, `gitlab`, or `bitbucket` |
+
+## Git Provider Support
+
+The template supports three git providers for cloning repositories, pushing branches, and creating pull requests:
+
+| Provider | Value | PR API |
+|----------|-------|--------|
+| GitHub | `github` | GitHub REST API |
+| GitLab | `gitlab` | GitLab REST API |
+| Bitbucket | `bitbucket` | Bitbucket REST API |
+
+The provider is determined by the `BLUEPRINT_GIT_PROVIDER` environment variable, which is set automatically based on the repository URL configured in the agent blueprint.
+
+## RDE Configuration
+
+The template includes a `.config.rde.qovery.yml` file that customizes which components are installed by the Qovery RDE install script. It disables web IDE components that are not needed for headless autonomous mode while keeping all AI runtimes and development tooling.
+
+**Enabled components:**
+- All AI runtimes (Claude Code, OpenCode, Codex, Cursor)
+- Development tools (Node.js, Python, Ruby, Go)
+- Git tooling (gh CLI, Qovery CLI)
+- Terminal utilities (zellij, fzf, ripgrep)
+
+**Disabled components:**
+- Code Server (web IDE) - not needed for headless mode
+- Standard entrypoint - replaced by the autonomous entrypoint
+- Browser-based extensions and resources
+
+See [Blueprint Management](/rde/admin/blueprint-management#official-workspace-template) for details on the RDE install script and `.config.rde.qovery.yml` configuration.
+
+## Agent Governance Proxy
+
+When the `RDE_PROXY_SCRIPT_GZ_B64` environment variable is set, the template starts an HTTP proxy before running the agent. This proxy intercepts all outbound HTTP/HTTPS traffic from the AI agent and enforces organization policies.
+
+The proxy supports:
+- **Allowlists** - restrict which external hosts the agent can reach
+- **Secret detection** - prevent accidental exfiltration of credentials
+- **Rate limiting** - throttle API calls to prevent abuse
+- **Kill switch** - immediately halt all agent egress
+
+The proxy runs on port 8877 and is transparent to the agent. All outbound traffic is routed through it automatically.
+
+<Info>
+The governance proxy is configured at the organization level by the Qovery team. Contact Qovery support to enable and configure proxy policies for your autonomous agents.
+</Info>
+
+## Customizing the Template
+
+To extend the template for your project:
+
+```dockerfile
+FROM ghcr.io/qovery/autonomous-agent-template:latest
+
+# Add project-specific dependencies
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    redis-tools
+
+# Add custom agent instructions
+COPY AGENTS.md /home/coder/project/AGENTS.md
+
+# Add custom scripts
+COPY my-setup.sh /usr/local/bin/my-setup.sh
+RUN chmod +x /usr/local/bin/my-setup.sh
+```
+
+Common customizations:
+- **Project dependencies** - install language-specific packages or system libraries your codebase requires
+- **Agent instructions** - add an `AGENTS.md` or `.claude/` directory with project-specific context for the AI agent
+- **Setup scripts** - run initialization steps before the agent starts (e.g., database migrations, seed data)
+- **Additional tools** - install linters, formatters, or test frameworks the agent needs
+
+<Tip>
+Keep the base image as your `FROM` layer and add customizations on top. This ensures you get updates to the AI runtimes, governance proxy, and core scripts automatically when the base image is updated.
+</Tip>
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Getting Started" icon="play" href="/rde/agents/getting-started">
+    Set up your first autonomous agent from scratch.
+  </Card>
+  <Card title="Agent Blueprints" icon="cubes" href="/rde/agents/agent-blueprints">
+    Configure runtime, repositories, and Linear integration.
+  </Card>
+  <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
+    Configure the issue flow, labels, and workflow states.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/agent-template.mdx
+++ b/docs/rde/agents/agent-template.mdx
@@ -9,7 +9,7 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 ## Overview
 
-The [autonomous agent template](https://github.com/Qovery/autonomous-agent-template) is the official Docker image for running headless AI agents on Qovery. When deployed as a workspace, the container automatically fetches a Linear issue, runs an AI agent, opens a pull request, and exits.
+The [autonomous agent template](https://github.com/Qovery/autonomous-agent-template) is the official Docker image for running headless AI agents on Qovery. When deployed as a workspace, the container automatically reads the issue context (from Linear or Jira) injected by the portal, runs an AI agent, opens a pull request, and exits.
 
 You can use the template directly or extend it with project-specific dependencies.
 
@@ -43,8 +43,8 @@ When the portal launches a workspace from the template, the container executes a
     If configured, the entrypoint starts an HTTP proxy that intercepts all outbound traffic from the agent and applies organization policies (allowlists, secret detection, rate limiting).
   </Step>
 
-  <Step title="Fetch the Linear issue">
-    The script reads the issue ID from environment variables, calls the Linear API, and writes the issue title and description to a task file.
+  <Step title="Read the issue context">
+    The portal injects the issue key, title, and description as environment variables (tracker-agnostic). The script writes them to a task file. The container talks only to the portal - no tracker token or tracker-specific identifiers are injected.
   </Step>
 
   <Step title="Clone the repository and create a branch">
@@ -64,7 +64,7 @@ When the portal launches a workspace from the template, the container executes a
 
     The command is wrapped in a `timeout` using the configured run timeout. Exit code 124 indicates a timeout.
 
-    During execution, the agent can stream live progress updates to Linear via the portal's progress endpoint. These appear as real-time "thought" activities in the Linear issue, giving your team visibility into what the agent is doing.
+    During execution, the agent can stream live progress updates via the portal's progress endpoint (`RDE_RUN_PROGRESS_URL`). The portal relays them to the tracker - as real-time "thought" activities in Linear, or as progress comments in Jira.
   </Step>
 
   <Step title="Commit and push">
@@ -72,11 +72,11 @@ When the portal launches a workspace from the template, the container executes a
   </Step>
 
   <Step title="Open a pull request">
-    A PR is created on the git provider (GitHub, GitLab, or Bitbucket) with the issue context in the body. The PR title includes the Linear issue key.
+    A PR is created on the git provider (GitHub, GitLab, or Bitbucket) with the issue context in the body. The PR title includes the issue key.
   </Step>
 
   <Step title="Report results">
-    The container calls back to the portal API to record the result. The portal then emits structured activities to the Linear agent session - updating the plan to completed, adding external URLs (dashboard link, PR link), and posting a response or error activity visible inline in Linear. A lifecycle comment is also posted on the issue for audit purposes. The workspace is automatically cleaned up after completion.
+    The container calls back to the portal API (`RDE_RUN_CALLBACK_URL`) to record the result. The portal then reports back on the tracker - in Linear, updating the agent plan, adding external URLs (dashboard link, PR link), and posting a response or error activity inline; in Jira, posting a comment and transitioning the issue status. A lifecycle comment is posted for audit purposes. The workspace is automatically cleaned up after completion.
   </Step>
 </Steps>
 
@@ -84,22 +84,30 @@ When the portal launches a workspace from the template, the container executes a
 
 These variables are injected automatically by the portal when it launches the workspace. You do not set them manually.
 
+The issue context is injected in a tracker-agnostic form. The container never receives a tracker token or tracker-specific identifiers - it reports back to the portal, which talks to Linear or Jira on its behalf.
+
 | Variable | Description |
 |----------|-------------|
-| `LINEAR_API_TOKEN` | Linear API token for reading issues and posting comments |
-| `LINEAR_ISSUE_ID` | Linear issue node ID to work on |
-| `LINEAR_ISSUE_KEY` | Human-readable issue key (e.g., `ENG-123`) |
+| `RDE_AUTONOMOUS` | Set to `1` when running in autonomous mode |
+| `RDE_AUTONOMOUS_PROVIDER` | Issue tracker for this run: `linear` or `jira` |
 | `RDE_AUTONOMOUS_AGENT` | Runtime to use: `claude`, `opencode`, `codex`, `gemini`, or `cursor` |
-| `RDE_RUN_CALLBACK_URL` | Portal API callback URL for reporting results |
+| `RDE_ISSUE_KEY` | Human-readable issue key (e.g., `ENG-123`) |
+| `RDE_ISSUE_TITLE` | Issue title |
+| `RDE_ISSUE_DESCRIPTION` | Issue description |
+| `RDE_AGENT_SYSTEM_PROMPT` | Optional system prompt from the blueprint |
+| `RDE_RUN_ID` | Unique run identifier |
+| `RDE_RUN_CALLBACK_URL` | Portal API callback URL for reporting the final result |
+| `RDE_RUN_PROGRESS_URL` | Portal endpoint for streaming live progress updates |
+| `RDE_RUN_MESSAGES_URL` | Portal endpoint for polling follow-up instructions |
 | `RDE_RUN_TIMEOUT_MIN` | Hard timeout for the agent run (minutes) |
-| `RDE_LINEAR_STATE_REVIEW_ID` | Linear workflow state ID for the In-Review transition (optional) |
-| `RDE_LINEAR_STATE_FAILED_ID` | Linear workflow state ID for the Needs-Human transition (optional) |
 | `ANTHROPIC_API_KEY` | API key for Claude Code, OpenCode, or Cursor runtimes |
 | `OPENAI_API_KEY` | API key for Codex runtime |
 | `GEMINI_API_KEY` | API key for Gemini CLI runtime |
-| `BLUEPRINT_GIT_REPOSITORY` | Target repository URL |
+| `BLUEPRINT_GIT_REPOSITORY` | Target repository URL (inherited from the blueprint environment) |
 | `BLUEPRINT_GIT_TOKEN` | Git token for clone, push, and PR creation |
 | `BLUEPRINT_GIT_PROVIDER` | Git provider: `github`, `gitlab`, or `bitbucket` |
+
+The portal also injects Qovery deploy credentials (`QOVERY_CLI_ACCESS_TOKEN`, `QOVERY_ORGANIZATION_ID`, `QOVERY_CLUSTER_ID`, `QOVERY_PROJECT_ID`) so the agent can run preview deployments.
 
 ## Git Provider Support
 
@@ -183,9 +191,9 @@ Keep the base image as your `FROM` layer and add customizations on top. This ens
     Set up your first autonomous agent from scratch.
   </Card>
   <Card title="Agent Blueprints" icon="cubes" href="/rde/agents/agent-blueprints">
-    Configure runtime, repositories, and Linear integration.
+    Configure runtime, repositories, and tracker integration.
   </Card>
-  <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
-    Configure the issue flow, labels, and workflow states.
+  <Card title="Jira Integration" icon="arrows-rotate" href="/rde/agents/jira-integration">
+    Connect Jira, map statuses, and trigger agents by assignment.
   </Card>
 </CardGroup>

--- a/docs/rde/agents/getting-started.mdx
+++ b/docs/rde/agents/getting-started.mdx
@@ -1,0 +1,149 @@
+---
+title: "Getting Started with Autonomous Agents"
+description: "Set up your first autonomous agent - from creating a blueprint to triggering your first run and reviewing the pull request."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+## Overview
+
+Autonomous agents pick up Linear issues, work on them in isolated cloud workspaces, and open pull requests - without human intervention. This guide walks you through creating an agent blueprint and triggering your first run.
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- AI Builder Portal configured - see [Admin Setup](/rde/getting-started/admin-setup)
+- A running Kubernetes cluster on Qovery
+- A Linear workspace with API access connected to the portal
+- A git repository the agent will work on
+- An API key for your chosen AI runtime (Anthropic, OpenAI, or Google)
+
+## Create an Agent Blueprint
+
+<Steps>
+  <Step title="Navigate to Blueprints">
+    Go to **Admin > Blueprints** and click **Create Blueprint**. In the type chooser dialog, select **Agent Blueprint**.
+  </Step>
+
+  <Step title="Choose a Runtime">
+    Select one of the five supported AI runtimes:
+
+    | Runtime | Command | API Key Variable |
+    |---------|---------|-----------------|
+    | Claude Code | `claude -p` | `ANTHROPIC_API_KEY` |
+    | OpenCode | `opencode run` | `ANTHROPIC_API_KEY` |
+    | Codex | `codex --full-auto` | `OPENAI_API_KEY` |
+    | Gemini CLI | `gemini -p` | `GEMINI_API_KEY` |
+    | Cursor CLI | `cursor-agent` | `ANTHROPIC_API_KEY` |
+
+    Optionally enter the API key for the selected runtime. The key is stored encrypted and injected into the workspace at launch.
+  </Step>
+
+  <Step title="Configure Repositories">
+    Add one or more git repositories the agent will work on.
+
+    For each repository:
+    - **URL** (required) - the HTTPS clone URL
+    - **Branch** - defaults to `main`
+    - **Token** - optional, required for private repositories
+
+    At least one repository URL must be provided.
+  </Step>
+
+  <Step title="Connect to Linear">
+    Configure the Linear integration that drives the agent's work queue.
+
+    **Required fields:**
+    - **Linear Team** - the team whose issues the agent will pick up
+    - **Issue Label** - the label that triggers a run (default: `qovery-agent-ready`)
+    - **In-Progress State** - the workflow state the issue transitions to when claimed by the agent
+
+    **Optional fields:**
+    - **In-Review State** - the workflow state when the agent opens a PR
+    - **Needs-Human State** - the workflow state when the agent fails or times out
+
+    **Resource limits:**
+    - **Max concurrent runs** - how many issues the agent works on simultaneously (default: `3`)
+    - **Run timeout** - maximum duration per run in minutes (default: `60`)
+
+    <Tip>
+    Under **Advanced**, you can customize the blueprint name (default: `Autonomous Agent`), description, target cluster, and resource allocation (CPU, memory, storage). The defaults - 4000 mCPU, 4096 MB memory, 10 GB storage - work well for most workloads.
+    </Tip>
+  </Step>
+
+  <Step title="Create the Blueprint">
+    Click **Create**. The portal provisions a Qovery project and environment for the agent. Once complete, the blueprint appears in your admin panel under **Admin > Blueprints**.
+  </Step>
+</Steps>
+
+## Trigger Your First Run
+
+1. Open your Linear workspace and navigate to the team you configured in the blueprint.
+2. Create or select an existing issue.
+3. Add the trigger label to the issue (e.g., `qovery-agent-ready`).
+4. The background runner picks up the labeled issue within 60 seconds.
+5. The issue automatically transitions to the **In-Progress** state, and a comment is posted on the issue confirming the agent has claimed it.
+
+<Info>
+The background runner polls Linear every 60 seconds. There may be up to a one-minute delay between labeling an issue and the agent claiming it.
+</Info>
+
+## Monitor the Run
+
+Navigate to **Admin > Agents > Runs** to watch the agent work.
+
+A run progresses through these statuses:
+
+```mermaid
+stateDiagram-v2
+    classDef qoveryPurple fill:#642DFF,color:#fff,stroke:#7C3FFF
+    [*] --> claimed:::qoveryPurple
+    claimed --> launching:::qoveryPurple
+    launching --> running:::qoveryPurple
+    running --> pr_opened:::qoveryPurple
+    running --> failed
+    running --> timed_out
+    pr_opened --> [*]
+    failed --> [*]
+    timed_out --> [*]
+```
+
+- **claimed** - the agent has picked up the issue and reserved it
+- **launching** - the cloud workspace is being provisioned
+- **running** - the AI runtime is actively working on the issue
+- **pr_opened** - the agent opened a pull request (success)
+- **failed** - the agent encountered an error
+- **timed_out** - the run exceeded the configured timeout
+
+The runs table auto-refreshes every 30 seconds. When a run completes successfully, the PR URL appears in the table.
+
+## What Happens Under the Hood
+
+<Tip>
+Here is what the system does end-to-end when an issue is labeled:
+
+1. The background runner polls Linear every 60 seconds for issues with the trigger label.
+2. It claims the issue atomically - a database constraint prevents duplicate runs for the same issue.
+3. The issue transitions to the In-Progress state and a lifecycle comment is posted.
+4. A cloud workspace launches with the configured runtime, repositories, and API key.
+5. The AI agent receives the issue title, description, and context, then works on the code.
+6. When the agent finishes, it reports the result (PR URL or error) back via a callback.
+7. The portal stops the workspace, updates the Linear issue state, and posts a final comment with the outcome.
+</Tip>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Agent Blueprints" icon="robot" href="/rde/agents/agent-blueprints">
+    Deep dive on agent blueprint configuration, runtimes, and resource tuning.
+  </Card>
+  <Card title="Managing Runs" icon="list-check" href="/rde/agents/managing-runs">
+    Monitor active runs, review logs, and handle failures.
+  </Card>
+  <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
+    Configure the issue flow, labels, and workflow state mapping.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/getting-started.mdx
+++ b/docs/rde/agents/getting-started.mdx
@@ -79,6 +79,10 @@ Before starting, make sure you have:
   </Step>
 </Steps>
 
+<Info>
+The wizard uses the [official agent template](https://github.com/Qovery/autonomous-agent-template) as the base image. For advanced customization - adding project dependencies, custom agent instructions, or setup scripts - see [Agent Template](/rde/agents/agent-template).
+</Info>
+
 ## Trigger Your First Run
 
 1. Open your Linear workspace and navigate to the team you configured in the blueprint.

--- a/docs/rde/agents/getting-started.mdx
+++ b/docs/rde/agents/getting-started.mdx
@@ -17,7 +17,7 @@ Before starting, make sure you have:
 
 - AI Builder Portal configured - see [Admin Setup](/rde/getting-started/admin-setup)
 - A running Kubernetes cluster on Qovery
-- A Linear workspace with API access connected to the portal
+- Linear connected to the portal via OAuth - see [Linear Integration](/rde/agents/linear-integration#connecting-linear)
 - A git repository the agent will work on
 - An API key for your chosen AI runtime (Anthropic, OpenAI, or Google)
 
@@ -57,8 +57,7 @@ Before starting, make sure you have:
     Configure the Linear integration that drives the agent's work queue.
 
     **Required fields:**
-    - **Linear Team** - the team whose issues the agent will pick up
-    - **Issue Label** - the label that triggers a run (default: `qovery-agent-ready`)
+    - **Linear Team** - the team whose issues the agent will respond to
     - **In-Progress State** - the workflow state the issue transitions to when claimed by the agent
 
     **Optional fields:**
@@ -68,6 +67,10 @@ Before starting, make sure you have:
     **Resource limits:**
     - **Max concurrent runs** - how many issues the agent works on simultaneously (default: `3`)
     - **Run timeout** - maximum duration per run in minutes (default: `60`)
+
+    <Info>
+    The wizard also shows a **label** field (default: `qovery-agent-ready`). This label is stored for organization and display purposes. Triggering happens when users @mention or assign the agent on an issue - not via labels.
+    </Info>
 
     <Tip>
     Under **Advanced**, you can customize the blueprint name (default: `Autonomous Agent`), description, target cluster, and resource allocation (CPU, memory, storage). The defaults - 4000 mCPU, 4096 MB memory, 10 GB storage - work well for most workloads.
@@ -86,13 +89,13 @@ The wizard uses the [official agent template](https://github.com/Qovery/autonomo
 ## Trigger Your First Run
 
 1. Open your Linear workspace and navigate to the team you configured in the blueprint.
-2. Create or select an existing issue.
-3. Add the trigger label to the issue (e.g., `qovery-agent-ready`).
-4. The background runner picks up the labeled issue within 60 seconds.
-5. The issue automatically transitions to the **In-Progress** state, and a comment is posted on the issue confirming the agent has claimed it.
+2. Open an existing issue or create a new one.
+3. **@mention the agent** in a comment, or **assign the agent** to the issue.
+4. The agent responds within seconds - a plan with four steps appears directly in the Linear issue.
+5. The issue automatically transitions to the **In-Progress** state.
 
 <Info>
-The background runner polls Linear every 60 seconds. There may be up to a one-minute delay between labeling an issue and the agent claiming it.
+The agent is triggered by @mention or assignment, not by labels. The response is instant - driven by webhooks, not polling.
 </Info>
 
 ## Monitor the Run
@@ -124,18 +127,21 @@ stateDiagram-v2
 
 The runs table auto-refreshes every 30 seconds. When a run completes successfully, the PR URL appears in the table.
 
+You can also follow the agent's progress directly in the Linear issue, where it posts a real-time plan and status updates as structured activities.
+
 ## What Happens Under the Hood
 
 <Tip>
-Here is what the system does end-to-end when an issue is labeled:
+Here is what the system does end-to-end when the agent is triggered:
 
-1. The background runner polls Linear every 60 seconds for issues with the trigger label.
-2. It claims the issue atomically - a database constraint prevents duplicate runs for the same issue.
-3. The issue transitions to the In-Progress state and a lifecycle comment is posted.
-4. A cloud workspace launches with the configured runtime, repositories, and API key.
-5. The AI agent receives the issue title, description, and context, then works on the code.
-6. When the agent finishes, it reports the result (PR URL or error) back via a callback.
-7. The portal stops the workspace, updates the Linear issue state, and posts a final comment with the outcome.
+1. A user @mentions or assigns the agent on a Linear issue.
+2. Linear sends a webhook to the portal. The session handler acknowledges within 10 seconds.
+3. The handler finds the matching agent blueprint by the issue's team.
+4. It claims the issue atomically - a database constraint prevents duplicate runs.
+5. A 4-step plan appears in the Linear issue, and the issue transitions to the In-Progress state.
+6. A cloud workspace launches with the configured runtime, repositories, and API key.
+7. The AI agent works on the code, streaming live progress updates to the Linear issue.
+8. When the agent finishes, the portal updates the plan, posts the PR link (or error), transitions the issue state, and cleans up the workspace.
 </Tip>
 
 ## Next Steps

--- a/docs/rde/agents/getting-started.mdx
+++ b/docs/rde/agents/getting-started.mdx
@@ -9,7 +9,7 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 ## Overview
 
-Autonomous agents pick up Linear issues, work on them in isolated cloud workspaces, and open pull requests - without human intervention. This guide walks you through creating an agent blueprint and triggering your first run.
+Autonomous agents pick up Linear or Jira issues, work on them in isolated cloud workspaces, and open pull requests - without human intervention. This guide walks you through creating an agent blueprint and triggering your first run.
 
 ## Prerequisites
 
@@ -17,15 +17,15 @@ Before starting, make sure you have:
 
 - AI Builder Portal configured - see [Admin Setup](/rde/getting-started/admin-setup)
 - A running Kubernetes cluster on Qovery
-- Linear connected to the portal via OAuth - see [Linear Integration](/rde/agents/linear-integration#connecting-linear)
+- Linear connected via OAuth (see [Linear Integration](/rde/agents/linear-integration#connecting-linear)) **or** Jira connected via OAuth (see [Jira Integration](/rde/agents/jira-integration#connecting-jira))
 - A git repository the agent will work on
 - An API key for your chosen AI runtime (Anthropic, OpenAI, or Google)
 
 ## Create an Agent Blueprint
 
 <Steps>
-  <Step title="Navigate to Blueprints">
-    Go to **Admin > Blueprints** and click **Create Blueprint**. In the type chooser dialog, select **Agent Blueprint**.
+  <Step title="Open the Agent Blueprints page">
+    Go to **Admin > Agent Blueprints** and click **Create Agent Blueprint** to open the wizard.
   </Step>
 
   <Step title="Choose a Runtime">
@@ -53,24 +53,36 @@ Before starting, make sure you have:
     At least one repository URL must be provided.
   </Step>
 
-  <Step title="Connect to Linear">
-    Configure the Linear integration that drives the agent's work queue.
+  <Step title="Configure the Issue Tracker">
+    In the third step, select the **Issue Tracker** provider. The selector defaults to whichever tracker is connected (Jira if only Jira is connected, otherwise Linear).
 
-    **Required fields:**
-    - **Linear Team** - the team whose issues the agent will respond to
-    - **In-Progress State** - the workflow state the issue transitions to when claimed by the agent
+    <Tabs>
+      <Tab title="Linear">
+        **Required fields:**
+        - **Linear Team** - the team whose issues the agent will respond to
+        - **In-Progress State** - the workflow state the issue transitions to when claimed by the agent
 
-    **Optional fields:**
-    - **In-Review State** - the workflow state when the agent opens a PR
-    - **Needs-Human State** - the workflow state when the agent fails or times out
+        **Optional fields:**
+        - **In-Review State** - the workflow state when the agent opens a PR
+        - **Needs-Human State** - the workflow state when the agent fails or times out
+        - **Issue Label** - default `qovery-agent-ready`, stored for organization and display. Triggering happens when users @mention or assign the agent on an issue, not via labels.
+      </Tab>
+      <Tab title="Jira">
+        **Required fields:**
+        - **Jira Project** - the project whose issues the agent will respond to
+        - **Claimed Status** - the status the issue transitions to when claimed by the agent
 
-    **Resource limits:**
+        **Optional fields:**
+        - **Review Status** - the status when the agent opens a PR
+        - **Failed Status** - the status when the agent fails or times out
+
+        Jira runs are triggered by assigning an issue to the agent's Jira user. There is no label field.
+      </Tab>
+    </Tabs>
+
+    **Resource limits (both trackers):**
     - **Max concurrent runs** - how many issues the agent works on simultaneously (default: `3`)
     - **Run timeout** - maximum duration per run in minutes (default: `60`)
-
-    <Info>
-    The wizard also shows a **label** field (default: `qovery-agent-ready`). This label is stored for organization and display purposes. Triggering happens when users @mention or assign the agent on an issue - not via labels.
-    </Info>
 
     <Tip>
     Under **Advanced**, you can customize the blueprint name (default: `Autonomous Agent`), description, target cluster, and resource allocation (CPU, memory, storage). The defaults - 4000 mCPU, 4096 MB memory, 10 GB storage - work well for most workloads.
@@ -78,7 +90,7 @@ Before starting, make sure you have:
   </Step>
 
   <Step title="Create the Blueprint">
-    Click **Create**. The portal provisions a Qovery project and environment for the agent. Once complete, the blueprint appears in your admin panel under **Admin > Blueprints**.
+    Click **Create**. The portal provisions a Qovery project and environment for the agent. Once complete, the blueprint appears under **Admin > Agent Blueprints**, tagged with a Linear or Jira provider badge.
   </Step>
 </Steps>
 
@@ -88,14 +100,25 @@ The wizard uses the [official agent template](https://github.com/Qovery/autonomo
 
 ## Trigger Your First Run
 
-1. Open your Linear workspace and navigate to the team you configured in the blueprint.
-2. Open an existing issue or create a new one.
-3. **@mention the agent** in a comment, or **assign the agent** to the issue.
-4. The agent responds within seconds - a plan with four steps appears directly in the Linear issue.
-5. The issue automatically transitions to the **In-Progress** state.
+<Tabs>
+  <Tab title="Linear">
+    1. Open your Linear workspace and navigate to the team you configured in the blueprint.
+    2. Open an existing issue or create a new one.
+    3. **@mention the agent** in a comment, or **assign the agent** to the issue.
+    4. The agent responds within seconds - a plan with four steps appears directly in the Linear issue.
+    5. The issue automatically transitions to the **In-Progress** state.
+  </Tab>
+  <Tab title="Jira">
+    1. Open your Jira project and navigate to the project you configured in the blueprint.
+    2. Open an existing issue or create a new one.
+    3. **Assign the issue to the agent's Jira user.**
+    4. The agent claims the issue and posts a comment confirming it has started.
+    5. The issue automatically transitions to the **Claimed** status.
+  </Tab>
+</Tabs>
 
 <Info>
-The agent is triggered by @mention or assignment, not by labels. The response is instant - driven by webhooks, not polling.
+The agent is triggered by assignment (or @mention in Linear), not by labels. The response is driven by webhooks, not polling.
 </Info>
 
 ## Monitor the Run
@@ -127,21 +150,21 @@ stateDiagram-v2
 
 The runs table auto-refreshes every 30 seconds. When a run completes successfully, the PR URL appears in the table.
 
-You can also follow the agent's progress directly in the Linear issue, where it posts a real-time plan and status updates as structured activities.
+You can also follow the agent's progress directly on the issue. In Linear, it posts a real-time plan and status updates as structured agent activities; in Jira, it posts progress comments and transitions the issue status.
 
 ## What Happens Under the Hood
 
 <Tip>
 Here is what the system does end-to-end when the agent is triggered:
 
-1. A user @mentions or assigns the agent on a Linear issue.
-2. Linear sends a webhook to the portal. The session handler acknowledges within 10 seconds.
-3. The handler finds the matching agent blueprint by the issue's team.
+1. A user triggers the agent on an issue (@mention or assignment in Linear; assignment to the agent user in Jira).
+2. The tracker sends a webhook to the portal, which the session handler verifies and acknowledges quickly.
+3. The handler finds the matching agent blueprint by the issue's team (Linear) or project (Jira).
 4. It claims the issue atomically - a database constraint prevents duplicate runs.
-5. A 4-step plan appears in the Linear issue, and the issue transitions to the In-Progress state.
+5. The issue transitions to the claimed state, and progress reporting begins (a 4-step plan in Linear, or a comment in Jira).
 6. A cloud workspace launches with the configured runtime, repositories, and API key.
-7. The AI agent works on the code, streaming live progress updates to the Linear issue.
-8. When the agent finishes, the portal updates the plan, posts the PR link (or error), transitions the issue state, and cleans up the workspace.
+7. The AI agent works on the code, streaming live progress updates back to the issue.
+8. When the agent finishes, the portal posts the PR link (or error), transitions the issue state, and cleans up the workspace.
 </Tip>
 
 ## Next Steps
@@ -155,5 +178,8 @@ Here is what the system does end-to-end when the agent is triggered:
   </Card>
   <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
     Configure the issue flow, labels, and workflow state mapping.
+  </Card>
+  <Card title="Jira Integration" icon="arrows-rotate" href="/rde/agents/jira-integration">
+    Connect Jira, map statuses, and trigger agents by assignment.
   </Card>
 </CardGroup>

--- a/docs/rde/agents/jira-integration.mdx
+++ b/docs/rde/agents/jira-integration.mdx
@@ -1,0 +1,212 @@
+---
+title: "Jira Integration"
+description: "Connect autonomous agents to Jira via OAuth for assignment-driven issue resolution with comment and status-transition updates."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+## Overview
+
+Autonomous agents integrate with Jira via OAuth 2.0 (3LO). When a user assigns a Jira issue to the agent's Jira user, Jira sends a webhook to the portal, which claims the issue, launches a workspace, and reports progress back on the issue as comments and workflow status transitions. No polling and no labels are required for triggering.
+
+Unlike Linear, Jira has no native agent-activity UI, so all progress is reported through issue comments and status transitions.
+
+## Connecting Jira
+
+<Steps>
+  <Step title="Open settings">
+    Navigate to **Admin > Settings** in the portal.
+  </Step>
+  <Step title="Add to Jira">
+    In the **Jira Agent** section, click the **Add to Jira** button.
+  </Step>
+  <Step title="Authorize the agent">
+    Authorize the Qovery agent on Atlassian's consent screen. The agent requests the following scopes: `read:jira-work`, `write:jira-work`, `read:jira-user`, `offline_access`, and `read:me`.
+  </Step>
+  <Step title="Confirm connection">
+    You are redirected back to the portal. A green **Jira connected** badge confirms the connection.
+  </Step>
+</Steps>
+
+On connect, the portal resolves your Jira site (cloud ID) and the agent app's account ID, stores the OAuth tokens encrypted, and automatically registers a webhook. The token auto-refreshes automatically - no manual token management is required.
+
+<Warning>
+Without a connected Jira site, agent blueprints configured for Jira cannot respond to issues.
+</Warning>
+
+## How the Issue Flow Works
+
+The following diagram shows the end-to-end flow from assigning the agent on an issue to receiving a pull request.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Jira as Jira
+    participant Portal as Portal Session Handler
+    participant DB as Database
+    participant WS as Workspace
+
+    Dev->>Jira: Assigns issue to the agent user
+    Jira->>Portal: issue_updated webhook (JWT-verified)
+    Portal->>Portal: Verifies JWT
+    Portal->>Portal: Responds 200 fast, processes async
+    Portal->>Portal: Detects assignee change to the agent account
+    Portal->>Portal: Finds matching blueprint by project
+    Portal->>DB: Claims issue atomically
+    Note over DB: UNIQUE constraint on<br/>(org_id, provider, issue_id)<br/>prevents duplicates
+    Portal->>Jira: Posts a comment ("starting work")
+    Portal->>Jira: Transitions issue to Claimed status
+    Portal->>WS: Launches workspace with agent config
+
+    WS->>Jira: Posts milestone progress comments
+
+    alt Success
+        WS->>Portal: Callback with PR URL
+        Portal->>Jira: Posts comment with PR link
+        Portal->>Jira: Transitions issue to Review status
+        Portal->>WS: Keeps workspace briefly, then cleans up
+    else Failure or Timeout
+        WS->>Portal: Callback with error
+        Portal->>Jira: Posts comment with failure reason
+        Portal->>Jira: Transitions issue to Failed status
+        Portal->>WS: Deletes workspace
+    end
+
+    style Dev fill:#642DFF,color:#fff
+    style Jira fill:#7C3FFF,color:#fff
+    style Portal fill:#965FFF,color:#fff
+    style DB fill:#B080FF,color:#fff
+    style WS fill:#7C3FFF,color:#fff
+```
+
+## Configuring the Project
+
+Each agent blueprint monitors one Jira project. Only issues from the configured project are picked up by that blueprint.
+
+The project dropdown in the blueprint wizard uses the OAuth connection to list all available projects. To monitor multiple projects, create separate agent blueprints - one per project.
+
+| Blueprint Setting | Value |
+|---|---|
+| **Jira Project** | Required. The project whose issues the agent monitors. |
+
+## Status Mapping
+
+Agent blueprints map three Jira statuses to key moments in the run lifecycle. These transitions keep your Jira board in sync with agent activity.
+
+### Claimed Status (required)
+
+Set when the agent claims the issue and begins work. This signals to the team that work has started.
+
+The blueprint cannot function without this status configured.
+
+### Review Status (optional)
+
+Set when the agent successfully opens a pull request. If not configured, the issue status is not changed on success - only a comment with the PR URL is posted.
+
+### Failed Status (optional)
+
+Set when the agent fails or the run times out. If not configured, the issue status is not changed on failure - only a comment with the failure reason is posted.
+
+```mermaid
+stateDiagram-v2
+    classDef purple fill:#642DFF,color:#fff,stroke:#7C3FFF
+    classDef midPurple fill:#7C3FFF,color:#fff,stroke:#965FFF
+    classDef lightPurple fill:#965FFF,color:#fff,stroke:#B080FF
+    classDef successState fill:#7C3FFF,color:#fff,stroke:#642DFF
+    classDef failState fill:#B080FF,color:#fff,stroke:#965FFF
+
+    [*] --> Backlog:::purple : Issue created
+    Backlog --> Assigned:::midPurple : Issue assigned to agent
+    Assigned --> Claimed:::lightPurple : Agent claims issue
+    Claimed --> Review:::successState : PR opened (optional)
+    Claimed --> Failed:::failState : Failed / timed out (optional)
+```
+
+| Status | Required | When Set | Fallback if Not Configured |
+|---|---|---|---|
+| **Claimed** | Yes | Agent claims the issue | Blueprint will not process issues |
+| **Review** | No | Agent opens a PR | Comment posted, status unchanged |
+| **Failed** | No | Agent fails or times out | Comment posted, status unchanged |
+
+## Progress Reporting in Jira
+
+Jira has no native agent UI, so the agent reports progress through issue comments alongside the status transitions above.
+
+| Moment | Reported As |
+|---|---|
+| **Started** | Comment "Qovery agent is starting work..." + transition to Claimed status |
+| **Workspace launched** | Comment with the agent runtime and the RDE dashboard link |
+| **Progress** | Milestone comments as the run proceeds |
+| **PR opened** | Comment with the pull request link + transition to Review status |
+| **Failed** | Comment with the failure reason + transition to Failed status |
+| **Timed out** | Comment noting the timeout + transition to Failed status |
+| **Stopped** | Comment "Stopped working on this issue." |
+
+<Info>
+Comments authored by the agent are ignored by the webhook handler to prevent feedback loops.
+</Info>
+
+## Interacting with Agents from Jira
+
+### Follow-up Instructions
+
+While an agent is running, users can post follow-up instructions as comments on the Jira issue. The agent processes these messages and can adjust its approach. If the run has already reached a terminal state (PR opened, failed, or timed out), a follow-up comment revives it by launching a fresh workspace with the new instruction.
+
+### Stop Signal
+
+There are two ways to stop a running agent from Jira:
+
+| Action | Effect |
+|---|---|
+| Post a comment containing `/stop` | Stops the workspace and marks the run as failed |
+| Unassign the issue from the agent user | Stops the workspace and marks the run as failed |
+
+When stopped, the portal stops the environment, records the reason, and posts a "Stopped working on this issue." comment.
+
+<Tip>
+This gives your team a way to guide autonomous agents without leaving Jira. If an agent is heading in the wrong direction, post a clarifying comment or unassign the issue to stop it.
+</Tip>
+
+## Concurrency and Timing
+
+### Max Concurrent Runs
+
+Each blueprint has a configurable concurrency cap (default: **3**). When the number of active runs (status `claimed`, `launching`, or `running`) reaches this limit, incoming webhooks for that blueprint are queued until a slot opens.
+
+### Run Timeout
+
+Each run has a maximum duration (default: **60 minutes**). When the timeout is reached, the workspace is stopped, the run status is set to `timed_out`, and a comment is posted on the Jira issue. If a Failed status is configured, the issue transitions to that status.
+
+### Atomic Claiming
+
+When the webhook fires, the session handler claims the issue atomically via a database unique constraint on `(org_id, provider, issue_id)`. This prevents duplicate runs even if the assignment event fires multiple times on the same issue.
+
+## Webhook Security and Lifecycle
+
+Incoming Jira webhooks are verified as JWTs signed with the agent app's client secret (HS256, with a required expiry claim). Atlassian webhooks expire after 30 days, so the portal automatically refreshes the registered webhook on a daily background job. No action is required on your part.
+
+## Disconnecting Jira
+
+To disconnect, navigate to **Admin > Settings** and click the **Disconnect** link under the **Jira Agent** section. This revokes the OAuth tokens and removes the organization mapping. Existing runs are not affected, but no new runs can be triggered.
+
+## Future Integrations
+
+<Info>
+**GitHub Issues** integration is planned. If you need a specific integration, contact the Qovery team.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Agent Blueprints" icon="cubes" href="/rde/agents/agent-blueprints">
+    Configure blueprints that define how agents run, including runtimes, repositories, and resource limits.
+  </Card>
+  <Card title="Managing Runs" icon="list-check" href="/rde/agents/managing-runs">
+    Monitor active runs, review results, and troubleshoot failures.
+  </Card>
+  <Card title="Getting Started" icon="play" href="/rde/agents/getting-started">
+    Set up your first autonomous agent from scratch.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/linear-integration.mdx
+++ b/docs/rde/agents/linear-integration.mdx
@@ -171,7 +171,7 @@ Each blueprint has a configurable concurrency cap (default: **3**). When the num
 
 ### Run Timeout
 
-Each run has a maximum duration (default: **30 minutes**). When the timeout is reached, the workspace is stopped, the run status is set to `timed_out`, and a lifecycle comment is posted on the Linear issue. If a Needs-Human state is configured, the issue transitions to that state.
+Each run has a maximum duration (default: **60 minutes**). When the timeout is reached, the workspace is stopped, the run status is set to `timed_out`, and a lifecycle comment is posted on the Linear issue. If a Needs-Human state is configured, the issue transitions to that state.
 
 ### Atomic Claiming
 

--- a/docs/rde/agents/linear-integration.mdx
+++ b/docs/rde/agents/linear-integration.mdx
@@ -159,6 +159,23 @@ All comments are posted by the **Qovery Autonomous Agent** bot identity (`autono
 Lifecycle comments are append-only. The system never edits or deletes previous comments, preserving a complete history of agent activity on each issue.
 </Info>
 
+## Controlling Agents from Linear
+
+Once an agent is running, you can control it directly from the Linear issue by posting a comment with one of these commands:
+
+| Command | Action |
+|---------|--------|
+| `/stop` | Stop the agent and its workspace environment |
+| `/restart` | Restart the workspace environment |
+| `/delete` | Stop the agent and mark the run as done |
+| `/status` | Show the current agent status and workspace state |
+
+Commands are processed by the portal and take effect within seconds. The system posts a confirmation comment on the issue when the action completes.
+
+<Tip>
+This gives your team a way to manage autonomous agents without leaving Linear. If an agent is heading in the wrong direction, a developer can `/stop` it, update the issue description with more context, and let the agent retry.
+</Tip>
+
 ## Concurrency and Timing
 
 ### Polling Interval

--- a/docs/rde/agents/linear-integration.mdx
+++ b/docs/rde/agents/linear-integration.mdx
@@ -11,7 +11,7 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 Autonomous agents integrate with Linear via OAuth. When a user @mentions or assigns the agent on a Linear issue, Linear sends a webhook to the portal, which instantly claims the issue, launches a workspace, and streams progress back to Linear. No polling and no labels are required for triggering.
 
-Linear is the currently supported project tracker. Jira and GitHub Issues integrations are planned.
+Linear and Jira are both supported. For Jira, see [Jira Integration](/rde/agents/jira-integration).
 
 ## Connecting Linear
 
@@ -211,10 +211,10 @@ When the webhook fires, the session handler claims the issue atomically via a da
 
 To disconnect, navigate to **Admin > Settings** and click the **Disconnect** link under the **Autonomous Agent** section. This revokes the OAuth tokens and removes the organization mapping. Existing runs are not affected, but no new runs can be triggered.
 
-## Future Integrations
+## Other Trackers
 
 <Info>
-**Jira** and **GitHub Issues** integrations are planned. The agent blueprint configuration will be extended with additional project tracker options. If you need a specific integration, contact the Qovery team.
+**Jira** is also supported - see [Jira Integration](/rde/agents/jira-integration). A **GitHub Issues** integration is planned. If you need a specific integration, contact the Qovery team.
 </Info>
 
 ## Next Steps

--- a/docs/rde/agents/linear-integration.mdx
+++ b/docs/rde/agents/linear-integration.mdx
@@ -1,0 +1,204 @@
+---
+title: "Linear Integration"
+description: "Connect autonomous agents to Linear for issue-driven development - API setup, issue flow, state mapping, lifecycle comments, and concurrency."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+## Overview
+
+Autonomous agents are triggered by issues in your project tracker. When an issue is labeled with the configured trigger label, the system claims it, launches an agent workspace, and reports results back - including posting lifecycle comments and transitioning workflow states.
+
+Linear is currently the supported project tracker. Jira and GitHub Issues integrations are planned.
+
+## Connecting Linear
+
+The Linear API token is configured in the portal admin settings. This token gives the system read/write access to your Linear workspace - it uses it to fetch issues, post comments, transition workflow states, and read team and label metadata.
+
+The token must have access to:
+
+- **Issues** - read and write (to fetch issue details and update state)
+- **Comments** - write (to post lifecycle comments)
+- **Labels** - read (to match trigger labels)
+- **Workflow states** - read (to populate state dropdowns in blueprint configuration)
+- **Teams** - read (to populate team dropdowns in blueprint configuration)
+
+<Warning>
+Without a valid Linear API token configured in the portal, agent blueprints cannot pick up issues. The background runner skips blueprints when the token is missing or invalid.
+</Warning>
+
+## How the Issue Flow Works
+
+The following diagram shows the end-to-end flow from labeling an issue to receiving a pull request.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Linear as Linear
+    participant Runner as Background Runner
+    participant DB as Database
+    participant WS as Workspace
+
+    Dev->>Linear: Labels issue with trigger label
+    
+    loop Every 60 seconds
+        Runner->>Linear: Polls for issues with trigger label
+    end
+
+    Runner->>DB: Claims issue (atomic insert)
+    Note over DB: UNIQUE constraint on<br/>(org_id, linear_issue_id)<br/>prevents duplicates
+
+    Runner->>Linear: Transitions issue to In-Progress
+    Runner->>Linear: Posts "claimed" comment
+    Runner->>WS: Launches workspace with agent config
+
+    WS->>WS: Agent works on the issue
+
+    alt Success
+        WS->>Runner: Callback with PR URL
+        Runner->>Linear: Posts comment with PR URL
+        Runner->>Linear: Transitions to In-Review state
+    else Failure or Timeout
+        WS->>Runner: Callback with error
+        Runner->>Linear: Posts comment with failure reason
+        Runner->>Linear: Transitions to Needs-Human state
+    end
+
+    Runner->>WS: Stops workspace
+
+    style Dev fill:#642DFF,color:#fff
+    style Linear fill:#7C3FFF,color:#fff
+    style Runner fill:#965FFF,color:#fff
+    style DB fill:#B080FF,color:#fff
+    style WS fill:#7C3FFF,color:#fff
+```
+
+## Configuring Teams
+
+Each agent blueprint monitors one Linear team. Only issues from the configured team are picked up by that blueprint.
+
+The team dropdown in the blueprint settings lists all teams accessible via the configured API token. To monitor multiple teams, create separate agent blueprints - one per team.
+
+| Blueprint Setting | Value |
+|---|---|
+| **Linear Team** | Required. The team whose issues the agent monitors. |
+
+## Configuring the Trigger Label
+
+The trigger label determines which issues within the configured team are picked up by the agent. Only issues that have both the correct team **and** the trigger label are candidates for a run.
+
+| Blueprint Setting | Default | Description |
+|---|---|---|
+| **Issue Label** | `qovery-agent-ready` | The Linear label that triggers an agent run. |
+
+The label dropdown in the blueprint settings lists all labels available in your Linear workspace. You can use any existing label or create a dedicated one.
+
+<Tip>
+Using a dedicated label like `qovery-agent-ready` keeps the trigger explicit. Avoid reusing labels that are applied automatically by other workflows, as this could trigger unintended agent runs.
+</Tip>
+
+## Workflow State Mapping
+
+Agent blueprints map three Linear workflow states to key moments in the run lifecycle. These state transitions keep your Linear board in sync with agent activity.
+
+### In-Progress State (required)
+
+Set when the agent claims the issue. This signals to the team that work has started and prevents the issue from being picked up by another agent or assigned manually.
+
+The blueprint cannot function without this state configured. If autonomous mode is enabled but no In-Progress state is set, the blueprint will not process issues.
+
+### In-Review State (optional)
+
+Set when the agent successfully opens a pull request. If not configured, the issue state is not changed on success - only a lifecycle comment with the PR URL is posted.
+
+### Needs-Human State (optional)
+
+Set when the agent fails or the run times out. If not configured, the issue state is not changed on failure - only a lifecycle comment with the failure reason is posted.
+
+```mermaid
+stateDiagram-v2
+    classDef purple fill:#642DFF,color:#fff,stroke:#7C3FFF
+    classDef midPurple fill:#7C3FFF,color:#fff,stroke:#965FFF
+    classDef lightPurple fill:#965FFF,color:#fff,stroke:#B080FF
+    classDef successState fill:#7C3FFF,color:#fff,stroke:#642DFF
+    classDef failState fill:#B080FF,color:#fff,stroke:#965FFF
+
+    [*] --> Backlog:::purple : Issue created
+    Backlog --> Labeled:::midPurple : Trigger label added
+    Labeled --> InProgress:::lightPurple : Agent claims issue
+    InProgress --> InReview:::successState : PR opened (optional)
+    InProgress --> NeedsHuman:::failState : Failed / timed out (optional)
+```
+
+| State | Required | When Set | Fallback if Not Configured |
+|---|---|---|---|
+| **In-Progress** | Yes | Agent claims the issue | Blueprint will not process issues |
+| **In-Review** | No | Agent opens a PR | Comment posted, state unchanged |
+| **Needs-Human** | No | Agent fails or times out | Comment posted, state unchanged |
+
+## Lifecycle Comments
+
+The system posts comments on Linear issues at each stage of the run. These comments provide a real-time audit trail of agent activity directly in your project tracker.
+
+All comments are posted by the **Qovery Autonomous Agent** bot identity (`autonomous-agent@qovery.com`).
+
+| Event | Comment Content |
+|---|---|
+| **Issue claimed** | Agent has claimed the issue and is setting up a workspace. |
+| **Workspace launched** | Workspace is running; agent is actively working on the issue. |
+| **PR opened** | Agent completed the work. Includes a direct link to the pull request. |
+| **Run failed** | Agent encountered an error. Includes the failure reason. |
+| **Run timed out** | Run exceeded the configured timeout. Includes the failure reason. |
+| **Stopped manually** | Administrator stopped the run via the portal ("Stopped via portal"). |
+| **Retried** | Administrator retried the run. A new workspace will be launched. |
+| **Deleted** | Administrator deleted the run via the portal ("Deleted via portal"). |
+
+<Info>
+Lifecycle comments are append-only. The system never edits or deletes previous comments, preserving a complete history of agent activity on each issue.
+</Info>
+
+## Concurrency and Timing
+
+### Polling Interval
+
+The background runner polls Linear every **60 seconds** for issues matching each blueprint's team and label criteria. There may be up to a one-minute delay between labeling an issue and the agent claiming it.
+
+### Max Concurrent Runs
+
+Each blueprint has a configurable concurrency cap (default: **3**). When the number of active runs (status `claimed`, `launching`, or `running`) reaches this limit, the runner skips that blueprint until a slot opens.
+
+### Run Timeout
+
+Each run has a maximum duration (default: **30 minutes**). When the timeout is reached, the workspace is stopped, the run status is set to `timed_out`, and a lifecycle comment is posted on the Linear issue. If a Needs-Human state is configured, the issue transitions to that state.
+
+### Atomic Claiming
+
+When the runner finds a matching issue, it inserts a claim record into the database. A UNIQUE constraint on `(org_id, linear_issue_id)` ensures that only one runner cycle can claim a given issue. If two cycles attempt to claim the same issue simultaneously, only one succeeds - the other is silently rejected.
+
+## Duplicate Prevention
+
+The system uses a database unique constraint on the combination of organization ID and Linear issue ID to prevent the same issue from being claimed twice. This guarantee holds even under concurrent polling cycles or manual run creation.
+
+If a run for a given issue already exists (in any non-terminal status), the system will not create another run for that issue. Once a run reaches a terminal status (`pr_opened`, `failed`, `timed_out`, or `done`), the issue can be retried - but retries go through the existing run record rather than creating a new one.
+
+## Future Integrations
+
+<Info>
+**Jira** and **GitHub Issues** integrations are planned. The agent blueprint configuration will be extended with additional project tracker options. If you need a specific integration, contact the Qovery team.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Agent Blueprints" icon="cubes" href="/rde/agents/agent-blueprints">
+    Configure blueprints that define how agents run, including runtimes, repositories, and resource limits.
+  </Card>
+  <Card title="Managing Runs" icon="list-check" href="/rde/agents/managing-runs">
+    Monitor active runs, review results, and troubleshoot failures.
+  </Card>
+  <Card title="Getting Started" icon="play" href="/rde/agents/getting-started">
+    Set up your first autonomous agent from scratch.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/linear-integration.mdx
+++ b/docs/rde/agents/linear-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Linear Integration"
-description: "Connect autonomous agents to Linear for issue-driven development - API setup, issue flow, state mapping, lifecycle comments, and concurrency."
+description: "Connect autonomous agents to Linear via OAuth for instant, webhook-driven issue resolution."
 ---
 
 import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
@@ -9,68 +9,76 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 ## Overview
 
-Autonomous agents are triggered by issues in your project tracker. When an issue is labeled with the configured trigger label, the system claims it, launches an agent workspace, and reports results back - including posting lifecycle comments and transitioning workflow states.
+Autonomous agents integrate with Linear via OAuth. When a user @mentions or assigns the agent on a Linear issue, Linear sends a webhook to the portal, which instantly claims the issue, launches a workspace, and streams progress back to Linear. No polling and no labels are required for triggering.
 
-Linear is currently the supported project tracker. Jira and GitHub Issues integrations are planned.
+Linear is the currently supported project tracker. Jira and GitHub Issues integrations are planned.
 
 ## Connecting Linear
 
-The Linear API token is configured in the portal admin settings. This token gives the system read/write access to your Linear workspace - it uses it to fetch issues, post comments, transition workflow states, and read team and label metadata.
+<Steps>
+  <Step title="Open settings">
+    Navigate to **Admin > Settings** in the portal.
+  </Step>
+  <Step title="Add to Linear">
+    In the **Autonomous Agent** section, click the **Add to Linear** button.
+  </Step>
+  <Step title="Authorize the agent">
+    Authorize the Qovery agent in Linear's consent screen. The agent requests access to issues, comments, workflow states, and teams.
+  </Step>
+  <Step title="Confirm connection">
+    You are redirected back to the portal. A green **Linear Agent connected** badge confirms the connection.
+  </Step>
+</Steps>
 
-The token must have access to:
-
-- **Issues** - read and write (to fetch issue details and update state)
-- **Comments** - write (to post lifecycle comments)
-- **Labels** - read (to match trigger labels)
-- **Workflow states** - read (to populate state dropdowns in blueprint configuration)
-- **Teams** - read (to populate team dropdowns in blueprint configuration)
+The OAuth token auto-refreshes automatically. No manual token management is required.
 
 <Warning>
-Without a valid Linear API token configured in the portal, agent blueprints cannot pick up issues. The background runner skips blueprints when the token is missing or invalid.
+Without a connected Linear workspace, agent blueprints cannot respond to issues.
 </Warning>
 
 ## How the Issue Flow Works
 
-The following diagram shows the end-to-end flow from labeling an issue to receiving a pull request.
+The following diagram shows the end-to-end flow from @mentioning or assigning the agent on an issue to receiving a pull request.
 
 ```mermaid
 sequenceDiagram
     participant Dev as Developer
     participant Linear as Linear
-    participant Runner as Background Runner
+    participant Portal as Portal Session Handler
     participant DB as Database
     participant WS as Workspace
 
-    Dev->>Linear: Labels issue with trigger label
-    
-    loop Every 60 seconds
-        Runner->>Linear: Polls for issues with trigger label
-    end
-
-    Runner->>DB: Claims issue (atomic insert)
+    Dev->>Linear: @mentions or assigns agent on issue
+    Linear->>Portal: AgentSessionEvent webhook (HMAC-SHA256)
+    Portal->>Portal: Verifies signature
+    Portal->>Portal: Acknowledges within 10s
+    Portal->>Portal: Finds matching blueprint by team
+    Portal->>DB: Claims issue atomically
     Note over DB: UNIQUE constraint on<br/>(org_id, linear_issue_id)<br/>prevents duplicates
+    Portal->>Linear: Sets agent as delegate on issue
+    Portal->>Linear: Posts 4-step plan activity
+    Portal->>WS: Launches workspace with agent config
 
-    Runner->>Linear: Transitions issue to In-Progress
-    Runner->>Linear: Posts "claimed" comment
-    Runner->>WS: Launches workspace with agent config
-
-    WS->>WS: Agent works on the issue
+    WS->>Linear: Streams thought activities (progress)
 
     alt Success
-        WS->>Runner: Callback with PR URL
-        Runner->>Linear: Posts comment with PR URL
-        Runner->>Linear: Transitions to In-Review state
+        WS->>Portal: Callback with PR URL
+        Portal->>Linear: Updates plan (all steps completed)
+        Portal->>Linear: Adds external URL (PR link)
+        Portal->>Linear: Posts response activity with PR URL
+        Portal->>Linear: Transitions issue state
+        Portal->>WS: Keeps workspace briefly, then cleans up
     else Failure or Timeout
-        WS->>Runner: Callback with error
-        Runner->>Linear: Posts comment with failure reason
-        Runner->>Linear: Transitions to Needs-Human state
+        WS->>Portal: Callback with error
+        Portal->>Linear: Updates plan (failed step)
+        Portal->>Linear: Posts error activity with details
+        Portal->>Linear: Transitions to Needs-Human state
+        Portal->>WS: Deletes workspace
     end
-
-    Runner->>WS: Stops workspace
 
     style Dev fill:#642DFF,color:#fff
     style Linear fill:#7C3FFF,color:#fff
-    style Runner fill:#965FFF,color:#fff
+    style Portal fill:#965FFF,color:#fff
     style DB fill:#B080FF,color:#fff
     style WS fill:#7C3FFF,color:#fff
 ```
@@ -79,25 +87,11 @@ sequenceDiagram
 
 Each agent blueprint monitors one Linear team. Only issues from the configured team are picked up by that blueprint.
 
-The team dropdown in the blueprint settings lists all teams accessible via the configured API token. To monitor multiple teams, create separate agent blueprints - one per team.
+The team dropdown in the blueprint settings uses the OAuth connection to list all available teams. To monitor multiple teams, create separate agent blueprints - one per team.
 
 | Blueprint Setting | Value |
 |---|---|
 | **Linear Team** | Required. The team whose issues the agent monitors. |
-
-## Configuring the Trigger Label
-
-The trigger label determines which issues within the configured team are picked up by the agent. Only issues that have both the correct team **and** the trigger label are candidates for a run.
-
-| Blueprint Setting | Default | Description |
-|---|---|---|
-| **Issue Label** | `qovery-agent-ready` | The Linear label that triggers an agent run. |
-
-The label dropdown in the blueprint settings lists all labels available in your Linear workspace. You can use any existing label or create a dedicated one.
-
-<Tip>
-Using a dedicated label like `qovery-agent-ready` keeps the trigger explicit. Avoid reusing labels that are applied automatically by other workflows, as this could trigger unintended agent runs.
-</Tip>
 
 ## Workflow State Mapping
 
@@ -126,8 +120,8 @@ stateDiagram-v2
     classDef failState fill:#B080FF,color:#fff,stroke:#965FFF
 
     [*] --> Backlog:::purple : Issue created
-    Backlog --> Labeled:::midPurple : Trigger label added
-    Labeled --> InProgress:::lightPurple : Agent claims issue
+    Backlog --> Triggered:::midPurple : Agent @mentioned or assigned
+    Triggered --> InProgress:::lightPurple : Agent claims issue
     InProgress --> InReview:::successState : PR opened (optional)
     InProgress --> NeedsHuman:::failState : Failed / timed out (optional)
 ```
@@ -138,30 +132,53 @@ stateDiagram-v2
 | **In-Review** | No | Agent opens a PR | Comment posted, state unchanged |
 | **Needs-Human** | No | Agent fails or times out | Comment posted, state unchanged |
 
-## Lifecycle Comments
+## Agent Activities in Linear
 
-The system posts comments on Linear issues at each stage of the run. These comments provide a real-time audit trail of agent activity directly in your project tracker.
+When a run starts, the agent posts structured activities directly in the Linear issue - visible inline to all team members.
 
-All comments are posted by the **Qovery Autonomous Agent** bot identity (`autonomous-agent@qovery.com`).
+### Agent Plan
 
-| Event | Comment Content |
-|---|---|
-| **Issue claimed** | Agent has claimed the issue and is setting up a workspace. |
-| **Workspace launched** | Workspace is running; agent is actively working on the issue. |
-| **PR opened** | Agent completed the work. Includes a direct link to the pull request. |
-| **Run failed** | Agent encountered an error. Includes the failure reason. |
-| **Run timed out** | Run exceeded the configured timeout. Includes the failure reason. |
-| **Stopped manually** | Administrator stopped the run via the portal ("Stopped via portal"). |
-| **Retried** | Administrator retried the run. A new workspace will be launched. |
-| **Deleted** | Administrator deleted the run via the portal ("Deleted via portal"). |
+A 4-step checklist appears in the Linear issue:
+
+1. **Analyzing issue**
+2. **Setting up workspace**
+3. **Running AI agent**
+4. **Opening pull request**
+
+Each step updates to in-progress or completed as the run progresses. If a step fails, it is marked accordingly.
+
+### Progress Updates
+
+The agent streams live "thought" activities from the workspace. These appear as real-time status updates in the Linear issue thread, giving the team visibility into what the agent is doing at each moment.
+
+### External URLs
+
+The session sidebar in Linear shows direct links to:
+
+- The **RDE dashboard** for the current run
+- The **pull request** (when available)
+
+### Final Result
+
+On success, the agent posts a **response** activity containing the PR link. On failure, it posts an **error** activity with the failure details.
 
 <Info>
-Lifecycle comments are append-only. The system never edits or deletes previous comments, preserving a complete history of agent activity on each issue.
+Traditional comments are also posted on the issue for audit trail purposes.
 </Info>
 
-## Controlling Agents from Linear
+## Interacting with Agents from Linear
 
-Once an agent is running, you can control it directly from the Linear issue by posting a comment with one of these commands:
+### Bidirectional Messaging
+
+While an agent is running, users can post follow-up instructions as comments on the Linear issue. The agent processes these messages and can adjust its approach. Messages are delivered to the workspace via a polling endpoint (approximately every 5 seconds).
+
+### Stop Signal
+
+Linear's native stop button works. When pressed, the portal stops the workspace and marks the run as failed.
+
+### Slash Commands
+
+You can also control agents by posting a comment with one of these commands:
 
 | Command | Action |
 |---------|--------|
@@ -173,18 +190,14 @@ Once an agent is running, you can control it directly from the Linear issue by p
 Commands are processed by the portal and take effect within seconds. The system posts a confirmation comment on the issue when the action completes.
 
 <Tip>
-This gives your team a way to manage autonomous agents without leaving Linear. If an agent is heading in the wrong direction, a developer can `/stop` it, update the issue description with more context, and let the agent retry.
+This gives your team a way to guide autonomous agents without leaving Linear. If an agent is heading in the wrong direction, post a clarifying comment or stop it and provide more context.
 </Tip>
 
 ## Concurrency and Timing
 
-### Polling Interval
-
-The background runner polls Linear every **60 seconds** for issues matching each blueprint's team and label criteria. There may be up to a one-minute delay between labeling an issue and the agent claiming it.
-
 ### Max Concurrent Runs
 
-Each blueprint has a configurable concurrency cap (default: **3**). When the number of active runs (status `claimed`, `launching`, or `running`) reaches this limit, the runner skips that blueprint until a slot opens.
+Each blueprint has a configurable concurrency cap (default: **3**). When the number of active runs (status `claimed`, `launching`, or `running`) reaches this limit, incoming webhooks for that blueprint are queued until a slot opens.
 
 ### Run Timeout
 
@@ -192,13 +205,11 @@ Each run has a maximum duration (default: **60 minutes**). When the timeout is r
 
 ### Atomic Claiming
 
-When the runner finds a matching issue, it inserts a claim record into the database. A UNIQUE constraint on `(org_id, linear_issue_id)` ensures that only one runner cycle can claim a given issue. If two cycles attempt to claim the same issue simultaneously, only one succeeds - the other is silently rejected.
+When the webhook fires, the session handler claims the issue atomically via a database unique constraint on `(org_id, linear_issue_id)`. This prevents duplicate runs even if the agent is @mentioned multiple times on the same issue.
 
-## Duplicate Prevention
+## Disconnecting Linear
 
-The system uses a database unique constraint on the combination of organization ID and Linear issue ID to prevent the same issue from being claimed twice. This guarantee holds even under concurrent polling cycles or manual run creation.
-
-If a run for a given issue already exists (in any non-terminal status), the system will not create another run for that issue. Once a run reaches a terminal status (`pr_opened`, `failed`, `timed_out`, or `done`), the issue can be retried - but retries go through the existing run record rather than creating a new one.
+To disconnect, navigate to **Admin > Settings** and click the **Disconnect** link under the **Autonomous Agent** section. This revokes the OAuth tokens and removes the organization mapping. Existing runs are not affected, but no new runs can be triggered.
 
 ## Future Integrations
 

--- a/docs/rde/agents/managing-runs.mdx
+++ b/docs/rde/agents/managing-runs.mdx
@@ -9,7 +9,7 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 ## Overview
 
-When a user @mentions or assigns the agent on a Linear issue that matches a blueprint's team, the system creates a **run**. A run tracks the full lifecycle from issue claim to pull request creation (or failure). This page covers the admin dashboard, run lifecycle, and management actions available to administrators.
+When a user triggers the agent on an issue that matches a blueprint - by @mentioning or assigning it in Linear, or by assigning it to the agent's user in Jira - the system creates a **run**. A run tracks the full lifecycle from issue claim to pull request creation (or failure). This page covers the admin dashboard, run lifecycle, and management actions available to administrators, and applies to both trackers.
 
 ## Run Statuses
 
@@ -17,7 +17,7 @@ Every run moves through a series of statuses that reflect its current stage.
 
 | Status | Description |
 |--------|-------------|
-| `claimed` | Issue claimed in Linear, workspace preparation started |
+| `claimed` | Issue claimed on the tracker, workspace preparation started |
 | `launching` | Workspace environment is deploying on your cluster |
 | `running` | Agent is actively working on the issue |
 | `pr_opened` | Agent completed successfully and opened a pull request. Workspace is kept alive briefly, then auto-deleted. |
@@ -90,7 +90,7 @@ The table includes these columns:
 
 | Column | Description |
 |--------|-------------|
-| Issue | Linear issue key, linked to the run detail page |
+| Issue | Linear or Jira issue key, linked to the run detail page |
 | Owner | Assigned owner email, with a fallback badge if applicable |
 | Status | Current run status |
 | PR | Link to the pull request (when available) |
@@ -107,14 +107,14 @@ Each run supports a set of actions based on its current status.
 
 | Action | Available When | Effect |
 |--------|---------------|--------|
-| **Stop** | `claimed`, `launching`, `running` | Stops the workspace, marks the run as `failed` with reason "Stopped via portal", and posts a comment on the Linear issue |
-| **Restart** | `running` (with active workspace) | Restarts the workspace environment and posts a comment on the Linear issue |
-| **Retry** | `failed`, `timed_out` | Resets the run, re-claims the Linear issue, and launches a new workspace |
-| **Delete** | `claimed`, `launching`, `running` | Stops the workspace, marks the run as `done` with reason "Deleted via portal", and posts a comment on the Linear issue |
+| **Stop** | `claimed`, `launching`, `running` | Stops the workspace, marks the run as `failed` with reason "Stopped via portal", and posts a comment on the issue |
+| **Restart** | `running` (with active workspace) | Restarts the workspace environment and posts a comment on the issue |
+| **Retry** | `failed`, `timed_out` | Resets the run, re-claims the issue, and launches a new workspace |
+| **Delete** | `claimed`, `launching`, `running` | Stops the workspace, marks the run as `done` with reason "Deleted via portal", and posts a comment on the issue |
 | **View Workspace** | Any run with an active workspace | Opens the workspace in the portal |
 
 <Info>
-All actions that modify a run are reflected in the Linear issue as lifecycle comments. This keeps your project tracker in sync with agent activity.
+All actions that modify a run are reflected on the issue as lifecycle comments (and status transitions where configured). This keeps your project tracker in sync with agent activity.
 </Info>
 
 ## Run Detail Page
@@ -123,7 +123,7 @@ View detailed information for a single run at **Admin > Agents > Runs > [Run]**.
 
 The detail page shows:
 
-- **Linear issue title and description** - the full context the agent is working from
+- **Issue title and description** - the full context the agent is working from
 - **Status** - current run status with timestamps
 - **Owner** - assigned owner, with a dropdown to reassign
 - **PR URL** - link to the pull request (when available)
@@ -133,15 +133,19 @@ Quick links at the top provide direct access to:
 
 - **Workspace** - open the agent's workspace in the portal
 - **Qovery Console** - view the underlying environment in the Qovery dashboard
-- **Linear issue** - jump to the issue in Linear
+- **Issue** - jump to the issue in Linear or Jira
 
 <Tip>
-When a run is assigned to the system fallback account, a **fallback** badge appears next to the owner. This indicates no human assignee was found on the Linear issue.
+When a run is assigned to the system fallback account, a **fallback** badge appears next to the owner. This indicates no human assignee was found on the issue.
 </Tip>
 
 ## Creating a Run Manually
 
 You can trigger a run manually without @mentioning the agent in Linear.
+
+<Info>
+Manual run creation currently searches Linear issues only. For Jira, trigger runs by assigning the issue to the agent's Jira user.
+</Info>
 
 <Steps>
   <Step title="Open the Create dialog">
@@ -161,20 +165,20 @@ You can trigger a run manually without @mentioning the agent in Linear.
   </Step>
 
   <Step title="Submit">
-    Click **Create**. The system validates that the selected blueprint has autonomous mode enabled and the In-Progress state is configured, then launches the run.
+    Click **Create**. The system validates that the selected blueprint has autonomous mode enabled and the claimed state is configured, then launches the run.
   </Step>
 </Steps>
 
 <Warning>
-Manual run creation requires a blueprint with autonomous mode enabled and a configured In-Progress workflow state. If either is missing, the creation will fail with a validation error.
+Manual run creation requires a blueprint with autonomous mode enabled and a configured claimed workflow state. If either is missing, the creation will fail with a validation error.
 </Warning>
 
 ## Owner Assignment
 
 Runs are assigned an owner based on the following logic:
 
-1. **Linear issue assignee** - the email of the person assigned to the Linear issue is used by default.
-2. **System fallback** - if the Linear issue has no assignee, the run is assigned to `autonomous-agent@qovery.com` and marked with `owner_fallback = true`. A **fallback** badge appears in the UI.
+1. **Issue assignee** - the email of the person assigned to the issue is used by default.
+2. **System fallback** - if the issue has no assignee, the run is assigned to `autonomous-agent@qovery.com` and marked with `owner_fallback = true`. A **fallback** badge appears in the UI.
 3. **Admin reassignment** - administrators can change the owner from the run detail page using the owner dropdown.
 
 ## My Runs (User View)
@@ -182,7 +186,7 @@ Runs are assigned an owner based on the following logic:
 Users can view their assigned runs from their personal dashboard. The **My Runs** view shows the latest 50 runs assigned to the authenticated user, including:
 
 - Run status
-- Linear issue link
+- Linear or Jira issue link
 - Pull request link (when available)
 - Timestamps
 

--- a/docs/rde/agents/managing-runs.mdx
+++ b/docs/rde/agents/managing-runs.mdx
@@ -1,0 +1,203 @@
+---
+title: "Managing Runs"
+description: "Monitor and manage autonomous agent runs - from the admin dashboard to individual run actions and lifecycle tracking."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+## Overview
+
+When an issue matches an agent blueprint's criteria (team, label, and workflow state), the system creates a **run**. A run tracks the full lifecycle from issue claim to pull request creation (or failure). This page covers the admin dashboard, run lifecycle, and management actions available to administrators.
+
+## Run Statuses
+
+Every run moves through a series of statuses that reflect its current stage.
+
+| Status | Description |
+|--------|-------------|
+| `claimed` | Issue claimed in Linear, workspace preparation started |
+| `launching` | Workspace environment is deploying on your cluster |
+| `running` | Agent is actively working on the issue |
+| `pr_opened` | Agent completed successfully and opened a pull request |
+| `failed` | Agent encountered an error or was stopped manually |
+| `timed_out` | Run exceeded the configured timeout |
+| `done` | Run was deleted by an admin |
+
+```mermaid
+stateDiagram-v2
+    classDef purple fill:#642DFF,color:#fff,stroke:#7C3FFF
+    classDef midPurple fill:#7C3FFF,color:#fff,stroke:#965FFF
+    classDef lightPurple fill:#965FFF,color:#fff,stroke:#B080FF
+    classDef terminalFail fill:#ef4444,color:#fff
+    classDef terminalDone fill:#6b7280,color:#fff
+
+    [*] --> claimed:::purple
+    claimed --> launching:::midPurple
+    launching --> running:::lightPurple
+    running --> pr_opened:::purple
+    running --> failed:::terminalFail
+    running --> timed_out:::terminalFail
+    claimed --> failed:::terminalFail : stop / delete
+    launching --> failed:::terminalFail : stop / delete
+    failed --> claimed:::purple : retry
+    timed_out --> claimed:::purple : retry
+    pr_opened --> [*]
+    failed --> [*]
+    timed_out --> [*]
+    claimed --> done:::terminalDone : delete
+    launching --> done:::terminalDone : delete
+    running --> done:::terminalDone : delete
+    done --> [*]
+```
+
+## Agents Overview Dashboard
+
+Navigate to **Admin > Agents > Overview** for a high-level view of all agent activity.
+
+### Stats Bar
+
+The top of the page displays aggregate counters:
+
+- **Active** - runs currently in `claimed`, `launching`, or `running` status
+- **Completed** - runs that reached `pr_opened`
+- **Failed** - runs in `failed` status
+- **Timed Out** - runs in `timed_out` status
+- **Total** - all runs across all statuses
+
+### Agent Topology Graph
+
+Below the stats bar, a visual graph maps the relationship between clusters, blueprints, and individual runs.
+
+- **Top level** - Kubernetes clusters where agents execute
+- **Middle level** - agent blueprints deployed to each cluster
+- **Bottom level** - individual run pills, color-coded by status
+
+Click a run pill to view its detail page. Click a blueprint node to edit its settings.
+
+Use the filter toggle to switch between **Active only** (default) and **All runs**.
+
+### Recent Runs
+
+A table at the bottom shows the latest 10 runs across all blueprints. The dashboard auto-refreshes every 30 seconds.
+
+## Runs Dashboard
+
+Navigate to **Admin > Agents > Runs** for the full runs table.
+
+The table includes these columns:
+
+| Column | Description |
+|--------|-------------|
+| Issue | Linear issue key, linked to the run detail page |
+| Owner | Assigned owner email, with a fallback badge if applicable |
+| Status | Current run status |
+| PR | Link to the pull request (when available) |
+| Started | Timestamp when the run was claimed |
+| Updated | Last status change timestamp |
+| Failure Reason | Error message for failed or timed-out runs |
+| Actions | Dropdown with available management actions |
+
+The table auto-refreshes every 30 seconds.
+
+## Run Actions
+
+Each run supports a set of actions based on its current status.
+
+| Action | Available When | Effect |
+|--------|---------------|--------|
+| **Stop** | `claimed`, `launching`, `running` | Stops the workspace, marks the run as `failed` with reason "Stopped via portal", and posts a comment on the Linear issue |
+| **Restart** | `running` (with active workspace) | Restarts the workspace environment and posts a comment on the Linear issue |
+| **Retry** | `failed`, `timed_out` | Resets the run, re-claims the Linear issue, and launches a new workspace |
+| **Delete** | `claimed`, `launching`, `running` | Stops the workspace, marks the run as `done` with reason "Deleted via portal", and posts a comment on the Linear issue |
+| **View Workspace** | Any run with an active workspace | Opens the workspace in the portal |
+
+<Info>
+All actions that modify a run are reflected in the Linear issue as lifecycle comments. This keeps your project tracker in sync with agent activity.
+</Info>
+
+## Run Detail Page
+
+View detailed information for a single run at **Admin > Agents > Runs > [Run]**.
+
+The detail page shows:
+
+- **Linear issue title and description** - the full context the agent is working from
+- **Status** - current run status with timestamps
+- **Owner** - assigned owner, with a dropdown to reassign
+- **PR URL** - link to the pull request (when available)
+- **Timestamps** - when the run was claimed and last updated
+
+Quick links at the top provide direct access to:
+
+- **Workspace** - open the agent's workspace in the portal
+- **Qovery Console** - view the underlying environment in the Qovery dashboard
+- **Linear issue** - jump to the issue in Linear
+
+<Tip>
+When a run is assigned to the system fallback account, a **fallback** badge appears next to the owner. This indicates no human assignee was found on the Linear issue.
+</Tip>
+
+## Creating a Run Manually
+
+You can trigger a run manually without waiting for the background poller.
+
+<Steps>
+  <Step title="Open the Create dialog">
+    Navigate to **Admin > Agents > Runs** and click **Create**.
+  </Step>
+
+  <Step title="Search for a Linear issue">
+    Type a Linear issue title or identifier (e.g., `ENG-142`) to search. Select the issue you want the agent to work on.
+  </Step>
+
+  <Step title="Select a blueprint">
+    The portal auto-matches an agent blueprint based on the issue's team. You can override the selection if multiple blueprints are available.
+  </Step>
+
+  <Step title="Assign an owner (optional)">
+    Select an organization member as the run owner. If left empty, the system uses the Linear issue assignee or falls back to the system account.
+  </Step>
+
+  <Step title="Submit">
+    Click **Create**. The system validates that the selected blueprint has autonomous mode enabled and the In-Progress state is configured, then launches the run.
+  </Step>
+</Steps>
+
+<Warning>
+Manual run creation requires a blueprint with autonomous mode enabled and a configured In-Progress workflow state. If either is missing, the creation will fail with a validation error.
+</Warning>
+
+## Owner Assignment
+
+Runs are assigned an owner based on the following logic:
+
+1. **Linear issue assignee** - the email of the person assigned to the Linear issue is used by default.
+2. **System fallback** - if the Linear issue has no assignee, the run is assigned to `autonomous-agent@qovery.com` and marked with `owner_fallback = true`. A **fallback** badge appears in the UI.
+3. **Admin reassignment** - administrators can change the owner from the run detail page using the owner dropdown.
+
+## My Runs (User View)
+
+Users can view their assigned runs from their personal dashboard. The **My Runs** view shows the latest 50 runs assigned to the authenticated user, including:
+
+- Run status
+- Linear issue link
+- Pull request link (when available)
+- Timestamps
+
+This view is read-only. Management actions (stop, restart, retry, delete) are only available from the admin dashboard.
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Agent Blueprints" icon="cubes" href="/rde/agents/agent-blueprints">
+    Configure blueprints that define how agents run, including runtimes, repositories, and resource limits.
+  </Card>
+  <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
+    Set up the issue flow, trigger labels, and workflow state mapping.
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/rde/reference/troubleshooting">
+    Diagnose and resolve common agent failures.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/managing-runs.mdx
+++ b/docs/rde/agents/managing-runs.mdx
@@ -9,7 +9,7 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 ## Overview
 
-When an issue matches an agent blueprint's criteria (team, label, and workflow state), the system creates a **run**. A run tracks the full lifecycle from issue claim to pull request creation (or failure). This page covers the admin dashboard, run lifecycle, and management actions available to administrators.
+When a user @mentions or assigns the agent on a Linear issue that matches a blueprint's team, the system creates a **run**. A run tracks the full lifecycle from issue claim to pull request creation (or failure). This page covers the admin dashboard, run lifecycle, and management actions available to administrators.
 
 ## Run Statuses
 
@@ -20,9 +20,9 @@ Every run moves through a series of statuses that reflect its current stage.
 | `claimed` | Issue claimed in Linear, workspace preparation started |
 | `launching` | Workspace environment is deploying on your cluster |
 | `running` | Agent is actively working on the issue |
-| `pr_opened` | Agent completed successfully and opened a pull request |
-| `failed` | Agent encountered an error or was stopped manually |
-| `timed_out` | Run exceeded the configured timeout |
+| `pr_opened` | Agent completed successfully and opened a pull request. Workspace is kept alive briefly, then auto-deleted. |
+| `failed` | Agent encountered an error or was stopped manually. Workspace environment is auto-deleted. |
+| `timed_out` | Run exceeded the configured timeout. Workspace environment is auto-deleted. |
 | `done` | Run was deleted by an admin |
 
 ```mermaid
@@ -141,7 +141,7 @@ When a run is assigned to the system fallback account, a **fallback** badge appe
 
 ## Creating a Run Manually
 
-You can trigger a run manually without waiting for the background poller.
+You can trigger a run manually without @mentioning the agent in Linear.
 
 <Steps>
   <Step title="Open the Create dialog">
@@ -195,7 +195,7 @@ This view is read-only. Management actions (stop, restart, retry, delete) are on
     Configure blueprints that define how agents run, including runtimes, repositories, and resource limits.
   </Card>
   <Card title="Linear Integration" icon="arrows-rotate" href="/rde/agents/linear-integration">
-    Set up the issue flow, trigger labels, and workflow state mapping.
+    Set up the OAuth connection, issue flow, and workflow state mapping.
   </Card>
   <Card title="Troubleshooting" icon="wrench" href="/rde/reference/troubleshooting">
     Diagnose and resolve common agent failures.

--- a/docs/rde/agents/overview.mdx
+++ b/docs/rde/agents/overview.mdx
@@ -1,0 +1,98 @@
+---
+title: "Autonomous Agents"
+description: "AI agents that autonomously resolve issues from your project tracker and open pull requests."
+---
+
+import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
+
+<RdePreviewWarning />
+
+Autonomous agents pick up issues from your project tracker, work on them in isolated cloud environments, and open pull requests - without human intervention. They use the same blueprint and governance infrastructure as workspaces, but operate autonomously.
+
+Linear is currently supported as the project tracker. Jira and GitHub Issues integrations are planned.
+
+## How It Works
+
+When an issue is labeled in your project tracker, an agent claims it, launches a workspace, writes the code, opens a pull request, and shuts down.
+
+```mermaid
+flowchart LR
+    A["Issue labeled\nin Linear"] --> B["Agent\nclaims issue"]
+    B --> C["Workspace\nlaunches"]
+    C --> D["Agent\nwrites code"]
+    D --> E["PR opened"]
+    E --> F["Workspace\nstopped"]
+
+    style A fill:#642DFF,color:#fff
+    style B fill:#7C3FFF,color:#fff
+    style C fill:#965FFF,color:#fff
+    style D fill:#965FFF,color:#fff
+    style E fill:#7C3FFF,color:#fff
+    style F fill:#642DFF,color:#fff
+```
+
+## Agents vs Workspaces
+
+Autonomous agents and workspaces share the same underlying infrastructure but serve different workflows.
+
+| | Workspaces | Autonomous Agents |
+|---|---|---|
+| **Trigger** | Human clicks "Create" | Issue labeled in project tracker |
+| **Interaction** | Human works in browser | AI agent runs autonomously |
+| **Output** | Running application | Pull request |
+| **Lifecycle** | Manual start/stop | Auto-launch, auto-stop on completion |
+| **Blueprint type** | Workspace Blueprint | Agent Blueprint |
+| **Admin view** | Workspace Management | Agents Dashboard & Runs |
+
+## Supported Runtimes
+
+Each agent blueprint specifies which AI coding runtime to use. The runtime determines the CLI tool that drives the agent inside the workspace.
+
+<CardGroup cols={3}>
+  <Card title="Claude Code" icon="terminal">
+    Anthropic's coding agent. Runs `claude -p` with the issue description as the prompt.
+  </Card>
+  <Card title="OpenCode" icon="code">
+    Open-source coding agent. Runs `opencode run` to process the issue autonomously.
+  </Card>
+  <Card title="Codex" icon="microchip">
+    OpenAI's coding agent. Runs `codex --full-auto` for fully autonomous operation.
+  </Card>
+  <Card title="Gemini CLI" icon="gem">
+    Google's coding agent. Runs `gemini -p` with the issue context as input.
+  </Card>
+  <Card title="Cursor CLI" icon="arrow-pointer">
+    Cursor's agent mode. Runs `cursor-agent` to resolve the issue.
+  </Card>
+</CardGroup>
+
+## Shared Infrastructure
+
+Autonomous agents run on the same Kubernetes cluster as workspaces. They use the same split architecture - the portal orchestrates agent runs from `rde.qovery.com`, while the agent containers execute on your infrastructure. The same security model applies: no inbound ports, outbound-only TLS/gRPC tunnels, and all code stays on your cluster.
+
+For details on the underlying infrastructure, see [Architecture](/rde/reference/architecture) and [Security & Data Residency](/rde/reference/security).
+
+## Supported Project Trackers
+
+**Linear** is the currently supported project tracker. You connect your Linear workspace, configure which labels trigger agent runs, and the system handles the rest - from issue assignment to PR creation.
+
+<Info>
+**Jira** and **GitHub Issues** integrations are planned. If you need a specific integration, contact the Qovery team.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Getting Started" icon="play" href="/rde/agents/getting-started">
+    Set up your first autonomous agent with Linear integration.
+  </Card>
+  <Card title="Agent Blueprints" icon="cubes" href="/rde/agents/agent-blueprints">
+    Configure blueprints that define how agents run.
+  </Card>
+  <Card title="Managing Runs" icon="list-check" href="/rde/agents/managing-runs">
+    Monitor agent runs, review results, and troubleshoot failures.
+  </Card>
+  <Card title="Linear Integration" icon="link" href="/rde/agents/linear-integration">
+    Connect Linear, configure labels, and manage issue routing.
+  </Card>
+</CardGroup>

--- a/docs/rde/agents/overview.mdx
+++ b/docs/rde/agents/overview.mdx
@@ -13,11 +13,11 @@ Linear is currently supported as the project tracker. Jira and GitHub Issues int
 
 ## How It Works
 
-When an issue is labeled in your project tracker, an agent claims it, launches a workspace, writes the code, opens a pull request, and shuts down.
+When a user @mentions or assigns the agent on a Linear issue, the agent claims it instantly, launches a workspace, writes the code, opens a pull request, and shuts down. Progress is streamed back to Linear in real time.
 
 ```mermaid
 flowchart LR
-    A["Issue labeled\nin Linear"] --> B["Agent\nclaims issue"]
+    A["Agent @mentioned\nor assigned"] --> B["Agent\nclaims issue"]
     B --> C["Workspace\nlaunches"]
     C --> D["Agent\nwrites code"]
     D --> E["PR opened"]
@@ -37,7 +37,7 @@ Autonomous agents and workspaces share the same underlying infrastructure but se
 
 | | Workspaces | Autonomous Agents |
 |---|---|---|
-| **Trigger** | Human clicks "Create" | Issue labeled in project tracker |
+| **Trigger** | Human clicks "Create" | Agent @mentioned or assigned on issue |
 | **Interaction** | Human works in browser | AI agent runs autonomously |
 | **Output** | Running application | Pull request |
 | **Lifecycle** | Manual start/stop | Auto-launch, auto-stop on completion |
@@ -74,7 +74,7 @@ For details on the underlying infrastructure, see [Architecture](/rde/reference/
 
 ## Supported Project Trackers
 
-**Linear** is the currently supported project tracker. You connect your Linear workspace, configure which labels trigger agent runs, and the system handles the rest - from issue assignment to PR creation.
+**Linear** is the currently supported project tracker. You connect your Linear workspace via OAuth, and your team triggers agents by @mentioning or assigning them on issues. The agent responds instantly with a real-time plan and progress updates visible directly in Linear.
 
 <Info>
 **Jira** and **GitHub Issues** integrations are planned. If you need a specific integration, contact the Qovery team.

--- a/docs/rde/agents/overview.mdx
+++ b/docs/rde/agents/overview.mdx
@@ -9,15 +9,15 @@ import RdePreviewWarning from "/snippets/rde-preview-warning.mdx";
 
 Autonomous agents pick up issues from your project tracker, work on them in isolated cloud environments, and open pull requests - without human intervention. They use the same blueprint and governance infrastructure as workspaces, but operate autonomously.
 
-Linear is currently supported as the project tracker. Jira and GitHub Issues integrations are planned.
+Linear and Jira are supported as project trackers. A GitHub Issues integration is planned.
 
 ## How It Works
 
-When a user @mentions or assigns the agent on a Linear issue, the agent claims it instantly, launches a workspace, writes the code, opens a pull request, and shuts down. Progress is streamed back to Linear in real time.
+When a user triggers the agent on an issue - by @mentioning or assigning it in Linear, or by assigning it to the agent's user in Jira - the agent claims it, launches a workspace, writes the code, opens a pull request, and shuts down. Progress is reported back on the issue in real time.
 
 ```mermaid
 flowchart LR
-    A["Agent @mentioned\nor assigned"] --> B["Agent\nclaims issue"]
+    A["Agent triggered\non issue"] --> B["Agent\nclaims issue"]
     B --> C["Workspace\nlaunches"]
     C --> D["Agent\nwrites code"]
     D --> E["PR opened"]
@@ -37,7 +37,7 @@ Autonomous agents and workspaces share the same underlying infrastructure but se
 
 | | Workspaces | Autonomous Agents |
 |---|---|---|
-| **Trigger** | Human clicks "Create" | Agent @mentioned or assigned on issue |
+| **Trigger** | Human clicks "Create" | Agent triggered from a Linear or Jira issue |
 | **Interaction** | Human works in browser | AI agent runs autonomously |
 | **Output** | Running application | Pull request |
 | **Lifecycle** | Manual start/stop | Auto-launch, auto-stop on completion |
@@ -74,10 +74,13 @@ For details on the underlying infrastructure, see [Architecture](/rde/reference/
 
 ## Supported Project Trackers
 
-**Linear** is the currently supported project tracker. You connect your Linear workspace via OAuth, and your team triggers agents by @mentioning or assigning them on issues. The agent responds instantly with a real-time plan and progress updates visible directly in Linear.
+Both trackers connect via OAuth and auto-refresh their tokens. You configure which tracker an agent blueprint uses in the [Create Agent Blueprint](/rde/agents/getting-started#create-an-agent-blueprint) wizard.
+
+- **Linear** - trigger agents by @mentioning or assigning them on issues. The agent responds with a real-time plan and progress updates visible directly in Linear as agent activities. See [Linear Integration](/rde/agents/linear-integration).
+- **Jira** - trigger agents by assigning an issue to the agent's Jira user. Progress is reported as issue comments and workflow status transitions. See [Jira Integration](/rde/agents/jira-integration).
 
 <Info>
-**Jira** and **GitHub Issues** integrations are planned. If you need a specific integration, contact the Qovery team.
+A **GitHub Issues** integration is planned. If you need a specific integration, contact the Qovery team.
 </Info>
 
 ## Next Steps
@@ -94,5 +97,8 @@ For details on the underlying infrastructure, see [Architecture](/rde/reference/
   </Card>
   <Card title="Linear Integration" icon="link" href="/rde/agents/linear-integration">
     Connect Linear, configure labels, and manage issue routing.
+  </Card>
+  <Card title="Jira Integration" icon="link" href="/rde/agents/jira-integration">
+    Connect Jira, map statuses, and trigger agents by assignment.
   </Card>
 </CardGroup>

--- a/docs/rde/overview.mdx
+++ b/docs/rde/overview.mdx
@@ -12,7 +12,7 @@ description: "A self-service web portal that gives every team member their own i
 </Note>
 
 <Info>
-Looking for the CLI-based approach? See [Remote Development Environments with the CLI](/getting-started/guides/use-cases/remote-development-environments) for managing RDEs via `qovery rde` commands.
+Looking for the CLI-based approach? See [Remote Development Environments with the CLI](/cli/commands/rde) for managing RDEs via `qovery rde` commands.
 </Info>
 
 ## Your Team Is Already Building with AI
@@ -85,6 +85,9 @@ The portal includes a **built-in terminal with Claude Code and OpenCode chat** f
   <Card title="Multi-Cluster Support" icon="server">
     Route workspaces to specific Kubernetes clusters per blueprint for data residency, resource isolation, or specialized hardware requirements.
   </Card>
+  <Card title="Autonomous Agents" icon="robot">
+    Connect AI agents to your project tracker. They pick up issues, write code in isolated environments, and open pull requests - autonomously.
+  </Card>
 </CardGroup>
 
 ## Secure by Design
@@ -140,6 +143,11 @@ flowchart LR
 A **blueprint** is a pre-configured workspace template created by your platform team. Think of it as a ready-to-use work environment - the right tools, the right database connections, the right API credentials - all set up and secured. Builders don't configure anything. They pick a blueprint, click Create, and start building.
 
 The platform team controls what each blueprint can access: which databases, which internal APIs, which credentials. That governance is invisible to the builder. From their perspective, they just pick a template and get to work.
+
+Blueprints come in two types:
+
+- **Workspace Blueprints** - The default. A human creates a workspace, works in the browser with built-in AI tools, and publishes their application.
+- **Agent Blueprints** - Configured for autonomous AI agents. Instead of a human, an AI agent runs in the workspace, picks up issues from your project tracker, writes code, and opens pull requests. See [Autonomous Agents](/rde/agents/overview) for details.
 
 Different teams get different blueprints, scoped to what they actually need:
 
@@ -234,5 +242,8 @@ Before using the AI Builder Portal, make sure you have:
   </Card>
   <Card title="Architecture" icon="sitemap" href="/rde/reference/architecture">
     Understand how the portal works under the hood.
+  </Card>
+  <Card title="Autonomous Agents" icon="robot" href="/rde/agents/overview">
+    Let AI agents resolve issues and open pull requests autonomously.
   </Card>
 </CardGroup>

--- a/docs/rde/reference/architecture.mdx
+++ b/docs/rde/reference/architecture.mdx
@@ -302,10 +302,56 @@ The portal splits data storage between its database and the Qovery API:
 | User tags | Portal database |
 | Connection audit logs | Portal database |
 | Firewall rules and events | Portal database |
+| Autonomous run state | Portal database |
+| Linear issue mapping | Portal database |
+| Agent run results (PR URL, failure reason) | Portal database |
 
 <Note>
 No source code, AI conversations, or application data is stored in the portal database. All development data lives exclusively in workspace containers on your cluster.
 </Note>
+
+## Autonomous Agent Architecture
+
+Autonomous agents extend the portal with an automated issue-to-PR pipeline. Three components are added on top of the existing workspace infrastructure:
+
+**Background Runner** - A polling job that runs every 60 seconds. It scans all organizations with agent blueprints enabled, queries Linear for issues matching the configured team and label, claims them atomically via a database unique constraint, and launches workspaces.
+
+**Agent Workspace** - A standard workspace environment with the AI runtime (Claude Code, OpenCode, Codex, Gemini CLI, or Cursor CLI) pre-configured. The agent receives the Linear issue context, works on the code, and reports results via a callback endpoint.
+
+**Result Callback** - When the agent finishes, the workspace calls back to the API server with the result (PR opened, failed, or timed out). The API server updates the run status, stops the workspace, and posts a lifecycle comment on the Linear issue.
+
+```mermaid
+sequenceDiagram
+    participant Linear
+    participant Runner as Background Runner
+    participant API as API Server
+    participant DB as Database
+    participant CP as Qovery Control Plane
+    participant Agent as Agent Workspace
+
+    Runner->>Linear: Query issues with trigger label
+    Linear-->>Runner: Matching issues
+    Runner->>DB: Claim issue (atomic)
+    Runner->>Linear: Transition to In-Progress
+    Runner->>Linear: Post comment
+    Runner->>CP: Launch workspace
+    CP->>Agent: Deploy environment
+    Agent->>Agent: AI agent works on issue
+    Agent->>API: Report result
+    API->>DB: Update run status
+    API->>CP: Stop workspace
+    API->>Linear: Post result comment
+    API->>Linear: Transition state
+
+    style Runner fill:#642DFF,color:#fff
+    style API fill:#642DFF,color:#fff
+    style DB fill:#642DFF,color:#fff
+    style CP fill:#1a1a2e,color:#fff
+    style Agent fill:#0d9488,color:#fff
+    style Linear fill:#1a1a2e,color:#fff
+```
+
+For a full walkthrough of the Linear integration, issue flow, and lifecycle comments, see [Linear Integration](/rde/agents/linear-integration).
 
 ## Next Steps
 

--- a/docs/rde/reference/troubleshooting.mdx
+++ b/docs/rde/reference/troubleshooting.mdx
@@ -293,7 +293,7 @@ This page covers common issues you may encounter with the AI Builder Portal and 
     **Symptoms:** The run status shows 'timed_out'.
 
     **Solutions:**
-    - The run exceeded the configured timeout (default: 60 minutes). The issue may have been too complex for the agent.
+    - The run exceeded the configured timeout. The issue may have been too complex for the agent.
     - You can **retry** the run from the Runs dashboard. Consider increasing the timeout in the blueprint's Autonomous settings.
     - Check the workspace logs in the Qovery Console for errors the agent encountered before timing out.
   </Accordion>

--- a/docs/rde/reference/troubleshooting.mdx
+++ b/docs/rde/reference/troubleshooting.mdx
@@ -267,17 +267,17 @@ This page covers common issues you may encounter with the AI Builder Portal and 
 ## Autonomous Agent Issues
 
 <AccordionGroup>
-  <Accordion title="Agent not picking up Linear issues">
-    **Symptoms:** Issues are labeled correctly in Linear but no run is created.
+  <Accordion title="Agent not responding to @mentions">
+    **Symptoms:** You @mentioned or assigned the agent on a Linear issue but nothing happened.
 
     **Solutions:**
-    - Verify the agent blueprint has autonomous mode enabled in **Admin > Blueprints > [Blueprint] > Autonomous**.
-    - Check that the **Linear API token** is configured in the portal settings. The Autonomous tab shows a warning if no token is set.
-    - Confirm the **issue label** matches exactly what is configured on the blueprint (default: `qovery-agent-ready`).
-    - Confirm the **Linear team** matches the blueprint's configured team. Issues from other teams are ignored.
-    - The **In-Progress state** must be configured. The blueprint cannot claim issues without it.
-    - The background runner polls every **60 seconds**. Wait at least one minute after labeling the issue.
+    - Verify **Linear is connected** via OAuth in **Admin > Settings**. The Autonomous Agent section should show a green "Linear Agent connected" badge.
+    - Verify the agent blueprint's **Linear team** matches the issue's team. The system finds blueprints by team - if no blueprint is configured for the issue's team, the agent cannot respond.
+    - Make sure you **@mentioned or assigned the agent** on the issue. Labeling an issue alone does not trigger the agent.
+    - Verify the blueprint has **autonomous mode enabled** in **Admin > Blueprints > [Blueprint] > Autonomous**.
+    - The **In-Progress state** must be configured on the blueprint. Without it, the agent cannot claim issues.
     - Check that the blueprint's **max concurrent runs** limit has not been reached. View active runs in **Admin > Agents > Runs**.
+    - If the agent still does not respond, the webhook configuration may need attention. Contact Qovery support.
   </Accordion>
 
   <Accordion title="Run stuck in 'claimed' or 'launching' state">
@@ -313,7 +313,7 @@ This page covers common issues you may encounter with the AI Builder Portal and 
 
     **Solutions:**
     - This should not happen under normal operation. The system uses a database unique constraint to prevent duplicate claims.
-    - If you see duplicates, one may have been created manually via the **Create** button while the background runner also picked it up. The atomic constraint prevents this, but check if the runs are for different blueprints (which is allowed).
+    - If you see duplicates, one may have been created manually via the **Create** button while a webhook also triggered a run. The atomic constraint prevents this, but check if the runs are for different blueprints (which is allowed).
     - Contact Qovery support if genuine duplicates appear for the same blueprint and issue.
   </Accordion>
 </AccordionGroup>

--- a/docs/rde/reference/troubleshooting.mdx
+++ b/docs/rde/reference/troubleshooting.mdx
@@ -264,6 +264,60 @@ This page covers common issues you may encounter with the AI Builder Portal and 
   </Accordion>
 </AccordionGroup>
 
+## Autonomous Agent Issues
+
+<AccordionGroup>
+  <Accordion title="Agent not picking up Linear issues">
+    **Symptoms:** Issues are labeled correctly in Linear but no run is created.
+
+    **Solutions:**
+    - Verify the agent blueprint has autonomous mode enabled in **Admin > Blueprints > [Blueprint] > Autonomous**.
+    - Check that the **Linear API token** is configured in the portal settings. The Autonomous tab shows a warning if no token is set.
+    - Confirm the **issue label** matches exactly what is configured on the blueprint (default: `qovery-agent-ready`).
+    - Confirm the **Linear team** matches the blueprint's configured team. Issues from other teams are ignored.
+    - The **In-Progress state** must be configured. The blueprint cannot claim issues without it.
+    - The background runner polls every **60 seconds**. Wait at least one minute after labeling the issue.
+    - Check that the blueprint's **max concurrent runs** limit has not been reached. View active runs in **Admin > Agents > Runs**.
+  </Accordion>
+
+  <Accordion title="Run stuck in 'claimed' or 'launching' state">
+    **Symptoms:** A run was created but never progresses to 'running'.
+
+    **Solutions:**
+    - The workspace environment may be failing to deploy. Check the **Qovery Console** for deployment errors on the workspace environment.
+    - Common causes: container image pull failure, insufficient cluster resources, invalid environment variables.
+    - Try **stopping** the run from **Admin > Agents > Runs**, then **retrying** it.
+  </Accordion>
+
+  <Accordion title="Agent run timed out">
+    **Symptoms:** The run status shows 'timed_out'.
+
+    **Solutions:**
+    - The run exceeded the configured timeout (default: 60 minutes). The issue may have been too complex for the agent.
+    - You can **retry** the run from the Runs dashboard. Consider increasing the timeout in the blueprint's Autonomous settings.
+    - Check the workspace logs in the Qovery Console for errors the agent encountered before timing out.
+  </Accordion>
+
+  <Accordion title="Agent run failed">
+    **Symptoms:** The run status shows 'failed' with a failure reason.
+
+    **Solutions:**
+    - Read the **failure reason** shown in the Runs dashboard or the run detail page.
+    - Common failures: invalid API key for the chosen runtime, repository clone failure (incorrect URL or expired token), agent crash.
+    - Check the workspace logs in the Qovery Console for detailed error output.
+    - Fix the underlying issue (e.g., update the API key or repository token) and **retry** the run.
+  </Accordion>
+
+  <Accordion title="Duplicate runs for the same issue">
+    **Symptoms:** Multiple runs appear for the same Linear issue.
+
+    **Solutions:**
+    - This should not happen under normal operation. The system uses a database unique constraint to prevent duplicate claims.
+    - If you see duplicates, one may have been created manually via the **Create** button while the background runner also picked it up. The atomic constraint prevents this, but check if the runs are for different blueprints (which is allowed).
+    - Contact Qovery support if genuine duplicates appear for the same blueprint and issue.
+  </Accordion>
+</AccordionGroup>
+
 ## Performance Issues
 
 <AccordionGroup>

--- a/docs/snippets/rde-preview-warning.mdx
+++ b/docs/snippets/rde-preview-warning.mdx
@@ -1,0 +1,3 @@
+<Warning>
+**Preview**: AI Builder Portal is in preview. Features and capabilities are under active development and may change.
+</Warning>


### PR DESCRIPTION
## Summary

Adds a new **Autonomous Agents** tab to the AI Builder Portal documentation, covering the full autonomous agent lifecycle - from blueprint creation through Linear integration and run management.

## What's Included

### New pages (5)
- `docs/rde/agents/overview.mdx` - Landing page: concept, supported runtimes, comparison with workspaces
- `docs/rde/agents/getting-started.mdx` - End-to-end setup: create agent blueprint wizard, trigger first run
- `docs/rde/agents/agent-blueprints.mdx` - Configuration reference: all settings, runtimes, API keys
- `docs/rde/agents/managing-runs.mdx` - Runs dashboard, statuses, lifecycle actions, topology graph, manual run creation
- `docs/rde/agents/linear-integration.mdx` - Linear setup, issue flow, state mapping, lifecycle comments, concurrency

### Updated pages (4)
- `docs/rde/overview.mdx` - Added agents to Key Capabilities, blueprint types section, fixed CLI link
- `docs/rde/admin/blueprint-management.mdx` - Added Info callout about blueprint type chooser (Workspace vs Agent)
- `docs/rde/reference/architecture.mdx` - Added autonomous agent architecture section with sequence diagram
- `docs/rde/reference/troubleshooting.mdx` - Added 5 agent-specific troubleshooting accordions

### Infrastructure
- `docs/snippets/rde-preview-warning.mdx` - Extracted preview warning into reusable snippet
- `docs/docs.json` - Added "Autonomous Agents" tab (icon: robot) between "For Admins" and "For Users"

## Design Decisions
- **Separate tab, same product**: Agents get their own focused tab within the AI Builder Portal product rather than being mixed into "For Admins". Shared concepts (blueprints, security, architecture) are cross-linked, not duplicated.
- **Linear as first tracker**: Documentation covers Linear integration with an Info callout noting Jira and GitHub Issues are planned.
- **5 supported runtimes**: Claude Code, OpenCode, Codex, Gemini CLI, Cursor CLI - all documented with CLI commands and API key env vars.

## Corresponds to
Portal changes in `rde-portal` introducing the autonomous agents feature (agent blueprints, Linear integration, runs management, topology graph).