### PR TITLE
feat(docs): add contextual CTAs on high-traffic pages

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -104,3 +104,11 @@ qovery log
 <Card title="CLI Commands" icon="terminal" href="/cli/commands/overview">
   Explore all available commands and examples
 </Card>
+
+<div className="cta-banner">
+  <div className="cta-banner-text">
+    <h3>Your entire infrastructure, one terminal command away</h3>
+    <p>Deploy, manage, and monitor without ever opening a Kubernetes dashboard. Qovery turns complex cluster operations into simple CLI calls.</p>
+  </div>
+  <a href="https://console.qovery.com" className="cta-banner-button">Get started free →</a>
+</div>

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -108,7 +108,7 @@ qovery log
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Your entire infrastructure, one terminal command away</h3>
-    <p>Deploy, manage, and monitor without ever opening a Kubernetes dashboard. Qovery turns complex cluster operations into simple CLI calls.</p>
+    <p className="cta-banner-subtitle">Deploy, manage, and monitor without ever opening a Kubernetes dashboard. Qovery turns complex cluster operations into simple CLI calls.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Get started free →</a>
 </div>

--- a/docs/copilot/mcp-server.mdx
+++ b/docs/copilot/mcp-server.mdx
@@ -202,3 +202,11 @@ The API token has the same permissions as the role you selected during creation:
 - **MCP Protocol**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
 - **Claude**: [claude.ai](https://claude.ai)
 - **Technical Blog**: [How We Built an Agentic DevOps Copilot](https://www.qovery.com/blog/how-we-built-an-agentic-devops-copilot-to-automate-infrastructure-tasks-and-beyond)
+
+<div className="cta-banner">
+  <div className="cta-banner-text">
+    <h3>Manage your infrastructure and applications with natural language</h3>
+    <p>Ask Claude to list environments, check application status, tail logs, or trigger a deploy — directly through Qovery's MCP Server. No kubectl needed.</p>
+  </div>
+  <a href="https://console.qovery.com" className="cta-banner-button">Try Qovery free →</a>
+</div>

--- a/docs/copilot/mcp-server.mdx
+++ b/docs/copilot/mcp-server.mdx
@@ -206,7 +206,7 @@ The API token has the same permissions as the role you selected during creation:
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Manage your infrastructure and applications with natural language</h3>
-    <p>Ask Claude to list environments, check application status, tail logs, or trigger a deploy — directly through Qovery's MCP Server. No kubectl needed.</p>
+    <p className="cta-banner-subtitle">Ask Claude to list environments, check application status, tail logs, or trigger a deploy — directly through Qovery's MCP Server. No kubectl needed.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Try Qovery free →</a>
 </div>

--- a/docs/copilot/mcp-server.mdx
+++ b/docs/copilot/mcp-server.mdx
@@ -206,7 +206,7 @@ The API token has the same permissions as the role you selected during creation:
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Manage your infrastructure and applications with natural language</h3>
-    <p className="cta-banner-subtitle">Ask Claude to list environments, check application status, tail logs, or trigger a deploy — directly through Qovery's MCP Server. No kubectl needed.</p>
+    <p className="cta-banner-subtitle">Ask Claude to list environments, check application status, tail logs, or trigger a deploy. All through Qovery's MCP Server. No kubectl needed.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Try Qovery free →</a>
 </div>

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -999,3 +999,64 @@ footer,
     padding-left: 2rem !important;
   }
 }
+
+/* CTA Banner — conversion block on high-traffic pages */
+.cta-banner {
+  background: linear-gradient(135deg, #642DFF 0%, #8B5CF6 100%);
+  border-radius: 16px;
+  padding: 28px 32px;
+  margin: 40px 0 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.cta-banner-text h3 {
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 6px !important;
+  line-height: 1.3;
+}
+
+.cta-banner-text p {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 14px;
+  margin: 0 !important;
+  line-height: 1.5;
+}
+
+.cta-banner-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #ffffff;
+  color: #642DFF !important;
+  font-weight: 700;
+  font-size: 14px;
+  padding: 11px 22px;
+  border-radius: 8px;
+  text-decoration: none !important;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.cta-banner-button:hover {
+  opacity: 0.92;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 640px) {
+  .cta-banner {
+    flex-direction: column;
+    text-align: center;
+    padding: 24px 20px;
+  }
+
+  .cta-banner-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,0 +1,48 @@
+(function () {
+  var debounceTimer;
+
+  function applyVariant() {
+    if (!window.posthog) return;
+
+    var variant = window.posthog.getFeatureFlag('docs-cta-subtitle');
+    document.querySelectorAll('.cta-banner-subtitle').forEach(function (el) {
+      el.style.display = variant === 'no-subtitle' ? 'none' : '';
+    });
+
+    document.querySelectorAll('.cta-banner-button').forEach(function (btn) {
+      if (btn._ctaTracked) return;
+      btn._ctaTracked = true;
+      btn.addEventListener('click', function () {
+        if (!window.posthog) return;
+        window.posthog.capture('docs_cta_click', {
+          variant: window.posthog.getFeatureFlag('docs-cta-subtitle') || 'unknown',
+          page: window.location.pathname
+        });
+      });
+    });
+  }
+
+  function waitForPostHog(callback) {
+    if (window.posthog && window.posthog.getFeatureFlag) {
+      window.posthog.onFeatureFlags(callback);
+    } else {
+      setTimeout(function () { waitForPostHog(callback); }, 100);
+    }
+  }
+
+  waitForPostHog(applyVariant);
+
+  // Re-apply on SPA navigation (Mintlify uses Next.js router)
+  var lastUrl = location.href;
+  new MutationObserver(function () {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function () {
+      if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        waitForPostHog(applyVariant);
+      } else {
+        applyVariant();
+      }
+    }, 300);
+  }).observe(document.body, { childList: true, subtree: true });
+})();

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -739,6 +739,9 @@
   "css": [
     "/custom.css"
   ],
+  "js": [
+    "/custom.js"
+  ],
   "integrations": {
     "posthog": {
       "apiHost": "https://phprox.qovery.com",

--- a/docs/getting-started/guides/use-cases/ephemeral-environment.mdx
+++ b/docs/getting-started/guides/use-cases/ephemeral-environment.mdx
@@ -98,7 +98,7 @@ Qovery offers **two approaches** to create and manage ephemeral environments, de
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Stop configuring ephemeral environments manually</h3>
-    <p className="cta-banner-subtitle">Qovery auto-creates a full-stack preview environment for every pull request — and destroys it on merge. Setup in 15 minutes.</p>
+    <p className="cta-banner-subtitle">Qovery auto-creates a full-stack preview environment for every pull request and destroys it on merge. Setup in 15 minutes.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Try Qovery free →</a>
 </div>

--- a/docs/getting-started/guides/use-cases/ephemeral-environment.mdx
+++ b/docs/getting-started/guides/use-cases/ephemeral-environment.mdx
@@ -94,3 +94,11 @@ Qovery offers **two approaches** to create and manage ephemeral environments, de
     **Time to setup:** 1-2 hours
   </Card>
 </CardGroup>
+
+<div className="cta-banner">
+  <div className="cta-banner-text">
+    <h3>Stop configuring ephemeral environments manually</h3>
+    <p>Qovery auto-creates a full-stack preview environment for every pull request — and destroys it on merge. Setup in 15 minutes.</p>
+  </div>
+  <a href="https://console.qovery.com" className="cta-banner-button">Try Qovery free →</a>
+</div>

--- a/docs/getting-started/guides/use-cases/ephemeral-environment.mdx
+++ b/docs/getting-started/guides/use-cases/ephemeral-environment.mdx
@@ -98,7 +98,7 @@ Qovery offers **two approaches** to create and manage ephemeral environments, de
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Stop configuring ephemeral environments manually</h3>
-    <p>Qovery auto-creates a full-stack preview environment for every pull request — and destroys it on merge. Setup in 15 minutes.</p>
+    <p className="cta-banner-subtitle">Qovery auto-creates a full-stack preview environment for every pull request — and destroys it on merge. Setup in 15 minutes.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Try Qovery free →</a>
 </div>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -55,7 +55,7 @@ Describe what you want to deploy and an AI agent handles the rest — or use the
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Ready to deploy on your own cloud?</h3>
-    <p>Kubernetes on AWS, GCP, Azure, or Scaleway — managed by Qovery. No expertise required. Free to start.</p>
+    <p className="cta-banner-subtitle">Kubernetes on AWS, GCP, Azure, or Scaleway — managed by Qovery. No expertise required. Free to start.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
 </div>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -55,7 +55,7 @@ Describe what you want to deploy and an AI agent handles the rest — or use the
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Ready to deploy on your own cloud?</h3>
-    <p className="cta-banner-subtitle">Kubernetes on AWS, GCP, Azure, or Scaleway — managed by Qovery. No expertise required. Free to start.</p>
+    <p className="cta-banner-subtitle">Kubernetes on AWS, GCP, Azure, or Scaleway. Managed by Qovery. No expertise required. Free to start.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
 </div>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -51,3 +51,11 @@ Describe what you want to deploy and an AI agent handles the rest — or use the
     Essential terminology
   </Card>
 </CardGroup>
+
+<div className="cta-banner">
+  <div className="cta-banner-text">
+    <h3>Ready to deploy on your own cloud?</h3>
+    <p>Kubernetes on AWS, GCP, Azure, or Scaleway — managed by Qovery. No expertise required. Free to start.</p>
+  </div>
+  <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
+</div>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -67,3 +67,11 @@ Choose your deployment path.
     Code & automation
   </Card>
 </CardGroup>
+
+<div className="cta-banner">
+  <div className="cta-banner-text">
+    <h3>Your own Kubernetes cluster, ready in 30 minutes</h3>
+    <p>No cloud expertise needed — Qovery handles provisioning, upgrades, and guardrails. Free to start, no credit card required.</p>
+  </div>
+  <a href="https://console.qovery.com" className="cta-banner-button">Start free →</a>
+</div>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -71,7 +71,7 @@ Choose your deployment path.
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Your own Kubernetes cluster, ready in 30 minutes</h3>
-    <p>No cloud expertise needed — Qovery handles provisioning, upgrades, and guardrails. Free to start, no credit card required.</p>
+    <p className="cta-banner-subtitle">No cloud expertise needed — Qovery handles provisioning, upgrades, and guardrails. Free to start, no credit card required.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Start free →</a>
 </div>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -71,7 +71,7 @@ Choose your deployment path.
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Your own Kubernetes cluster, ready in 30 minutes</h3>
-    <p className="cta-banner-subtitle">No cloud expertise needed — Qovery handles provisioning, upgrades, and guardrails. Free to start, no credit card required.</p>
+    <p className="cta-banner-subtitle">No cloud expertise needed. Qovery handles provisioning, upgrades, and guardrails. Free to start, no credit card required.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Start free →</a>
 </div>

--- a/docs/getting-started/quickstart/ai-agent.mdx
+++ b/docs/getting-started/quickstart/ai-agent.mdx
@@ -206,7 +206,7 @@ The Skill deploys. The MCP Server operates. Use both together. [→ MCP Server](
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Let your AI agent deploy, under your control</h3>
-    <p className="cta-banner-subtitle">Qovery runs on your cloud, your cluster, your rules. Set guardrails, RBAC, and cost limits. Your agent operates within them. No vendor lock-in.</p>
+    <p className="cta-banner-subtitle">Qovery runs on your cloud, your cluster, your rules. Set guardrails and RBAC. Your agent operates within them. No vendor lock-in.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
 </div>

--- a/docs/getting-started/quickstart/ai-agent.mdx
+++ b/docs/getting-started/quickstart/ai-agent.mdx
@@ -202,3 +202,11 @@ The Skill deploys. The MCP Server operates. Use both together. [→ MCP Server](
     Fork or contribute
   </Card>
 </CardGroup>
+
+<div className="cta-banner">
+  <div className="cta-banner-text">
+    <h3>Let your AI agent deploy, under your control</h3>
+    <p>Qovery runs on your cloud, your cluster, your rules. Set guardrails, RBAC, and cost limits — your agent operates within them. No vendor lock-in.</p>
+  </div>
+  <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
+</div>

--- a/docs/getting-started/quickstart/ai-agent.mdx
+++ b/docs/getting-started/quickstart/ai-agent.mdx
@@ -206,7 +206,7 @@ The Skill deploys. The MCP Server operates. Use both together. [→ MCP Server](
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Let your AI agent deploy, under your control</h3>
-    <p className="cta-banner-subtitle">Qovery runs on your cloud, your cluster, your rules. Set guardrails, RBAC, and cost limits — your agent operates within them. No vendor lock-in.</p>
+    <p className="cta-banner-subtitle">Qovery runs on your cloud, your cluster, your rules. Set guardrails, RBAC, and cost limits. Your agent operates within them. No vendor lock-in.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
 </div>

--- a/docs/getting-started/quickstart/ai-agent.mdx
+++ b/docs/getting-started/quickstart/ai-agent.mdx
@@ -206,7 +206,7 @@ The Skill deploys. The MCP Server operates. Use both together. [→ MCP Server](
 <div className="cta-banner">
   <div className="cta-banner-text">
     <h3>Let your AI agent deploy, under your control</h3>
-    <p>Qovery runs on your cloud, your cluster, your rules. Set guardrails, RBAC, and cost limits — your agent operates within them. No vendor lock-in.</p>
+    <p className="cta-banner-subtitle">Qovery runs on your cloud, your cluster, your rules. Set guardrails, RBAC, and cost limits — your agent operates within them. No vendor lock-in.</p>
   </div>
   <a href="https://console.qovery.com" className="cta-banner-button">Create free account →</a>
 </div>


### PR DESCRIPTION
## Summary

- Add contextual CTA banners on the 6 highest-traffic doc pages (introduction, ephemeral environments, CLI overview, AI agent quickstart, MCP server, quickstart)
- Each CTA is contextualised to the page content with a specific message
- New `.cta-banner` CSS class: Qovery purple gradient, white button, mobile responsive
- All CTAs point to `https://console.qovery.com`
- Add PostHog A/B test (experiment ID 377409) to measure impact of showing/hiding the subtitle — `control` (with subtitle) vs `no-subtitle` (50/50 split, 100% rollout)
- `custom.js` reads the `docs-cta-subtitle` feature flag and hides `.cta-banner-subtitle` elements for the `no-subtitle` variant; fires a `docs_cta_click` event on button click

## Pages updated

| Page | CTA headline | Button |
|------|-------------|--------|
| Introduction | Ready to deploy on your own cloud? | Create free account → |
| Ephemeral environments | Stop configuring ephemeral environments manually | Try Qovery free → |
| CLI overview | Your entire infrastructure, one terminal command away | Get started free → |
| AI Agent quickstart | Let your AI agent deploy, under your control | Create free account → |
| MCP Server | Manage your infrastructure and applications with natural language | Try Qovery free → |
| Quickstart | Your own Kubernetes cluster, ready in 30 minutes | Start free → |

## Test plan

- [ ] Check CTA banner renders correctly on each page
- [ ] Check mobile responsive layout (stacked vertically on small screens)
- [ ] Check button link points to `https://console.qovery.com`
- [ ] Check dark mode rendering
- [ ] Verify PostHog A/B test: override flag in browser console and confirm subtitle hides/shows on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)