### PR TITLE
docs(QOV-2075): document disabling the CPU limit via resources.override.limit.cpu_in_milli = -1

### DIFF
--- a/docs/configuration/cluster-advanced-settings.mdx
+++ b/docs/configuration/cluster-advanced-settings.mdx
@@ -1996,7 +1996,7 @@ Envoy Gateway automatically selects the best compression algorithm based on the 
 CPU overcommit can cause CPU throttling and unpredictable latency when nodes are under pressure. Use with caution in production.
 </Warning>
 
-**Use Case:** Once enabled, you can update the service advanced setting `resources.override.limit.cpu_in_milli` to set a CPU limit higher than the request.
+**Use Case:** Once enabled, you can update the service advanced setting `resources.override.limit.cpu_in_milli` to set a CPU limit higher than the request, or set it to `-1` to disable the CPU limit for that service entirely.
 
 **Default Value:** `false`
 

--- a/docs/configuration/service-advanced-settings.mdx
+++ b/docs/configuration/service-advanced-settings.mdx
@@ -1485,9 +1485,15 @@ Setting `ndots=2` reduces this to **1 DNS query** since the hostname already has
 
 **Type:** `integer`
 
-**Description:** Allows you to override the CPU limit for your service pods in millicores (1000m = 1 vCPU).
+**Description:** Allows you to override the CPU limit for your service pods in millicores (1000m = 1 vCPU). Set to `-1` to disable the CPU limit entirely, so the container is not capped and can use all the CPU available on the node.
 
-**Use Case:** Use this to fine-tune CPU allocation beyond the standard Qovery instance sizes.
+**Use Case:** Use a positive value to fine-tune CPU allocation beyond the standard Qovery instance sizes, or use `-1` to remove CPU throttling for CPU-bound workloads that need to burst freely.
+
+<Info>
+Setting a custom CPU limit (including `-1` to disable it) requires CPU overcommit to be enabled on the cluster via the `allow_service_cpu_overcommit` cluster advanced setting. This only affects the CPU limit; the RAM limit (`resources.override.limit.ram_in_mib`) remains mandatory and cannot be disabled, since it protects the pod from being OOMKilled.
+</Info>
+
+**Valid values:** `-1` (disabled) or a positive integer greater than the service's CPU request
 
 **Default Value:** `null`
 


### PR DESCRIPTION
## Ticket
QOV-2075

## What
Documents the new `-1` sentinel on the `resources.override.limit.cpu_in_milli` service advanced setting, which disables the Kubernetes CPU limit entirely for Application/Container/Job services. Cross-referenced from the `allow_service_cpu_overcommit` cluster advanced setting, which gates it.

## Related
- q-core MR: https://gitlab.com/qovery/backend/q-core/-/merge_requests/3706
- engine MR: https://gitlab.com/qovery/backend/engine/-/merge_requests/2708