### PR TITLE
feat(docs): add authentication mode and read-write docs for the copilot

### DIFF
--- a/docs/copilot/console.mdx
+++ b/docs/copilot/console.mdx
@@ -53,7 +53,7 @@ The Qovery AI Copilot supports two operating modes:
     - ✅ Delete resources
 
     <Warning>
-    Read-write mode allows the Copilot to make **real changes** to your infrastructure. The Copilot will always ask for confirmation before performing destructive operations.
+    Read-write mode allows the Copilot to make **real changes** to your infrastructure. The Copilot will always ask for confirmation before making any changes.
     </Warning>
   </Tab>
 </Tabs>

--- a/docs/copilot/console.mdx
+++ b/docs/copilot/console.mdx
@@ -35,12 +35,12 @@ The Qovery AI Copilot supports two operating modes:
     - ❌ Execute any write operations
 
     <Note>
-    Read-only mode is **enabled by default** for safety. The Console Copilot currently operates exclusively in read-only mode.
+    Read-only mode is **enabled by default** for safety. Each new thread starts in read-only mode, even when read-write is enabled in the settings.
     </Note>
   </Tab>
 
   <Tab title="Read-Write Mode">
-    **Full automation capabilities** - Available in Slack Bot and MCP Server
+    **Full automation capabilities** - When you need to take action
 
     **What it can do:**
     - ✅ Everything in read-only mode, plus:
@@ -53,14 +53,32 @@ The Qovery AI Copilot supports two operating modes:
     - ✅ Delete resources
 
     <Warning>
-    Read-write mode allows the Copilot to make **real changes** to your infrastructure. The Copilot will ask for confirmation before performing destructive operations.
+    Read-write mode allows the Copilot to make **real changes** to your infrastructure. The Copilot will always ask for confirmation before performing destructive operations.
     </Warning>
-
-    <Info>
-    To enable read-write capabilities, use the [Slack Bot](/copilot/slack-bot) or [MCP Server](/copilot/mcp-server) interfaces.
-    </Info>
   </Tab>
 </Tabs>
+
+## Enabling Read-Write Mode
+
+Read-write capabilities must first be enabled by an organization administrator in the Copilot settings panel.
+
+<Steps>
+  <Step title="Open the Copilot Settings">
+    In the Qovery Console, open the AI Copilot panel and navigate to its **settings**.
+  </Step>
+
+  <Step title="Enable Read-Write Mode">
+    Toggle on the **Read-Write Mode** option. This unlocks write capabilities for all users in your organization who have the appropriate permissions.
+  </Step>
+
+  <Step title="Switch Mode Per Thread">
+    Once enabled, a **read/write toggle** appears at the bottom of each Copilot thread. Each new thread starts in **read-only mode** by default — switch the toggle to read-write only when you intend to make changes.
+  </Step>
+</Steps>
+
+<Info>
+This setting applies to the Console Copilot and the [MCP Server](/copilot/mcp-server). The [Slack Bot](/copilot/slack-bot) is always read-only.
+</Info>
 
 ## Accessing the AI Copilot
 
@@ -231,14 +249,7 @@ When was my last deployment?
 ## Current Mode in Console
 
 <Note>
-**Console = Read-Only Mode Only**: The Console Copilot currently operates exclusively in **read-only mode** for safety and security. This means:
-
-- ✅ You can explore, learn, and get help safely
-- ✅ No risk of accidental changes to your infrastructure
-- ✅ Perfect for understanding and troubleshooting
-- ❌ Cannot execute actions or make changes
-
-**Need write capabilities?** Switch to [Slack Bot](/copilot/slack-bot) or [MCP Server](/copilot/mcp-server) for read-write mode.
+Each Copilot thread starts in **read-only mode** by default, even if read-write is enabled in your organization settings. Use the **toggle at the bottom of the thread** to switch to read-write mode when you need to make changes.
 </Note>
 
 ## Context Switching
@@ -308,6 +319,20 @@ At the bottom of the Copilot panel, you'll see the system status:
 
 This helps you understand if issues you're experiencing are related to the Qovery platform itself.
 
+## Authentication Modes
+
+The Copilot supports two authentication modes, configured by an organization administrator in the Copilot settings. See the [Getting Started guide](/copilot/getting-started#authentication-modes) for full details.
+
+<CardGroup cols={2}>
+  <Card title="JWT Mode (Default)" icon="user">
+    The Copilot acts on behalf of the currently logged-in user, using their JWT token. Actions are limited to what that user is authorized to do in Qovery.
+  </Card>
+
+  <Card title="Role Mode" icon="shield-halved">
+    The Copilot uses a token linked to a dedicated **"AI Copilot"** role. An admin can configure this role to define exactly which permissions the Copilot has, the role has viewer permissions by default — independently of individual users. Useful for centralized access control and cleaner audit trails.
+  </Card>
+</CardGroup>
+
 ## Privacy & Security
 
 <AccordionGroup>
@@ -344,49 +369,40 @@ This helps you understand if issues you're experiencing are related to the Qover
     - Troubleshooting guidance
 
     **Mode:**
-    - 🔒 Read-only mode only (default)
+    - Read-only by default per thread
+    - Read-write available (requires admin activation in Copilot settings)
 
     **Advantages:**
     - No setup required
     - Contextual awareness
     - Always available
     - Integrated experience
-    - Safe exploration
-
-    **Limitations:**
-    - Cannot execute actions
-    - Cannot modify infrastructure
-    - Web interface only
+    - Safe exploration by default
 
     **Use when:**
     - You're already in the console
-    - You need quick answers
-    - You want contextual help
+    - You need quick answers or contextual help
     - Learning the platform
-    - Don't need to make changes
+    - You want to take actions directly from the console
   </Tab>
 
   <Tab title="Slack Bot">
     **Best for:**
     - Team collaboration
-    - Executing deployments
-    - Shared infrastructure management
+    - Shared status monitoring
     - ChatOps workflows
 
     **Mode:**
-    - 🔓 Read-write mode supported (defaults to read-only)
+    - Read-only
 
     **Advantages:**
-    - Full automation capabilities
-    - Can create, modify, delete resources
     - Team collaboration
     - Mobile access
     - No installation required
 
     **Use when:**
     - Working with a team
-    - Need to execute actions
-    - Want to deploy/modify services
+    - Need status checks and monitoring
     - Want mobile access
     - Prefer Slack interface
 
@@ -401,7 +417,7 @@ This helps you understand if issues you're experiencing are related to the Qover
     - Advanced integrations
 
     **Mode:**
-    - 🔓 Read-write mode supported (defaults to read-only)
+    - Read-write mode supported (defaults to read-only)
 
     **Advantages:**
     - Most powerful capabilities

--- a/docs/copilot/getting-started.mdx
+++ b/docs/copilot/getting-started.mdx
@@ -44,12 +44,52 @@ Only **organization administrators** can enable or disable the AI Copilot for th
 **Experimental Feature**: This is an experimental feature. Functionality may change, and billing terms are not final.
 </Warning>
 
+## Authentication Modes
+
+The Qovery AI Copilot supports two authentication modes, configurable by an organization administrator in the Copilot settings:
+
+<Tabs>
+  <Tab title="JWT Mode (Default)">
+    **Uses the logged-in user's identity**
+
+    In this mode, the Copilot authenticates using the JWT token of the user who is actively interacting with it. Every action the Copilot takes is performed with that user's permissions — it can only do what the user themselves is authorized to do.
+
+    - Actions are scoped to the current user's RBAC permissions
+    - No additional configuration required
+    - Natural permission boundary: the Copilot cannot exceed the user's own access level
+
+    <Note>
+    This is the default mode. It provides the simplest setup and ensures the Copilot never acts beyond what the user is allowed to do.
+    </Note>
+  </Tab>
+
+  <Tab title="Role Mode (AI Copilot Role)">
+    **Uses a dedicated AI Copilot role token**
+
+    In this mode, the Copilot authenticates using a token linked to a dedicated **"AI Copilot"** role. An organization administrator can configure this role to define exactly which permissions the Copilot has — independently of individual user permissions. The role has **viewer permissions by default**.
+
+    - Admin configures the "AI Copilot" role (viewer by default) with the desired permissions
+    - All users interact with the Copilot through this shared role
+    - Admin can restrict or expand Copilot capabilities at any time by modifying the role
+    - Actions are attributed to the AI Copilot role in audit logs, not to individual users
+
+    <Warning>
+    This mode requires careful configuration. Granting broad permissions to the AI Copilot role means **all users** interact with those permissions, regardless of their own access level. Scope the role to the minimum permissions needed.
+    </Warning>
+
+    **When to use Role Mode:**
+    - You want to centrally control what the Copilot can and cannot do
+    - You need the Copilot to have access that differs from individual users' permissions
+    - You want clear audit separation between human actions and Copilot actions
+  </Tab>
+</Tabs>
+
 ## Operating Modes
 
 The Qovery AI Copilot operates in two modes:
 
 <CardGroup cols={2}>
-  <Card title="Read-Only Mode (Current)" icon="eye">
+  <Card title="Read-Only Mode (Default)" icon="eye">
     **Safe exploration and information access**
 
     - View information and status
@@ -61,8 +101,8 @@ The Qovery AI Copilot operates in two modes:
     **Available in:** Console, Slack Bot, MCP Server
   </Card>
 
-  <Card title="Read-Write Mode (Coming Soon)" icon="pen-to-square">
-    **Full automation capabilities - In Development**
+  <Card title="Read-Write Mode" icon="pen-to-square">
+    **Full automation capabilities**
 
     - Everything in read-only mode
     - Deploy and restart services
@@ -70,13 +110,9 @@ The Qovery AI Copilot operates in two modes:
     - Update configurations
     - Manage environment variables
 
-    **Status:** Coming soon for Slack Bot and MCP Server
+    **Available in:** Console, MCP Server (requires admin activation)
   </Card>
 </CardGroup>
-
-<Note>
-**Current Status**: The AI Copilot currently operates in **read-only mode** across all interfaces. Read-write mode is under active development and will be available soon.
-</Note>
 
 ## Choose Your Interface
 
@@ -88,7 +124,8 @@ Qovery AI Copilot is available through three interfaces:
 
     Get contextual assistance directly in the Qovery Console.
 
-    - 🔒 Read-only mode only
+    - Read-only by default per thread
+    - Read-write available (requires admin activation)
     - No setup required
     - Contextual awareness
     - Always available
@@ -100,10 +137,9 @@ Qovery AI Copilot is available through three interfaces:
 
     Use Copilot in Slack for collaborative infrastructure management.
 
-    - 🔓 Read-write mode supported
+    - Read-only
     - Team collaboration
     - Mobile access
-    - Full automation
     - Shared visibility
   </Card>
 
@@ -112,7 +148,8 @@ Qovery AI Copilot is available through three interfaces:
 
     Use Copilot in Claude Desktop for advanced workflows.
 
-    - 🔓 Read-write mode supported
+    - Read-only by default per thread
+    - Read-write available (requires admin activation)
     - Desktop integration
     - Most powerful
     - Advanced features

--- a/docs/copilot/slack-bot.mdx
+++ b/docs/copilot/slack-bot.mdx
@@ -15,40 +15,17 @@ The Qovery Slack Bot brings AI Copilot capabilities directly into your Slack wor
 **Beta Status**: The Qovery Slack Bot is currently in beta. Features and capabilities are being actively developed.
 </Warning>
 
-## Operating Modes
+## Operating Mode
 
-The Slack Bot supports both operating modes:
+<Note>
+The Slack Bot operates exclusively in **read-only mode**. It can query your infrastructure, display status, and provide guidance, but cannot make any changes. For write operations, use the [Console Copilot](/copilot/console) or the [MCP Server](/copilot/mcp-server).
+</Note>
 
-<Tabs>
-  <Tab title="Read-Only Mode (Default)">
-    **Default behavior** - Safe for exploration
-
-    The Slack Bot starts in **read-only mode** by default, allowing you to:
-    - View information and status
-    - Get help and recommendations
-    - Troubleshoot issues
-    - Monitor deployments
-    - **No changes** to infrastructure
-
-    This ensures safe exploration without risk of accidental modifications.
-  </Tab>
-
-  <Tab title="Read-Write Mode">
-    **Full automation** - When you need to take action
-
-    When needed, the Slack Bot can operate in **read-write mode** to:
-    - Deploy applications and services
-    - Create new environments
-    - Update configurations
-    - Add/modify/delete environment variables
-    - Scale, restart, or stop services
-    - Delete resources (with confirmation)
-
-    <Warning>
-    The Copilot will **ask for confirmation** before performing destructive operations like deletions.
-    </Warning>
-  </Tab>
-</Tabs>
+What the Slack Bot can do:
+- View information and status
+- Get help and recommendations
+- Troubleshoot issues
+- Monitor deployments
 
 ## Prerequisites
 
@@ -146,25 +123,12 @@ https://app.slack.com/client/T123ABC/C09M85XK3GQ
 
 Interact with the bot using natural language in your configured channel:
 
-**Read-only commands** (default, always safe):
 ```
 @qovery Show me all production environments
 @qovery What's the status of the database?
 @qovery List all applications in the dev environment
 @qovery Show me recent deployment history
 ```
-
-**Read-write commands** (when you need to take action):
-```
-@qovery Deploy the api-service to staging
-@qovery Restart the frontend application
-@qovery Scale the api to 3 replicas
-@qovery Add environment variable API_KEY=xxx to production
-```
-
-<Note>
-The bot will **confirm destructive actions** before executing them in read-write mode.
-</Note>
 
 ### Common Use Cases
 
@@ -293,19 +257,16 @@ Consider organizing channels by:
     - ChatOps workflows
 
     **Mode:**
-    - 🔓 Read-write mode supported (defaults to read-only)
+    - Read-only
 
     **Advantages:**
-    - Full automation capabilities
-    - Can create, modify, delete resources
     - Works on any device with Slack
     - Team visibility
     - Mobile access
 
     **Use when:**
     - Working with a team
-    - Need to execute actions
-    - Want mobile access
+    - Need status checks and monitoring
     - Want shared visibility
     - Prefer Slack interface
   </Tab>


### PR DESCRIPTION
Documentation update regarding the use of the copilot:
- Added information regarding the two authentication modes (JWT and role)
- Added information on the write mode